### PR TITLE
Repaired UTF8 in saved file paths.

### DIFF
--- a/src/Main.h
+++ b/src/Main.h
@@ -28,7 +28,7 @@ typedef wxString string;
 
 // Macro to convert a wxString to a c string
 #define CHR(s) (static_cast<const char*>((s).ToAscii()))
-
+#define UTF8(s) (static_cast<const char*>((s).c_str()))
 
 // Vectors
 #include <vector>

--- a/src/MainApp.cpp
+++ b/src/MainApp.cpp
@@ -866,14 +866,14 @@ void MainApp::readConfigFile()
 		if (!token.Cmp("base_resource_paths"))
 		{
 			// Skip {
-			token = wxString::FromUTF8(CHR(tz.getToken()));
+			token = wxString::FromUTF8(UTF8(tz.getToken()));
 
 			// Read paths until closing brace found
 			token = tz.getToken();
 			while (token.Cmp("}"))
 			{
 				theArchiveManager->addBaseResourcePath(token);
-				token = wxString::FromUTF8(CHR(tz.getToken()));
+				token = wxString::FromUTF8(UTF8(tz.getToken()));
 			}
 		}
 
@@ -884,11 +884,11 @@ void MainApp::readConfigFile()
 			token = tz.getToken();
 
 			// Read files until closing brace found
-			token = wxString::FromUTF8(CHR(tz.getToken()));
+			token = wxString::FromUTF8(UTF8(tz.getToken()));
 			while (token != "}")
 			{
 				theArchiveManager->addRecentFile(token);
-				token = wxString::FromUTF8(CHR(tz.getToken()));
+				token = wxString::FromUTF8(UTF8(tz.getToken()));
 			}
 		}
 


### PR DESCRIPTION
With a new UTF8 macro used instead of CHR.
