### PR TITLE
Fixes for wxWidgets asserts

### DIFF
--- a/src/AudioFormats.h
+++ b/src/AudioFormats.h
@@ -649,8 +649,7 @@ public:
 		if (mc.getSize() > 35)
 		{
 			// Check for header text using official signature string
-			string header(wxString::FromAscii(mc.getData(), 27));
-			if (header == "SNES-SPC700 Sound File Data")
+			if (memcmp(mc.getData(), "SNES-SPC700 Sound File Data", 27) == 0)
 				return EDF_TRUE;
 		}
 		return EDF_FALSE;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -107,6 +107,7 @@ MainWindow::MainWindow()
  *******************************************************************/
 MainWindow::~MainWindow()
 {
+	m_mgr->UnInit();
 }
 
 /* MainWindow::loadLayout

--- a/src/MapEditorWindow.cpp
+++ b/src/MapEditorWindow.cpp
@@ -97,6 +97,7 @@ MapEditorWindow::MapEditorWindow()
  *******************************************************************/
 MapEditorWindow::~MapEditorWindow()
 {
+	wxAuiManager::GetManager(this)->UnInit();
 }
 
 /* MapEditorWindow::loadLayout

--- a/src/TarArchive.cpp
+++ b/src/TarArchive.cpp
@@ -546,7 +546,7 @@ bool TarArchive::isTarArchive(MemChunk& mc)
 		// Read tar header
 		tar_header header;
 		mc.read(&header, 512);
-		if (string(wxString::FromAscii(header.magic, 5)).CmpNoCase(TMAGIC))
+		if (string(wxString::From8BitData(header.magic, 5)).CmpNoCase(TMAGIC))
 		{
 			if (TarMakeChecksum(&header) == 0)
 			{


### PR DESCRIPTION
TarArchive::isTarArchive() and SPDCDataFormat::isThisFormat() no longer cause
src/common/string.cpp(1187): assert "c < 0x80" failed in FromAscii(): Non-ASCII value passed to FromAscii().

MainWindow::~MainWindow() and MapEditorWindow::~MapEditorWindow() no longer cause
src/common/wincmn.cpp(468): assert "GetEventHandler() == this" failed in ~wxWindowBase(): any pushed event handlers must have been removed
