### PR TITLE
Fix assert in BrowserWindow class

### DIFF
--- a/src/BrowserWindow.cpp
+++ b/src/BrowserWindow.cpp
@@ -435,7 +435,7 @@ void BrowserWindow::populateItemTree()
 {
 	// Clear current tree
 	tree_items->DeleteAllItems();
-	tree_items->DeleteColumn(0);
+	tree_items->ClearColumns();
 
 	// Add root item
 	tree_items->AppendColumn("Categories", wxCOL_WIDTH_AUTOSIZE);


### PR DESCRIPTION
Opening of Things Browser no longer triggers this assert within wxWidgets:
src/generic/treelist.cpp(1128): assert "col < GetColumnCount()" failed in DeleteColumn(): Invalid column index
