### PR TITLE
Wolfenstein 3D archive loading improvements

### DIFF
--- a/src/ArchiveManager.cpp
+++ b/src/ArchiveManager.cpp
@@ -674,7 +674,9 @@ string ArchiveManager::getArchiveExtensionsString()
 	                    "audiot.*;AUDIOT.*;Audiot.*;"
 	                    "audiohed.*;AUDIOHED.*;Audiohed.*;"
 	                    "gamemaps.*;GAMEMAPS.*;Gamemaps.*;"
+	                    "gfxtiles.*;GFXTILES.*;Gfxtiles.*;"
 	                    "maphead.*;MAPHEAD.*;Maphead.*"
+	                    "maptemp.*;MAPTEMP.*;Maptemp.*"
 	                    "vgagraph.*;VGAGRAPH.*;Vgagraph.*"
 	                    "vgahead.*;VGAHEAD.*;Vgahead.*;"
 	                    "vgadict.*;VGADICT.*;Vgadict.*";		extensions += ext_wolf +";";


### PR DESCRIPTION
Improves audiot loader to properly scan for which sounds are PC Speaker, AdLib, digital, or music.  The location of the IMF name in the chunk footer is actually a constant so no need to actually search for it.

Also allows Corridor 7's GFXTILES to be opened (renamed VSWAP).
