### PR TITLE
MIDI variants should compile on Linux now

### DIFF
--- a/src/zreaders/i_music.cpp
+++ b/src/zreaders/i_music.cpp
@@ -48,7 +48,7 @@ enum EMIDIType
 	MIDI_MUS
 };
 
-extern int MUSHeaderSearch(const BYTE *head, int len);
+extern int MUSHeaderSearch(const uint8_t *head, int len);
 
 //==========================================================================
 //
@@ -56,21 +56,21 @@ extern int MUSHeaderSearch(const BYTE *head, int len);
 //
 //==========================================================================
 
-static MIDIStreamer *CreateMIDIStreamer(FILE *file, const BYTE *musiccache, int len, EMidiDevice devtype, EMIDIType miditype)
+static MIDIStreamer *CreateMIDIStreamer(FILE *file, const uint8_t *musiccache, int len, EMIDIType miditype)
 {
 	switch (miditype)
 	{
 	case MIDI_MUS:
-		return new MUSSong(file, musiccache, len, devtype);
+		return new MUSSong(file, musiccache, len);
 
 	case MIDI_MIDI:
-		return new MIDISong(file, musiccache, len, devtype);
+		return new MIDISong(file, musiccache, len);
 
 	case MIDI_HMI:
-		return new HMISong(file, musiccache, len, devtype);
+		return new HMISong(file, musiccache, len);
 
 	case MIDI_XMI:
-		return new XMISong(file, musiccache, len, devtype);
+		return new XMISong(file, musiccache, len);
 
 	default:
 		return NULL;
@@ -83,11 +83,11 @@ static MIDIStreamer *CreateMIDIStreamer(FILE *file, const BYTE *musiccache, int 
 //
 //==========================================================================
 
-static EMIDIType IdentifyMIDIType(DWORD *id, int size)
+static EMIDIType IdentifyMIDIType(uint32_t *id, int size)
 {
 	// Check for MUS format
-	// Tolerate sloppy wads by searching up to 32 bytes for the header
-	if (MUSHeaderSearch((BYTE*)id, size) >= 0)
+	// Tolerate sloppy wads by searching up to 32 uint8_ts for the header
+	if (MUSHeaderSearch((uint8_t*)id, size) >= 0)
 	{
 		return MIDI_MUS;
 	}
@@ -135,15 +135,15 @@ static EMIDIType IdentifyMIDIType(DWORD *id, int size)
 
 bool zmus2mid(MemChunk& musinput, MemChunk& midioutput)
 {
-	EMIDIType type = IdentifyMIDIType((DWORD*)musinput.getData(), musinput.getSize());
+	EMIDIType type = IdentifyMIDIType((uint32_t*)musinput.getData(), musinput.getSize());
 	if (type != MIDI_NOTMIDI)
 	{
-		MIDIStreamer* streamer = CreateMIDIStreamer(NULL, musinput.getData(), musinput.getSize(), MDEV_FLUIDSYNTH, type);
+		MIDIStreamer* streamer = CreateMIDIStreamer(NULL, musinput.getData(), musinput.getSize(), type);
 		if (streamer)
 		{
-			TArray<BYTE> bytes;
-			streamer->CreateSMF(bytes, 1);
-			return (bytes.Size() && midioutput.write(&bytes[0], bytes.Size()));
+			TArray<uint8_t> uint8_ts;
+			streamer->CreateSMF(uint8_ts, 1);
+			return (uint8_ts.Size() && midioutput.write(&uint8_ts[0], uint8_ts.Size()));
 		}
 	}
 	return false;

--- a/src/zreaders/i_musicinterns.h
+++ b/src/zreaders/i_musicinterns.h
@@ -4,27 +4,16 @@
 #include "tarray.h"
 #include "i_music.h"
 
-enum EMidiDevice
-{
-	MDEV_DEFAULT = -1,
-	MDEV_MMAPI = 0,
-	MDEV_OPL = 1,
-	MDEV_FMOD = 2,
-	MDEV_TIMIDITY = 3,
-	MDEV_FLUIDSYNTH = 4,
-	MDEV_GUS = 5,
-};
-
 // Base class for streaming MUS and MIDI files ------------------------------
 
 class MIDIStreamer
 {
 public:
-	MIDIStreamer(EMidiDevice type);
+	MIDIStreamer();
 	~MIDIStreamer();
 
 	bool SetSubsong(int subsong);
-	void CreateSMF(TArray<BYTE> &file, int looplimit=0);
+	void CreateSMF(TArray<uint8_t> &file, int looplimit=0);
 
 protected:
 	int VolumeControllerChange(int channel, int volume);
@@ -36,7 +25,7 @@ protected:
 	virtual void DoRestart() = 0;
 	virtual bool CheckDone() = 0;
 	virtual bool SetMIDISubsong(int subsong);
-	virtual DWORD *MakeEvents(DWORD *events, DWORD *max_event_p, DWORD max_time) = 0;
+	virtual uint32_t *MakeEvents(uint32_t *events, uint32_t *max_event_p, uint32_t max_time) = 0;
 
 	enum
 	{
@@ -50,21 +39,11 @@ protected:
 		SONG_ERROR
 	};
 
-	DWORD Events[2][MAX_EVENTS*3];
-	MIDIHDR Buffer[2];
-	int BufferNum;
-	int EndQueued;
-	bool VolumeChanged;
-	bool Restarting;
-	bool InitialPlayback;
-	DWORD NewVolume;
+	uint32_t Events[2][MAX_EVENTS*3];
 	int Division;
 	int Tempo;
 	int InitialTempo;
-	BYTE ChannelVolumes[16];
-	DWORD Volume;
-	EMidiDevice DeviceType;
-	bool CallbackIsThreaded;
+	uint32_t Volume;
 	int LoopLimit;
 };
 
@@ -73,17 +52,17 @@ protected:
 class MUSSong : public MIDIStreamer
 {
 public:
-	MUSSong(FILE *file, const BYTE *musiccache, int length, EMidiDevice type);
+	MUSSong(FILE *file, const uint8_t *musiccache, int length);
 	~MUSSong();
 
 protected:
 	void DoRestart();
 	bool CheckDone();
-	DWORD *MakeEvents(DWORD *events, DWORD *max_events_p, DWORD max_time);
+	uint32_t *MakeEvents(uint32_t *events, uint32_t *max_events_p, uint32_t max_time);
 
 	MUSHeader *MusHeader;
-	BYTE *MusBuffer;
-	BYTE LastVelocity[16];
+	uint8_t *MusBuffer;
+	uint8_t LastVelocity[16];
 	size_t MusP, MaxMusP;
 };
 
@@ -92,44 +71,44 @@ protected:
 class MIDISong : public MIDIStreamer
 {
 public:
-	MIDISong(FILE *file, const BYTE *musiccache, int length, EMidiDevice type);
+	MIDISong(FILE *file, const uint8_t *musiccache, int length);
 	~MIDISong();
 
 protected:
 	void CheckCaps(int tech);
 	void DoRestart();
 	bool CheckDone();
-	DWORD *MakeEvents(DWORD *events, DWORD *max_events_p, DWORD max_time);
-	void AdvanceTracks(DWORD time);
+	uint32_t *MakeEvents(uint32_t *events, uint32_t *max_events_p, uint32_t max_time);
+	void AdvanceTracks(uint32_t time);
 
 	struct TrackInfo;
 
 	void ProcessInitialMetaEvents ();
-	DWORD *SendCommand (DWORD *event, TrackInfo *track, DWORD delay);
+	uint32_t *SendCommand (uint32_t *event, TrackInfo *track, uint32_t delay);
 	TrackInfo *FindNextDue ();
 
-	BYTE *MusHeader;
+	uint8_t *MusHeader;
 	int SongLen;
 	TrackInfo *Tracks;
 	TrackInfo *TrackDue;
 	int NumTracks;
 	int Format;
-	WORD DesignationMask;
+	uint16_t DesignationMask;
 };
 
 // HMI file played with a MIDI stream ---------------------------------------
 
 struct AutoNoteOff
 {
-	DWORD Delay;
-	BYTE Channel, Key;
+	uint32_t Delay;
+	uint8_t Channel, Key;
 };
 // Sorry, std::priority_queue, but I want to be able to modify the contents of the heap.
 class NoteOffQueue : public TArray<AutoNoteOff>
 {
 public:
-	void AddNoteOff(DWORD delay, BYTE channel, BYTE key);
-	void AdvanceTime(DWORD time);
+	void AddNoteOff(uint32_t delay, uint8_t channel, uint8_t key);
+	void AdvanceTime(uint32_t time);
 	bool Pop(AutoNoteOff &item);
 
 protected:
@@ -143,7 +122,7 @@ protected:
 class HMISong : public MIDIStreamer
 {
 public:
-	HMISong(FILE *file, const BYTE *musiccache, int length, EMidiDevice type);
+	HMISong(FILE *file, const uint8_t *musiccache, int length);
 	~HMISong();
 
 protected:
@@ -153,25 +132,25 @@ protected:
 
 	void DoRestart();
 	bool CheckDone();
-	DWORD *MakeEvents(DWORD *events, DWORD *max_events_p, DWORD max_time);
-	void AdvanceTracks(DWORD time);
+	uint32_t *MakeEvents(uint32_t *events, uint32_t *max_events_p, uint32_t max_time);
+	void AdvanceTracks(uint32_t time);
 
 	struct TrackInfo;
 
 	void ProcessInitialMetaEvents ();
-	DWORD *SendCommand (DWORD *event, TrackInfo *track, DWORD delay);
+	uint32_t *SendCommand (uint32_t *event, TrackInfo *track, uint32_t delay);
 	TrackInfo *FindNextDue ();
 
-	static DWORD ReadVarLenHMI(TrackInfo *);
-	static DWORD ReadVarLenHMP(TrackInfo *);
+	static uint32_t ReadVarLenHMI(TrackInfo *);
+	static uint32_t ReadVarLenHMP(TrackInfo *);
 
-	BYTE *MusHeader;
+	uint8_t *MusHeader;
 	int SongLen;
 	int NumTracks;
 	TrackInfo *Tracks;
 	TrackInfo *TrackDue;
 	TrackInfo *FakeTrack;
-	DWORD (*ReadVarLen)(TrackInfo *);
+	uint32_t (*ReadVarLen)(TrackInfo *);
 	NoteOffQueue NoteOffs;
 };
 
@@ -180,26 +159,26 @@ protected:
 class XMISong : public MIDIStreamer
 {
 public:
-	XMISong(FILE *file, const BYTE *musiccache, int length, EMidiDevice type);
+	XMISong(FILE *file, const uint8_t *musiccache, int length);
 	~XMISong();
 
 protected:
 	struct TrackInfo;
 	enum EventSource { EVENT_None, EVENT_Real, EVENT_Fake };
 
-	int FindXMIDforms(const BYTE *chunk, int len, TrackInfo *songs) const;
-	void FoundXMID(const BYTE *chunk, int len, TrackInfo *song) const;
+	int FindXMIDforms(const uint8_t *chunk, int len, TrackInfo *songs) const;
+	void FoundXMID(const uint8_t *chunk, int len, TrackInfo *song) const;
 	bool SetMIDISubsong(int subsong);
 	void DoRestart();
 	bool CheckDone();
-	DWORD *MakeEvents(DWORD *events, DWORD *max_events_p, DWORD max_time);
-	void AdvanceSong(DWORD time);
+	uint32_t *MakeEvents(uint32_t *events, uint32_t *max_events_p, uint32_t max_time);
+	void AdvanceSong(uint32_t time);
 
 	void ProcessInitialMetaEvents();
-	DWORD *SendCommand (DWORD *event, EventSource track, DWORD delay);
+	uint32_t *SendCommand (uint32_t *event, EventSource track, uint32_t delay);
 	EventSource FindNextDue();
 
-	BYTE *MusHeader;
+	uint8_t *MusHeader;
 	int SongLen;		// length of the entire file
 	int NumSongs;
 	TrackInfo *Songs;

--- a/src/zreaders/mus2midi.h
+++ b/src/zreaders/mus2midi.h
@@ -41,38 +41,38 @@
 //#include <stdio.h>
 //#include "doomtype.h"
 
-#define MIDI_SYSEX		((BYTE)0xF0)		 // SysEx begin
-#define MIDI_SYSEXEND	((BYTE)0xF7)		 // SysEx end
-#define MIDI_META		((BYTE)0xFF)		 // Meta event begin
-#define MIDI_META_TEMPO ((BYTE)0x51)
-#define MIDI_META_EOT	((BYTE)0x2F)		 // End-of-track
-#define MIDI_META_SSPEC	((BYTE)0x7F)		 // System-specific event
+#define MIDI_SYSEX		((uint8_t)0xF0)		 // SysEx begin
+#define MIDI_SYSEXEND	((uint8_t)0xF7)		 // SysEx end
+#define MIDI_META		((uint8_t)0xFF)		 // Meta event begin
+#define MIDI_META_TEMPO ((uint8_t)0x51)
+#define MIDI_META_EOT	((uint8_t)0x2F)		 // End-of-track
+#define MIDI_META_SSPEC	((uint8_t)0x7F)		 // System-specific event
 
-#define MIDI_NOTEOFF	((BYTE)0x80)		 // + note + velocity
-#define MIDI_NOTEON 	((BYTE)0x90)		 // + note + velocity
-#define MIDI_POLYPRESS	((BYTE)0xA0)		 // + pressure (2 bytes)
-#define MIDI_CTRLCHANGE ((BYTE)0xB0)		 // + ctrlr + value
-#define MIDI_PRGMCHANGE ((BYTE)0xC0)		 // + new patch
-#define MIDI_CHANPRESS	((BYTE)0xD0)		 // + pressure (1 byte)
-#define MIDI_PITCHBEND	((BYTE)0xE0)		 // + pitch bend (2 bytes)
+#define MIDI_NOTEOFF	((uint8_t)0x80)		 // + note + velocity
+#define MIDI_NOTEON 	((uint8_t)0x90)		 // + note + velocity
+#define MIDI_POLYPRESS	((uint8_t)0xA0)		 // + pressure (2 uint8_ts)
+#define MIDI_CTRLCHANGE ((uint8_t)0xB0)		 // + ctrlr + value
+#define MIDI_PRGMCHANGE ((uint8_t)0xC0)		 // + new patch
+#define MIDI_CHANPRESS	((uint8_t)0xD0)		 // + pressure (1 uint8_t)
+#define MIDI_PITCHBEND	((uint8_t)0xE0)		 // + pitch bend (2 uint8_ts)
 
-#define MUS_NOTEOFF 	((BYTE)0x00)
-#define MUS_NOTEON		((BYTE)0x10)
-#define MUS_PITCHBEND	((BYTE)0x20)
-#define MUS_SYSEVENT	((BYTE)0x30)
-#define MUS_CTRLCHANGE	((BYTE)0x40)
-#define MUS_SCOREEND	((BYTE)0x60)
+#define MUS_NOTEOFF 	((uint8_t)0x00)
+#define MUS_NOTEON		((uint8_t)0x10)
+#define MUS_PITCHBEND	((uint8_t)0x20)
+#define MUS_SYSEVENT	((uint8_t)0x30)
+#define MUS_CTRLCHANGE	((uint8_t)0x40)
+#define MUS_SCOREEND	((uint8_t)0x60)
 
 typedef struct
 {
-	DWORD Magic;
-	WORD SongLen;
-	WORD SongStart;
-	WORD NumChans;
-	WORD NumSecondaryChans;
-	WORD NumInstruments;
-	WORD Pad;
-	// WORD UsedInstruments[NumInstruments];
+	uint32_t Magic;
+	uint16_t SongLen;
+	uint16_t SongStart;
+	uint16_t NumChans;
+	uint16_t NumSecondaryChans;
+	uint16_t NumInstruments;
+	uint16_t Pad;
+	// uint16_t UsedInstruments[NumInstruments];
 } MUSHeader;
 
 #endif //__MUS2MIDI_H__

--- a/src/zreaders/music_hmi_midiout.cpp
+++ b/src/zreaders/music_hmi_midiout.cpp
@@ -88,18 +88,18 @@
 
 struct HMISong::TrackInfo
 {
-	const BYTE *TrackBegin;
+	const uint8_t *TrackBegin;
 	size_t TrackP;
 	size_t MaxTrackP;
-	DWORD Delay;
-	DWORD PlayedTime;
-	WORD Designation[NUM_HMI_DESIGNATIONS];
+	uint32_t Delay;
+	uint32_t PlayedTime;
+	uint16_t Designation[NUM_HMI_DESIGNATIONS];
 	bool Enabled;
 	bool Finished;
-	BYTE RunningStatus;
+	uint8_t RunningStatus;
     
-	DWORD ReadVarLenHMI();
-	DWORD ReadVarLenHMP();
+	uint32_t ReadVarLenHMI();
+	uint32_t ReadVarLenHMP();
 };
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
@@ -115,14 +115,14 @@ extern char MIDI_CommonLengths[15];
 //
 //==========================================================================
 
-HMISong::HMISong (FILE *file, const BYTE *musiccache, int len, EMidiDevice type)
-: MIDIStreamer(type), MusHeader(0), Tracks(0)
+HMISong::HMISong (FILE *file, const uint8_t *musiccache, int len)
+: MIDIStreamer(), MusHeader(0), Tracks(0)
 {
 	if (len < 0x100)
 	{ // Way too small to be HMI.
 		return;
 	}
-	MusHeader = new BYTE[len];
+	MusHeader = new uint8_t[len];
 	SongLen = len;
 	NumTracks = 0;
 	if (file != NULL)
@@ -468,12 +468,12 @@ bool HMISong::CheckDone()
 //
 //==========================================================================
 
-DWORD *HMISong::MakeEvents(DWORD *events, DWORD *max_event_p, DWORD max_time)
+uint32_t *HMISong::MakeEvents(uint32_t *events, uint32_t *max_event_p, uint32_t max_time)
 {
-	DWORD *start_events;
-	DWORD tot_time = 0;
-	DWORD time = 0;
-	DWORD delay;
+	uint32_t *start_events;
+	uint32_t tot_time = 0;
+	uint32_t time = 0;
+	uint32_t delay;
 
 	start_events = events;
 	while (TrackDue && events < max_event_p && tot_time <= max_time)
@@ -492,7 +492,7 @@ DWORD *HMISong::MakeEvents(DWORD *events, DWORD *max_event_p, DWORD max_time)
 			// Play all events for this tick.
 			do
 			{
-				DWORD *new_events = SendCommand(events, TrackDue, time);
+				uint32_t *new_events = SendCommand(events, TrackDue, time);
 				TrackDue = FindNextDue();
 				if (new_events != events)
 				{
@@ -516,7 +516,7 @@ DWORD *HMISong::MakeEvents(DWORD *events, DWORD *max_event_p, DWORD max_time)
 //
 //==========================================================================
 
-void HMISong::AdvanceTracks(DWORD time)
+void HMISong::AdvanceTracks(uint32_t time)
 {
 	for (int i = 0; i <= NumTracks; ++i)
 	{
@@ -537,10 +537,10 @@ void HMISong::AdvanceTracks(DWORD time)
 //
 //==========================================================================
 
-DWORD *HMISong::SendCommand (DWORD *events, TrackInfo *track, DWORD delay)
+uint32_t *HMISong::SendCommand (uint32_t *events, TrackInfo *track, uint32_t delay)
 {
-	DWORD len;
-	BYTE mevent, data1 = 0, data2 = 0;
+	uint32_t len;
+	uint8_t mevent, data1 = 0, data2 = 0;
 
 	// If the next event comes from the fake track, pop an entry off the note-off queue.
 	if (track == FakeTrack)
@@ -705,8 +705,8 @@ void HMISong::ProcessInitialMetaEvents ()
 {
 	TrackInfo *track;
 	int i;
-	BYTE event;
-	DWORD len;
+	uint8_t event;
+	uint32_t len;
 
 	for (i = 0; i < NumTracks; ++i)
 	{
@@ -751,7 +751,7 @@ void HMISong::ProcessInitialMetaEvents ()
 //
 //==========================================================================
 
-DWORD HMISong::ReadVarLenHMI(TrackInfo *track)
+uint32_t HMISong::ReadVarLenHMI(TrackInfo *track)
 {
 	return track->ReadVarLenHMI();
 }
@@ -762,7 +762,7 @@ DWORD HMISong::ReadVarLenHMI(TrackInfo *track)
 //
 //==========================================================================
 
-DWORD HMISong::ReadVarLenHMP(TrackInfo *track)
+uint32_t HMISong::ReadVarLenHMP(TrackInfo *track)
 {
 	return track->ReadVarLenHMP();
 }
@@ -775,9 +775,9 @@ DWORD HMISong::ReadVarLenHMP(TrackInfo *track)
 //
 //==========================================================================
 
-DWORD HMISong::TrackInfo::ReadVarLenHMI()
+uint32_t HMISong::TrackInfo::ReadVarLenHMI()
 {
-	DWORD time = 0, t = 0x80;
+	uint32_t time = 0, t = 0x80;
 
 	while ((t & 0x80) && TrackP < MaxTrackP)
 	{
@@ -797,10 +797,10 @@ DWORD HMISong::TrackInfo::ReadVarLenHMI()
 //
 //==========================================================================
 
-DWORD HMISong::TrackInfo::ReadVarLenHMP()
+uint32_t HMISong::TrackInfo::ReadVarLenHMP()
 {
-	DWORD time = 0;
-	BYTE t = 0;
+	uint32_t time = 0;
+	uint8_t t = 0;
 	int off = 0;
 
 	while (!(t & 0x80) && TrackP < MaxTrackP)
@@ -818,7 +818,7 @@ DWORD HMISong::TrackInfo::ReadVarLenHMP()
 //
 //==========================================================================
 
-void NoteOffQueue::AddNoteOff(DWORD delay, BYTE channel, BYTE key)
+void NoteOffQueue::AddNoteOff(uint32_t delay, uint8_t channel, uint8_t key)
 {
 	unsigned int i = Reserve(1);
 	while (i > 0 && (*this)[Parent(i)].Delay > delay)
@@ -854,7 +854,7 @@ bool NoteOffQueue::Pop(AutoNoteOff &item)
 //
 //==========================================================================
 
-void NoteOffQueue::AdvanceTime(DWORD time)
+void NoteOffQueue::AdvanceTime(uint32_t time)
 {
 	// Because the time is decreasing by the same amount for every entry,
 	// the heap property is maintained.
@@ -908,7 +908,7 @@ void NoteOffQueue::Heapify()
 HMISong::TrackInfo *HMISong::FindNextDue ()
 {
 	TrackInfo *track;
-	DWORD best;
+	uint32_t best;
 	int i;
 
 	// Give precedence to whichever track last had events taken from it.


### PR DESCRIPTION
Replaced Windows types (DWORD, WORD, BYTE) by SLADE's own (uint32_t,
uint16_t, uint8_t).
Removed more unneeded stuff.
