### PR TITLE
Highlight support for Boom's generalized line types

### DIFF
--- a/src/GameConfiguration.cpp
+++ b/src/GameConfiguration.cpp
@@ -69,8 +69,10 @@ void GameConfiguration::setDefaults() {
 	for (int a = 0; a < 4; a++)
 		map_formats[a] = false;
 	boom = false;
-	as_generalized.setName("Boom Generalized Special");
-	as_generalized.setTagged(AS_TT_SECTOR);
+	as_generalized_s.setName("Boom Generalized Switched Special");
+	as_generalized_s.setTagged(AS_TT_SECTOR);
+	as_generalized_m.setName("Boom Generalized Manual Special");
+	as_generalized_m.setTagged(AS_TT_SECTOR_BACK);
 }
 
 string GameConfiguration::udmfNamespace() {
@@ -1539,12 +1541,16 @@ bool GameConfiguration::openConfig(string game, string port) {
 
 ActionSpecial* GameConfiguration::actionSpecial(unsigned id) {
 	as_t& as = action_specials[id];
-	if (as.special)
+	if (as.special) {
 		return as.special;
-	else if (boom && id >= 0x2f80)
-		return &as_generalized;
-	else
+	} else if (boom && id >= 0x2f80) {
+		if ((id & 7) >= 6)
+			return &as_generalized_m;
+		else
+			return &as_generalized_s;
+	} else {
 		return &as_unknown;
+	}
 }
 
 string GameConfiguration::actionSpecialName(int special) {

--- a/src/GameConfiguration.h
+++ b/src/GameConfiguration.h
@@ -69,7 +69,8 @@ private:
 	bool				boom;				// Boom extensions enabled
 	ASpecialMap			action_specials;	// Action specials
 	ActionSpecial		as_unknown;			// Default action special
-	ActionSpecial		as_generalized;		// Dummy for Boom generalized specials
+	ActionSpecial		as_generalized_s;	// Dummy for Boom generalized switched specials
+	ActionSpecial		as_generalized_m;	// Dummy for Boom generalized manual specials
 	ThingTypeMap		thing_types;		// Thing types
 	vector<ThingType*>	tt_group_defaults;	// Thing type group defaults
 	ThingType			ttype_unknown;		// Default thing type


### PR DESCRIPTION
Affected sectors and affecting linedefs are now properly highlighted when appropriate.
