### PR TITLE
Fix #37 (Doom picture misidentified as Doom PSX picture)

### DIFF
--- a/src/ImageFormats.h
+++ b/src/ImageFormats.h
@@ -613,7 +613,7 @@ public:
 
 		// Check the size matches
 		size_t rawsize = (sizeof(psxpic_header_t) + (header->width * header->height));
-		if (mc.getSize() < rawsize && mc.getSize() >= rawsize + 4)
+		if (mc.getSize() < rawsize || mc.getSize() >= rawsize + 4)
 			return EDF_FALSE;
 
 		return EDF_TRUE;


### PR DESCRIPTION
Trivial fix. Just trying out that GitHub thing...
