### PR TITLE
Disabled update when map window is in background

### DIFF
--- a/src/MapCanvas.cpp
+++ b/src/MapCanvas.cpp
@@ -3753,7 +3753,11 @@ void MapCanvas::onFocus(wxFocusEvent& e)
 	{
 		if (editor->editMode() == MapEditor::MODE_3D)
 			lockMouse(true);
+		timer.Start(-1, true);
 	}
 	else if (e.GetEventType() == wxEVT_KILL_FOCUS)
+	{
+		timer.Stop();
 		lockMouse(false);
+	}
 }


### PR DESCRIPTION
Even with map_bg_ms CVAR set to 1000 map canvas updates consume significant amount of one CPU core cycles.
It’s important for mobile computers to reduce noise, heat and battery drain.
