### PR TITLE
Fix crashing when closing an archive with open child archives.

### DIFF
--- a/src/ArchiveManager.h
+++ b/src/ArchiveManager.h
@@ -24,6 +24,8 @@ private:
 	vector<ArchiveEntry*>	bookmarks;
 	static ArchiveManager*	instance;
 
+	void		getDependentArchivesInternal(Archive* archive, vector<Archive*>& vec);
+
 public:
 	ArchiveManager();
 	~ArchiveManager();
@@ -62,6 +64,8 @@ public:
 	void		closeAll();
 	int			numArchives() { return (int)open_archives.size(); }
 	int			archiveIndex(Archive* archive);
+	vector<Archive*>
+				getDependentArchives(Archive* archive);
 	Archive*	programResourceArchive() { return program_resource_archive; }
 	string		getArchiveExtensionsString();
 	bool		archiveIsResource(Archive* archive);

--- a/src/ArchiveManagerPanel.cpp
+++ b/src/ArchiveManagerPanel.cpp
@@ -50,7 +50,6 @@
  *******************************************************************/
 CVAR(Bool, close_archive_with_tab, true, CVAR_SAVE)
 CVAR(Int, am_current_tab, 0, CVAR_SAVE)
-int tab_closing = false;	// Hacky workaround to prevent crash on closing a tab when close_archive_with_tab is true
 
 
 /*******************************************************************
@@ -173,6 +172,7 @@ ArchiveManagerPanel::ArchiveManagerPanel(wxWindow* parent, wxAuiNotebook* nb_arc
 	notebook_archives->Bind(wxEVT_AUINOTEBOOK_PAGE_CHANGING, &ArchiveManagerPanel::onArchiveTabChanging, this);
 	notebook_archives->Bind(wxEVT_AUINOTEBOOK_PAGE_CHANGED, &ArchiveManagerPanel::onArchiveTabChanged, this);
 	notebook_archives->Bind(wxEVT_AUINOTEBOOK_PAGE_CLOSE, &ArchiveManagerPanel::onArchiveTabClose, this);
+	notebook_archives->Bind(wxEVT_AUINOTEBOOK_PAGE_CLOSED, &ArchiveManagerPanel::onArchiveTabClosed, this);
 	notebook_tabs->Bind(wxEVT_AUINOTEBOOK_PAGE_CHANGED, &ArchiveManagerPanel::onAMTabChanged, this);
 
 	// Listen to the ArchiveManager
@@ -624,35 +624,12 @@ void ArchiveManagerPanel::openTab(Archive* archive)
  *******************************************************************/
 void ArchiveManagerPanel::closeTab(int archive_index)
 {
-	// Don't close if this tab is already closing
-	if (tab_closing - 1 == archive_index)
-		return;
-
 	Archive* archive = theArchiveManager->getArchive(archive_index);
+	ArchivePanel* ap = getArchiveTab(archive);
 
-	if (archive)
-	{
-		// Go through all tabs
-		for (size_t a = 0; a < notebook_archives->GetPageCount(); a++)
-		{
-			// Check page type is "archive"
-			if (notebook_archives->GetPage(a)->GetName().CmpNoCase("archive"))
-				continue;
-
-			// Check for archive match
-			ArchivePanel* ap = (ArchivePanel*)notebook_archives->GetPage(a);
-			if (ap->getArchive() == archive)
-			{
-				// Remove custom menu
-				ap->removeMenus();
-
-				// Close the tab
-				notebook_archives->DeletePage(a);
-
-				return;
-			}
-		}
-	}
+	// Close the tab, unless it's already in mid-close
+	if (ap && !ap->isClosing())
+		notebook_archives->DeletePage(notebook_archives->GetPageIndex(ap));
 }
 
 /* ArchiveManagerPanel::openTextureTab
@@ -1103,11 +1080,11 @@ bool ArchiveManagerPanel::saveArchiveAs(Archive* archive)
 	return true;
 }
 
-/* ArchiveManagerPanel::closeArchive
+/* ArchiveManagerPanel::beforeCloseArchive
  * Checks for any unsaved changes and prompts the user to save if
- * needed before closing [archive]
+ * needed, but doesn't actually close the archive
  *******************************************************************/
