### PR TITLE
Fix an occasional crash in the propgrid when switching modes.

### DIFF
--- a/src/MapObjectPropsPanel.cpp
+++ b/src/MapObjectPropsPanel.cpp
@@ -434,6 +434,7 @@ void MapObjectPropsPanel::setupType(int objtype)
 	pg_properties->Clear();
 	pg_props_side1->Clear();
 	pg_props_side2->Clear();
+	group_custom = NULL;
 	properties.clear();
 	btn_add->Show(false);
 
@@ -684,6 +685,7 @@ void MapObjectPropsPanel::setupTypeUDMF(int objtype)
 	pg_properties->Clear();
 	pg_props_side1->Clear();
 	pg_props_side2->Clear();
+	group_custom = NULL;
 	properties.clear();
 	btn_add->Show();
 


### PR DESCRIPTION
Fixes #110.

If the previous mode had a "custom" prop group, it would be removed from the grid by the mode change, but wouldn't be deleted.  Trying to add properties to it would then cause a crash.

Fix is to just clear out `group_custom` when repopulating the grid.
