### PR TITLE
Aspect ratio / Undo / misc bug fixes

### DIFF
--- a/src/ArchiveManagerPanel.cpp
+++ b/src/ArchiveManagerPanel.cpp
@@ -971,7 +971,7 @@ bool ArchiveManagerPanel::closeArchive(Archive* archive) {
 
 	// If the archive has unsaved changes, prompt to save
 	if (archive->isModified() && archive->isWritable()) {
-		wxMessageDialog md(this, S_FMT("Save changes to %s?", archive->getFilename(false)), "Unsaved Changes", wxYES_NO|wxCANCEL);
+		wxMessageDialog md(this, S_FMT("Save changes to archive %s?", archive->getFilename(false)), "Unsaved Changes", wxYES_NO|wxCANCEL);
 		int result = md.ShowModal();
 		if (result == wxID_YES) {
 			// User selected to save

--- a/src/ArchivePanel.cpp
+++ b/src/ArchivePanel.cpp
@@ -396,22 +396,26 @@ void ArchivePanel::removeMenus() {
  * Performs an undo operation
  *******************************************************************/
 void ArchivePanel::undo() {
-	// Undo
-	undo_manager->undo();
+	if (!(cur_area && cur_area->undo())) {
+		// Undo
+		undo_manager->undo();
 
-	// Refresh entry list
-	entry_list->updateList();
+		// Refresh entry list
+		entry_list->updateList();
+	}
 }
 
 /* ArchivePanel::redo
  * Performs a redo operation
  *******************************************************************/
 void ArchivePanel::redo() {
-	// Redo
-	undo_manager->redo();
+	if (!(cur_area && cur_area->redo())) {
+		// Redo
+		undo_manager->redo();
 
-	// Refresh entry list
-	entry_list->updateList();
+		// Refresh entry list
+		entry_list->updateList();
+	}
 }
 
 /* ArchivePanel::save
@@ -1157,6 +1161,7 @@ bool ArchivePanel::pasteEntry() {
 
 	// Go through all clipboard items
 	bool pasted = false;
+	undo_manager->beginRecord("Paste Entry");
 	for (unsigned a = 0; a < theClipboard->nItems(); a++) {
 		// Check item type
 		if (theClipboard->getItem(a)->getType() != CLIPBOARD_ENTRY_TREE)
@@ -1169,6 +1174,7 @@ bool ArchivePanel::pasteEntry() {
 		if (archive->paste(clip->getTree(), index, entry_list->getCurrentDir()))
 			pasted = true;
 	}
+	undo_manager->endRecord(true);
 
 	if (pasted) {
 		// Update archive

--- a/src/CTextureCanvas.cpp
+++ b/src/CTextureCanvas.cpp
@@ -38,6 +38,7 @@
  * VARIABLES
  *******************************************************************/
 wxDEFINE_EVENT(EVT_DRAG_END, wxCommandEvent);
+CVAR(Bool, tx_arc, false, CVAR_SAVE)
 EXTERN_CVAR(Bool, gfx_show_border)
 
 
@@ -250,7 +251,8 @@ void CTextureCanvas::drawTexture() {
 	glTranslated(GetSize().x * 0.5, GetSize().y * 0.5, 0);
 
 	// Zoom
-	glScaled(scale, scale, 1);
+	double yscale = (tx_arc ? scale * 1.2 : scale);
+	glScaled(scale, yscale, 1);
 
 	// Apply texture scale
 	if (tex_scale) {

--- a/src/EntryPanel.h
+++ b/src/EntryPanel.h
@@ -56,7 +56,9 @@ public:
 	string			getCustomMenuName() { return custom_menu_name; }
 	void			callRefresh() { refreshPanel(); }
 	void			nullEntry() { entry = NULL; }
-	virtual void	handleAction(int menu_id) {}
+	//virtual void	handleAction(int menu_id) {}
+	virtual bool	undo() { return false; }
+	virtual bool	redo() { return false; }
 
 	virtual void	onBtnSave(wxCommandEvent& e);
 	virtual void	onBtnRevert(wxCommandEvent& e);

--- a/src/GfxCanvas.cpp
+++ b/src/GfxCanvas.cpp
@@ -40,6 +40,7 @@
 DEFINE_EVENT_TYPE(wxEVT_GFXCANVAS_OFFSET_CHANGED)
 CVAR(Bool, gfx_show_border, true, CVAR_SAVE)
 CVAR(Bool, gfx_hilight_mouseover, true, CVAR_SAVE)
+CVAR(Bool, gfx_arc, false, CVAR_SAVE)
 
 
 /*******************************************************************
@@ -145,9 +146,10 @@ void GfxCanvas::drawOffsetLines() {
 		glEnd();
 	}
 	else if (view_type == GFXVIEW_HUD) {
+		double yscale = (gfx_arc ? scale * 1.2 : scale);
 		glPushMatrix();
 		glEnable(GL_LINE_SMOOTH);
-		glScaled(scale, scale, 1);
+		glScaled(scale, yscale, 1);
 		Drawing::drawHud();
 		glDisable(GL_LINE_SMOOTH);
 		glPopMatrix();
@@ -167,7 +169,8 @@ void GfxCanvas::drawImage() {
 	glPushMatrix();
 
 	// Zoom
-	glScaled(scale, scale, 1);
+	double yscale = (gfx_arc ? scale * 1.2 : scale);
+	glScaled(scale, yscale, 1.0);
 
 	// Pan
 	if (view_type == GFXVIEW_CENTERED)

--- a/src/GfxEntryPanel.cpp
+++ b/src/GfxEntryPanel.cpp
@@ -44,6 +44,11 @@
 
 
 /*******************************************************************
+ * VARIABLES
+ *******************************************************************/
+EXTERN_CVAR(Bool, gfx_arc)
+
+/*******************************************************************
  * GFXCOLOURISEDIALOG CLASS
  *******************************************************************
  A simple dialog for the 'Colourise' function, allows the user to
@@ -322,6 +327,12 @@ GfxEntryPanel::GfxEntryPanel(wxWindow* parent)
 
 	sizer_bottom->AddStretchSpacer();
 
+	// Aspect ratio correction checkbox
+	cb_arc = new wxCheckBox(this, -1, "Aspect Ratio Correction");
+	cb_arc->SetValue(gfx_arc);
+	sizer_bottom->Add(cb_arc, 0, wxEXPAND, 0);
+	sizer_bottom->AddSpacer(8);
+
 	// Tile checkbox
 	cb_tile = new wxCheckBox(this, -1, "Tile");
 	sizer_bottom->Add(cb_tile, 0, wxEXPAND, 0);
@@ -368,6 +379,7 @@ GfxEntryPanel::GfxEntryPanel(wxWindow* parent)
 	spin_yoffset->Bind(wxEVT_COMMAND_SPINCTRL_UPDATED, &GfxEntryPanel::onYOffsetChanged, this);
 	choice_offset_type->Bind(wxEVT_COMMAND_CHOICE_SELECTED, &GfxEntryPanel::onOffsetTypeChanged, this);
 	cb_tile->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &GfxEntryPanel::onTileChanged, this);
+	cb_arc->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &GfxEntryPanel::onARCChanged, this);
 	Bind(wxEVT_GFXCANVAS_OFFSET_CHANGED, &GfxEntryPanel::onGfxOffsetChanged, this, gfx_canvas->GetId());
 	btn_nextimg->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &GfxEntryPanel::onBtnNextImg, this);
 	btn_previmg->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &GfxEntryPanel::onBtnPrevImg, this);
@@ -963,6 +975,14 @@ void GfxEntryPanel::onOffsetTypeChanged(wxCommandEvent& e) {
 void GfxEntryPanel::onTileChanged(wxCommandEvent& e) {
 	choice_offset_type->Enable(!cb_tile->IsChecked());
 	applyViewType();
+}
+
+/* GfxEntryPanel::onARCChanged
+ * Called when the 'Aspect Ratio' checkbox is checked/unchecked
+ *******************************************************************/
+void GfxEntryPanel::onARCChanged(wxCommandEvent& e) {
+	gfx_arc = cb_arc->IsChecked();
+	gfx_canvas->Refresh();
 }
 
 /* GfxEntryPanel::gfxOffsetChanged

--- a/src/GfxEntryPanel.h
+++ b/src/GfxEntryPanel.h
@@ -21,6 +21,7 @@ private:
 	wxSpinCtrl*		spin_xoffset;
 	wxSpinCtrl*		spin_yoffset;
 	wxCheckBox*		cb_tile;
+	wxCheckBox*		cb_arc;
 
 	wxButton*		btn_nextimg;
 	wxButton*		btn_previmg;
@@ -54,6 +55,7 @@ public:
 	void	onYOffsetChanged(wxSpinEvent& e);
 	void	onOffsetTypeChanged(wxCommandEvent& e);
 	void	onTileChanged(wxCommandEvent& e);
+	void	onARCChanged(wxCommandEvent& e);
 	void	onGfxOffsetChanged(wxEvent& e);
 	void	onBtnNextImg(wxCommandEvent& e);
 	void	onBtnPrevImg(wxCommandEvent& e);

--- a/src/MapEditorWindow.cpp
+++ b/src/MapEditorWindow.cpp
@@ -753,7 +753,7 @@ bool MapEditorWindow::handleAction(string id) {
  *******************************************************************/
 void MapEditorWindow::onClose(wxCloseEvent& e) {
 	if (editor.getMap().isModified()) {
-		wxMessageDialog md(this, S_FMT("Save changes to %s", CHR(currentMapDesc().name)), "Unsaved Changes", wxYES_NO|wxCANCEL);
+		wxMessageDialog md(this, S_FMT("Save changes to map %s", CHR(currentMapDesc().name)), "Unsaved Changes", wxYES_NO|wxCANCEL);
 		int answer = md.ShowModal();
 		if (answer == wxID_YES)
 			saveMap();

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -46,6 +46,9 @@ SLADEMap::SLADEMap() {
 
 	// Object id 0 is always null
 	all_objects.push_back(mobj_holder_t(NULL, false));
+
+	// Init opened time so it's not random leftover garbage values
+	setOpenedTime();
 }
 
 SLADEMap::~SLADEMap() {

--- a/src/TextEntryPanel.cpp
+++ b/src/TextEntryPanel.cpp
@@ -83,7 +83,6 @@ TextEntryPanel::TextEntryPanel(wxWindow* parent)
 	btn_jump_to->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &TextEntryPanel::onBtnJumpTo, this);
 
 	// Custom toolbar
-	custom_menu_name = "Text";
 	custom_toolbar_actions = "arch_scripts_compileacs;arch_scripts_compilehacs";
 
 	Layout();
@@ -156,6 +155,8 @@ bool TextEntryPanel::loadEntry(ArchiveEntry* entry) {
 	else
 		choice_text_language->Select(0);
 
+	// Prevent undoing loading the entry
+	text_area->EmptyUndoBuffer();
 
 	// Update variables
 	this->entry = entry;
@@ -228,6 +229,32 @@ string TextEntryPanel::statusString() {
 	return status;
 }
 
+/* TextEntryPanel::undo
+ * Tells the text editor to undo
+ *******************************************************************/
+bool TextEntryPanel::undo() {
+	if (text_area->CanUndo()) {
+		text_area->Undo();
+		// If we have undone all the way back, it is not modified anymore
+		if (!text_area->CanUndo()) {
+			setModified(false);
+		}
+		return true;
+	}
+	return false;
+}
+
+/* TextEntryPanel::redo
+ * Tells the text editor to redo
+ *******************************************************************/
+bool TextEntryPanel::redo() {
+	if (text_area->CanRedo()) {
+		text_area->Redo();
+		return true;
+	}
+	return false;
+}
+
 
 /*******************************************************************
  * TEXTENTRYPANEL CLASS EVENTS
@@ -269,11 +296,12 @@ void TextEntryPanel::onChoiceLanguageChanged(wxCommandEvent& e) {
  * Called when the "Word Wrap" checkbox is clicked
  *******************************************************************/
 void TextEntryPanel::onWordWrapChanged(wxCommandEvent& e) {
+	bool m = isModified();
 	if (cb_wordwrap->IsChecked())
 		text_area->SetWrapMode(wxSTC_WRAP_WORD);
 	else
 		text_area->SetWrapMode(wxSTC_WRAP_NONE);
-	setModified(false);
+	setModified(m);
 }
 
 /* TextEntryPanel::onUpdateUI

--- a/src/TextEntryPanel.h
+++ b/src/TextEntryPanel.h
@@ -23,6 +23,8 @@ public:
 	void	refreshPanel();
 	void	closeEntry();
 	string	statusString();
+	bool	undo();
+	bool	redo();
 
 	// Events
 	void	onTextModified(wxStyledTextEvent& e);

--- a/src/TextureEditorPanel.cpp
+++ b/src/TextureEditorPanel.cpp
@@ -41,6 +41,7 @@
  *******************************************************************/
 bool hack_nodrag = false;	// Hack to stop the drag event being erroneously triggered when
 							// double-clicking a patch in the patch browser to select it
+EXTERN_CVAR(Bool, tx_arc)
 
 
 /*******************************************************************
@@ -106,6 +107,11 @@ void TextureEditorPanel::setupLayout() {
 	cb_tex_scale->SetValue(false);
 	hbox->Add(cb_tex_scale, 0, wxEXPAND|wxRIGHT, 4);
 
+	// 'Aspect Ratio Correction' checkbox
+	cb_tex_arc = new wxCheckBox(this, -1, "Aspect Ratio Correction");
+	cb_tex_arc->SetValue(tx_arc);
+	hbox->Add(cb_tex_arc, 0, wxEXPAND|wxRIGHT, 4);
+
 	// 'Truecolour Preview' checkbox
 	cb_blend_rgba = new wxCheckBox(this, -1, "Truecolour Preview");
 	cb_blend_rgba->SetValue(false);
@@ -158,6 +164,7 @@ void TextureEditorPanel::setupLayout() {
 	spin_patch_left->Bind(wxEVT_COMMAND_SPINCTRL_UPDATED, &TextureEditorPanel::onPatchPositionXChanged, this);
 	spin_patch_top->Bind(wxEVT_COMMAND_SPINCTRL_UPDATED, &TextureEditorPanel::onPatchPositionYChanged, this);
 	cb_tex_scale->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &TextureEditorPanel::onApplyScaleChanged, this);
+	cb_tex_arc->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &TextureEditorPanel::onARCChanged, this);
 
 	// Init layout
 	Layout();
@@ -1161,5 +1168,13 @@ void TextureEditorPanel::onPatchPositionYChanged(wxSpinEvent& e) {
  *******************************************************************/
 void TextureEditorPanel::onApplyScaleChanged(wxCommandEvent& e) {
 	tex_canvas->applyTexScale(cb_tex_scale->GetValue());
+	tex_canvas->redraw();
+}
+
+/* TextureEditorPanel::onARCChanged
+ * Called when the 'Aspect Ratio Correction' checkbox is changed
+ *******************************************************************/
+void TextureEditorPanel::onARCChanged(wxCommandEvent& e) {
+	tx_arc = cb_tex_arc->IsChecked();
 	tex_canvas->redraw();
 }

--- a/src/TextureEditorPanel.h
+++ b/src/TextureEditorPanel.h
@@ -22,6 +22,7 @@ protected:
 	wxCheckBox*		cb_draw_outside;
 	wxCheckBox*		cb_blend_rgba;
 	wxCheckBox*		cb_tex_scale;
+	wxCheckBox*		cb_tex_arc;
 	wxStaticText*	label_viewtype;
 	wxChoice*		choice_viewtype;
 	CTextureCanvas*	tex_canvas;
@@ -111,6 +112,7 @@ public:
 	void	onPatchPositionYChanged(wxSpinEvent& e);
 	void	onContextMenu(wxCommandEvent& e);
 	void	onApplyScaleChanged(wxCommandEvent& e);
+	void	onARCChanged(wxCommandEvent& e);
 };
 
 #endif//__TEXTURE_EDITOR_PANEL_H__

--- a/stuff.txt
+++ b/stuff.txt
@@ -9,6 +9,7 @@ TODO List ---------------------------------------------------------------
 
 --- Bugs ---
 - Wall/flat scale not working in 3d mode
+- Undo/redo only works in WADs (no effect on ZIP entries)
 
 
 --- Map Editor 3.1 ---
@@ -152,6 +153,7 @@ To keep track of resource editor changes (in case I decide to release a 3.0.3 af
 - Various additions and improvements to texture editor for ZDoom TEXTURES format
 - Added option to colour entry list item background by entry type
 - Improved entry type detection speed
+- Console command batches (run all commands contained in a file or a lump)
 
 
 
@@ -173,6 +175,7 @@ Unimplemented Feature Requests ------------------------------------------
 Translation dialog:
 - Source/destination palette selectable
 - Scroll through multiple preview gfx
+- Zoom on preview gfx (perhaps in pop-up window?)
 - Allow use with truecolour gfx
 - Tool for trimming blank space around a graphic.
 - Tool for adding blank space to either side as needed to put the x offset right in the center (better for mirrored sprites).
@@ -235,7 +238,7 @@ Ideas / Possible Features -----------------------------------------------
 		- CRC (will be used to determine if the info is up-to-date)
 		- Extra properties
 		- Entry type
-- Model viewer
+- Model and voxel viewer
 - The 'findModifiedEntries()' function could be used to create an 'Export Changes in New File' feature as an alternative to saving the archive, useful especially for IWADs.
 - EntryPanels able to handle multiple entries for special purposes
 	- GfxEntryPanel: shows all selected images in a browser kind of thing
@@ -247,12 +250,13 @@ Ideas / Possible Features -----------------------------------------------
 	- Report on thing placement (using game configuration to name and categorize things)
 	- Report specials used in map (both linedefs and, if appropriate, things, using game config to name and categorize specials)
 	- Ideally would allow to output in a wiki syntax to help make the tables used in the Doom Wiki.
-- Waiting For SladeScript(tm), in four steps:
-	- Console commands to perform archive management actions (opening or creating archives, saving, importing files, exporting entries, copying, renaming, etc.)
-	- Console commands aliases (like in ZDoom)
-	- Console command batches (run all commands contained in a file or a lump)
+- Waiting For SladeScript(tm), in three remaining steps:
+	- Console commands to perform archive management actions (opening or creating archives, saving, importing files, exporting entries, copying, etc.)
+	- Console command aliases (like in ZDoom)
 	- Script mode: command-line options to (1) run a console command batch at startup and optionally also (2) quit once the batch is finished.
-		- Bonus fifth step: interpret DeuTex scripts, allowing SLADE to replace that outdated tool in projects like Hacx and Freedoom.
+		- Bonus fourth step: interpret DeuTex scripts, allowing SLADE to replace that outdated tool in projects like Hacx and Freedoom.
 
 
 Other / Notes -----------------------------------------------------------
+ http://tfc.duke.free.fr/old/models/md2.htm -- reference code for a simple OpenGL MD2 viewer
+ 


### PR DESCRIPTION
- Added aspect ratio correction checkbox to Gfx viewer and texture
  editor. This stretches images vertically by 20% to give a preview of
  in-game proportions for certain types of graphics.
- Undoing will now first query the entry panel first. For now, only the
  text editor has a built-in undo feature.
- Text editor no longer allows to undo loading the entry...
- Init opened time in SLADEMap's constructor so that SLADE will not
  randomly query to save a nameless map when quitting without having
  opened the map editor at all.
- Updated a bit stuff.txt.