-bool ArchiveManagerPanel::closeArchive(Archive* archive)
+bool ArchiveManagerPanel::beforeCloseArchive(Archive* archive)
 {
 	// Check for NULL pointers -- this can happen, for example,
 	// with onArchiveTabClose() when closing a texture editor tab.
@@ -1142,8 +1119,20 @@ bool ArchiveManagerPanel::closeArchive(Archive* archive)
 			return false;	// User selected cancel, don't close the archive
 	}
 
-	// Close the archive
-	return theArchiveManager->closeArchive(archive);
+	return true;
+}
+
+/* ArchiveManagerPanel::closeArchive
+ * Checks for any unsaved changes and prompts the user to save if
+ * needed before closing [archive]
+ *******************************************************************/
+bool ArchiveManagerPanel::closeArchive(Archive* archive)
+{
+	if (!archive)
+		return false;
+
+	return beforeCloseArchive(archive)
+		&& theArchiveManager->closeArchive(archive);
 }
 
 /* ArchiveManagerPanel::getSelectedArchives
@@ -1804,29 +1793,57 @@ void ArchiveManagerPanel::onArchiveTabClose(wxAuiNotebookEvent& e)
 {
 	// Get tab that is closing
 	int tabindex = e.GetSelection();
+	wxWindow* page = notebook_archives->GetPage(tabindex);
+
 	if (tabindex < 0)
 		return;
 
 	// Close the tab's archive if needed
-	if (close_archive_with_tab)
+	if (close_archive_with_tab && isArchivePanel(tabindex))
 	{
-		Archive* archive = getArchive(tabindex);
-		if (archive)
+		ArchivePanel* ap = (ArchivePanel*)page;
+		ap->markAsClosing();
+		Archive* archive = ap->getArchive();
+
+		vector<Archive*> deps = theArchiveManager->getDependentArchives(archive);
+		deps.insert(deps.begin(), archive);
+		// Iterate in reverse order so the deepest-nested is closed first
+		for (unsigned a = deps.size(); a > 0; a--)
 		{
-			tab_closing = theArchiveManager->archiveIndex(archive) + 1;
-			if (!closeArchive(archive))
+			if (!beforeCloseArchive(deps[a - 1]))
+			{
 				e.Veto();
+				return;
+			}
 		}
-		tab_closing = 0;
+
+		for (unsigned a = 0; a < deps.size(); a++)
+			pending_closed_archives.push_back(deps[a]);
+
+		e.Skip();
+		return;
 	}
 
 	// Check for texture editor
-	if (notebook_archives->GetPage(tabindex)->GetName() == "texture")
+	if (page->GetName() == "texture")
 	{
-		TextureXEditor* txed = (TextureXEditor*)(notebook_archives->GetPage(tabindex));
+		TextureXEditor* txed = (TextureXEditor*)page;
 		if (!txed->close())
 			e.Veto();
 	}
+
+	e.Skip();
+}
+
+/* ArchiveManagerPanel::onArchiveTabClosed
+ * Called after a tab has been closed by clicking on a close button
+ *******************************************************************/
+void ArchiveManagerPanel::onArchiveTabClosed(wxAuiNotebookEvent& e)
+{
+	// Actually close all the archives the CLOSE event decided to close
+	for (unsigned a = 0; a < pending_closed_archives.size(); a++)
+		theArchiveManager->closeArchive(pending_closed_archives[a]);
+	pending_closed_archives.clear();
 
 	e.Skip();
 }

--- a/src/ArchiveManagerPanel.h
+++ b/src/ArchiveManagerPanel.h
@@ -45,6 +45,7 @@ private:
 	wxButton*			btn_browser_open;
 	wxMenu*				menu_recent;
 	Archive*			current_maps;
+	vector<Archive*>	pending_closed_archives;
 
 public:
 	ArchiveManagerPanel(wxWindow* parent, wxAuiNotebook* nb_archives);
@@ -96,6 +97,7 @@ public:
 	bool	saveEntryChanges(Archive* archive);
 	bool	saveArchive(Archive* archive);
 	bool	saveArchiveAs(Archive* archive);
+	bool	beforeCloseArchive(Archive* archive);
 	bool	closeArchive(Archive* archive);
 
 	void	createNewArchive(uint8_t type);
