### PR TITLE
SVN r1416 update

### DIFF
--- a/src/Console.cpp
+++ b/src/Console.cpp
@@ -172,7 +172,7 @@ void Console::execute(string command) {
  *******************************************************************/
 void Console::logMessage(string message) {
 	// Add a newline to the end of the message if there isn't one
-	if (message.Last() != '\n')
+	if (message.size() == 0 || message.Last() != '\n')
 		message.Append("\n");
 
 	// Log the message

--- a/src/TextureXPanel.cpp
+++ b/src/TextureXPanel.cpp
@@ -1091,14 +1091,15 @@ void TextureXPanel::onTextureListSelect(wxListEvent& e) {
  *******************************************************************/
 void TextureXPanel::onTextureListRightClick(wxListEvent& e) {
 	// Create context menu
-	wxMenu context;
+	wxMenu context, texport;
 	theApp->getAction("txed_delete")->addToMenu(&context);
 	context.AppendSeparator();
 	theApp->getAction("txed_rename")->addToMenu(&context);
 	if (texturex.getFormat() == TXF_TEXTURES)
 		theApp->getAction("txed_offsets")->addToMenu(&context);
-	theApp->getAction("txed_export")->addToMenu(&context);
-	theApp->getAction("txed_extract")->addToMenu(&context);
+	theApp->getAction("txed_export")->addToMenu(&texport, "Archive (as image)");
+	theApp->getAction("txed_extract")->addToMenu(&texport, "File");
+	context.AppendSubMenu(&texport, "&Export To");
 	context.AppendSeparator();
 	theApp->getAction("txed_copy")->addToMenu(&context);
 	theApp->getAction("txed_cut")->addToMenu(&context);


### PR DESCRIPTION
- Fixed crash when logging an empty string to the console, which
  happened notably while logging ACC's output.
- The texture editor's context menu now shows the same export submenu as
  the Texture menu for consistency.
