### PR TITLE
Automatically load any WADs in the root of a zip/dir.

### DIFF
--- a/src/ArchiveManager.cpp
+++ b/src/ArchiveManager.cpp
@@ -59,7 +59,6 @@ ArchiveManager::ArchiveManager()
 	// Init variables
 	res_archive_open = false;
 	base_resource_archive = NULL;
-	open_silent = false;
 }
 
 /* ArchiveManager::~ArchiveManager
@@ -189,6 +188,28 @@ bool ArchiveManager::addArchive(Archive* archive)
 		// Add to resource manager
 		theResourceManager->addArchive(archive);
 
+		// ZDoom also loads any WADs found in the root of a PK3 or directory
+		if (archive->getType() == ARCHIVE_ZIP || archive->getType() == ARCHIVE_FOLDER)
+		{
+			ArchiveTreeNode* root = archive->getRoot();
+			ArchiveEntry* entry;
+			EntryType* type;
+			for (unsigned a = 0; a < root->numEntries(); a++)
+			{
+				entry = root->getEntry(a);
+
+				if (entry->getType() == EntryType::unknownType())
+					EntryType::detectEntryType(entry);
+
+				type = entry->getType();
+
+				if (type->getId() == "wad")
+					// First true: yes, manage this
+					// Second true: open silently, don't open a tab for it
+					openArchive(entry, true, true);
+			}
+		}
+
 		return true;
 	}
 	else
@@ -236,8 +257,6 @@ Archive* ArchiveManager::openArchive(string filename, bool manage, bool silent)
 	if (!wxFile::Exists(filename) && wxDirExists(filename))
 		return openDirArchive(filename, manage, silent);
 
-	open_silent = silent;
-
 	Archive* new_archive = getArchive(filename);
 
 	wxLogMessage("Opening archive %s", filename);
@@ -246,10 +265,13 @@ Archive* ArchiveManager::openArchive(string filename, bool manage, bool silent)
 	if (new_archive)
 	{
 		// Announce open
-		MemChunk mc;
-		uint32_t index = archiveIndex(new_archive);
-		mc.write(&index, 4);
-		announce("archive_opened", mc);
+		if (!silent)
+		{
+			MemChunk mc;
+			uint32_t index = archiveIndex(new_archive);
+			mc.write(&index, 4);
+			announce("archive_opened", mc);
+		}
 
 		return new_archive;
 	}
@@ -312,10 +334,13 @@ Archive* ArchiveManager::openArchive(string filename, bool manage, bool silent)
 			addArchive(new_archive);
 
 			// Announce open
-			MemChunk mc;
-			uint32_t index = archiveIndex(new_archive);
-			mc.write(&index, 4);
-			announce("archive_opened", mc);
+			if (!silent)
+			{
+				MemChunk mc;
+				uint32_t index = archiveIndex(new_archive);
+				mc.write(&index, 4);
+				announce("archive_opened", mc);
+			}
 
 			// Add to recent files
 			addRecentFile(filename);
@@ -337,7 +362,6 @@ Archive* ArchiveManager::openArchive(string filename, bool manage, bool silent)
  *******************************************************************/
 Archive* ArchiveManager::openArchive(ArchiveEntry* entry, bool manage, bool silent)
 {
-	open_silent = silent;
 	Archive* new_archive = NULL;
 
 	// Check entry was given
@@ -350,10 +374,13 @@ Archive* ArchiveManager::openArchive(ArchiveEntry* entry, bool manage, bool sile
 		if (open_archives[a].archive->getParent() == entry)
 		{
 			// Announce open
-			MemChunk mc;
-			uint32_t index = archiveIndex(open_archives[a].archive);
-			mc.write(&index, 4);
-			announce("archive_opened", mc);
+			if (!silent)
+			{
+				MemChunk mc;
+				uint32_t index = archiveIndex(open_archives[a].archive);
+				mc.write(&index, 4);
+				announce("archive_opened", mc);
+			}
 
 			return open_archives[a].archive;
 		}
@@ -424,10 +451,13 @@ Archive* ArchiveManager::openArchive(ArchiveEntry* entry, bool manage, bool sile
 			addArchive(new_archive);
 
 			// Announce open
-			MemChunk mc;
-			uint32_t index = archiveIndex(new_archive);
-			mc.write(&index, 4);
-			announce("archive_opened", mc);
+			if (!silent)
+			{
+				MemChunk mc;
+				uint32_t index = archiveIndex(new_archive);
+				mc.write(&index, 4);
+				announce("archive_opened", mc);
+			}
 		}
 
 		return new_archive;
@@ -446,8 +476,6 @@ Archive* ArchiveManager::openArchive(ArchiveEntry* entry, bool manage, bool sile
  *******************************************************************/
 Archive* ArchiveManager::openDirArchive(string dir, bool manage, bool silent)
 {
-	open_silent = silent;
-
 	Archive* new_archive = getArchive(dir);
 
 	wxLogMessage("Opening directory %s as archive", dir);
@@ -456,10 +484,13 @@ Archive* ArchiveManager::openDirArchive(string dir, bool manage, bool silent)
 	if (new_archive)
 	{
 		// Announce open
-		MemChunk mc;
-		uint32_t index = archiveIndex(new_archive);
-		mc.write(&index, 4);
-		announce("archive_opened", mc);
+		if (!silent)
+		{
+			MemChunk mc;
+			uint32_t index = archiveIndex(new_archive);
+			mc.write(&index, 4);
+			announce("archive_opened", mc);
+		}
 
 		return new_archive;
 	}
@@ -476,10 +507,13 @@ Archive* ArchiveManager::openDirArchive(string dir, bool manage, bool silent)
 			addArchive(new_archive);
 
 			// Announce open
-			MemChunk mc;
-			uint32_t index = archiveIndex(new_archive);
-			mc.write(&index, 4);
-			announce("archive_opened", mc);
+			if (!silent)
+			{
+				MemChunk mc;
+				uint32_t index = archiveIndex(new_archive);
+				mc.write(&index, 4);
+				announce("archive_opened", mc);
+			}
 
 			// Add to recent files
 			addRecentFile(dir);

--- a/src/ArchiveManager.h
+++ b/src/ArchiveManager.h
@@ -22,7 +22,6 @@ private:
 	vector<string>			base_resource_paths;
 	vector<string>			recent_files;
 	vector<ArchiveEntry*>	bookmarks;
-	bool					open_silent;
 	static ArchiveManager*	instance;
 
 public:
@@ -67,7 +66,6 @@ public:
 	string		getArchiveExtensionsString();
 	bool		archiveIsResource(Archive* archive);
 	void		setArchiveResource(Archive* archive, bool resource = true);
-	bool		openSilent() { return open_silent; }
 
 	// Base resource archive stuff
 	Archive*	baseResourceArchive() { return base_resource_archive; }

--- a/src/ArchiveManagerPanel.cpp
+++ b/src/ArchiveManagerPanel.cpp
@@ -1262,7 +1262,7 @@ void ArchiveManagerPanel::onAnnouncement(Announcer* announcer, string event_name
 	{
 		uint32_t index = -1;
 		event_data.read(&index, 4);
-		if (!theArchiveManager->openSilent()) openTab(index);
+		openTab(index);
 	}
 
 	// If an archive was saved


### PR DESCRIPTION
I've been dropping realm667 resource WADs into the root of a directory; it's zero-effort, avoids the fuss of moving all the parts to the right places, preserves the authorship information automatically, and is natively supported by ZDoom.  But not by SLADE!  So here you go.

The only other zip-supporting port SLADE knows about is Eternity, which sounds like it [supports embedded WADs as well](http://www.doomworld.com/vb/eternity/62087-eternity-engine-3-40-30-alfheim/).

Hmm, I did just realize that the WADs are supposed to be read [in alphabetical order](http://zdoom.org/wiki/PK3#How_to).  `ZipArchive` and `DirArchive` probably just read in disk order, right?  Is this addressed anywhere else or do you assume it's the author's problem if there are conflicts in the first place?  :)