@@ -134,6 +136,7 @@ public:
 	void	onArchiveTabChanging(wxAuiNotebookEvent& e);
 	void	onArchiveTabChanged(wxAuiNotebookEvent& e);
 	void	onArchiveTabClose(wxAuiNotebookEvent& e);
+	void	onArchiveTabClosed(wxAuiNotebookEvent& e);
 	void	onAMTabChanged(wxAuiNotebookEvent& e);
 };
 

--- a/src/ArchivePanel.cpp
+++ b/src/ArchivePanel.cpp
@@ -300,6 +300,7 @@ ArchivePanel::ArchivePanel(wxWindow* parent, Archive* archive)
 {
 	// Init variables
 	undo_manager = new UndoManager();
+	is_closing = false;
 
 	// Set archive
 	this->archive = archive;

--- a/src/ArchivePanel.h
+++ b/src/ArchivePanel.h
@@ -22,6 +22,7 @@ protected:
 	wxBitmapButton*		btn_updir;
 	wxSizer*			sizer_path_controls;
 	UndoManager*		undo_manager;
+	bool				is_closing;
 
 	// Entry panels
 	EntryPanel*	cur_area;
@@ -56,6 +57,8 @@ public:
 	bool			saveEntryChanges();
 	void			addMenus();
 	void			removeMenus();
+	bool			isClosing() { return is_closing; }
+	void			markAsClosing() { is_closing = true; }
 
 	// Editing actions - return success
 


### PR DESCRIPTION
...maybe.

I bumped into this playing with my last branch, but found it was pre-existing.  I still don't entirely understand why it was happening, but beating several possible causes with a stick seems to have fixed it.  I wish I had more closure on this, but the crashes are happening way down in the muck of wxWidgets.

I get a trace like the following from a copy of beta 3 by opening a PK3, opening a WAD inside it, switching back to the PK3 tab, and clicking the X:

```
Stack Trace:
0: [unknown location] [unknown:54754748]
1: [unknown location] [unknown:3343360]
2: [unknown location] ArchiveTreeNode::getEntry(unsigned int)
3: [unknown location] ArchiveEntryList::updateItemAttr(long) const
4: [unknown location] VirtualListView::OnGetItemAttr(long) const
5: [unknown location] [unknown:60674628]
6: [unknown location] [unknown:60731829]
7: [unknown location] [unknown:60722832]
8: [unknown location] wxAppConsoleBase::CallEventHandler(wxEvtHandler*, wxEventFunctor&, wxEvent&) const
9: [unknown location] wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&)
10: [unknown location] wxEventHashTable::HandleEvent(wxEvent&, wxEvtHandler*)
11: [unknown location] wxEvtHandler::TryHereOnly(wxEvent&)
12: [unknown location] wxEvtHandler::ProcessEventLocally(wxEvent&)
13: [unknown location] wxEvtHandler::ProcessEvent(wxEvent&)
14: [unknown location] wxEvtHandler::SafelyProcessEvent(wxEvent&)
15: [unknown location] wxWindow::GTKSendPaintEvents(_GdkRegion const*)
16: [unknown location] [unknown:60574356]
17: [unknown location] [unknown:21859717]
18: [unknown location] g_closure_invoke
19: [unknown location] [unknown:-1994691]
20: [unknown location] g_signal_emit_valist
21: [unknown location] g_signal_emit
22: [unknown location] [unknown:22973108]
23: [unknown location] gtk_main_do_event
24: [unknown location] [unknown:563439]
25: [unknown location] [unknown:563349]
26: [unknown location] [unknown:563349]
27: [unknown location] [unknown:563349]
28: [unknown location] [unknown:563349]
29: [unknown location] [unknown:563349]
30: [unknown location] [unknown:550190]
31: [unknown location] gdk_window_process_updates
32: [unknown location] wxWindow::Update()
33: [unknown location] SToolBarButton::onFocus(wxFocusEvent&)
34: [unknown location] wxAppConsoleBase::CallEventHandler(wxEvtHandler*, wxEventFunctor&, wxEvent&) const
35: [unknown location] wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&)
36: [unknown location] wxEvtHandler::SearchDynamicEventTable(wxEvent&)
37: [unknown location] wxEvtHandler::TryHereOnly(wxEvent&)
38: [unknown location] wxEvtHandler::ProcessEventLocally(wxEvent&)
39: [unknown location] wxEvtHandler::ProcessEvent(wxEvent&)
40: [unknown location] wxEvtHandler::SafelyProcessEvent(wxEvent&)
41: [unknown location] wxWindow::GTKHandleFocusOutNoDeferring()
42: [unknown location] wxWindow::GTKHandleFocusOut()
43: [unknown location] [unknown:60558508]
44: [unknown location] [unknown:21859717]
45: [unknown location] g_closure_invoke
46: [unknown location] [unknown:-1994691]
47: [unknown location] g_signal_emit_valist
48: [unknown location] g_signal_emit
49: [unknown location] [unknown:22973108]
50: [unknown location] gtk_widget_send_focus_change
51: [unknown location] [unknown:23023251]
52: [unknown location] [unknown:23023666]
53: [unknown location] g_cclosure_marshal_VOID__OBJECTv
54: [unknown location] [unknown:-2066217]
55: [unknown location] g_signal_emit_valist
56: [unknown location] g_signal_emit
57: [unknown location] [unknown:23053245]
58: [unknown location] gtk_widget_hide
59: [unknown location] wxWindow::Show(bool)
60: [unknown location] wxAuiNotebook::DeletePage(unsigned long)
61: [unknown location] wxAuiNotebook::OnTabButton(wxAuiNotebookEvent&)
62: [unknown location] wxAppConsoleBase::CallEventHandler(wxEvtHandler*, wxEventFunctor&, wxEvent&) const
63: [unknown location] wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&)
64: [unknown location] wxEventHashTable::HandleEvent(wxEvent&, wxEvtHandler*)
65: [unknown location] wxEvtHandler::TryHereOnly(wxEvent&)
66: [unknown location] wxEvtHandler::DoTryChain(wxEvent&)
67: [unknown location] wxEvtHandler::ProcessEvent(wxEvent&)
68: [unknown location] wxWindowBase::TryAfter(wxEvent&)
69: [unknown location] wxAuiTabCtrl::OnLeftUp(wxMouseEvent&)
70: [unknown location] wxAppConsoleBase::CallEventHandler(wxEvtHandler*, wxEventFunctor&, wxEvent&) const
71: [unknown location] wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&)
72: [unknown location] wxEventHashTable::HandleEvent(wxEvent&, wxEvtHandler*)
73: [unknown location] wxEvtHandler::TryHereOnly(wxEvent&)
74: [unknown location] wxEvtHandler::ProcessEventLocally(wxEvent&)
75: [unknown location] wxEvtHandler::ProcessEvent(wxEvent&)
76: [unknown location] wxEvtHandler::SafelyProcessEvent(wxEvent&)
77: [unknown location] [unknown:60548573]
78: [unknown location] [unknown:21859717]
79: [unknown location] g_closure_invoke
80: [unknown location] [unknown:-1994691]
81: [unknown location] g_signal_emit_valist
82: [unknown location] g_signal_emit
83: [unknown location] [unknown:22973108]
84: [unknown location] gtk_propagate_event
85: [unknown location] gtk_main_do_event
86: [unknown location] [unknown:662588]
87: [unknown location] g_main_context_dispatch
88: [unknown location] [unknown:-8370712]
89: [unknown location] g_main_loop_run
90: [unknown location] gtk_main
91: [unknown location] wxGUIEventLoop::DoRun()
92: [unknown location] wxEventLoopBase::Run()
93: [unknown location] wxAppConsoleBase::MainLoop()
94: [unknown location] wxEntry(int&, wchar_t**)
95: [unknown location] main
96: [unknown location] __libc_start_main
97: [unknown location] _start
```

Frame 59 (`wxWindow::Show(bool)`) is the `wxAuiNotebook` trying to hide the currently-open page before deleting it.  For some reason, this ultimately triggers a _redraw_ of the `ArchiveEntryList` on that very page, which is doomed to crash because the archive is already closed at this point.

That behavior makes absolutely no sense to me; I can only guess it's because the child tab was switched to as part of being closed, and wx wants to redraw the current tab once the child tab is gone.

The solution was ultimately to keep the archives open until _after_ the tabs have been closed.

Commit message has some further commentary.
