### PR TITLE
Use "<missing values>" in the sidedef tabs, and show it in gray.

### DIFF
--- a/src/MapObjectPropsPanel.cpp
+++ b/src/MapObjectPropsPanel.cpp
@@ -107,7 +107,10 @@ MapObjectPropsPanel::MapObjectPropsPanel(wxWindow* parent) : wxPanel(parent, -1)
 
 	wxPGCell cell;
 	cell.SetText("<multiple values>");
+	cell.SetFgCol(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
 	pg_properties->GetGrid()->SetUnspecifiedValueAppearance(cell);
+	pg_props_side1->GetGrid()->SetUnspecifiedValueAppearance(cell);
+	pg_props_side2->GetGrid()->SetUnspecifiedValueAppearance(cell);
 
 	// Bind events
 	btn_apply->Bind(wxEVT_BUTTON, &MapObjectPropsPanel::onBtnApply, this);


### PR DESCRIPTION
Ambiguous sidedef properties were rendering as blank, because their grids never had their styles updated.

I think it's a common pattern to show faux values in a fainter color?  Looks better to me, anyway  :)
