### PR TITLE
ZDoom language configurations update:

### DIFF
--- a/dist/res/config/languages/decorate.txt
+++ b/dist/res/config/languages/decorate.txt
@@ -14,9 +14,9 @@ decorate : cstyle {
 		Actor, States, Spawn, See, Melee, Missile, Pain, Death, XDeath, Burn, Ice, Disintegrate,
 		Raise, Heal, Crash, Crush, Wound, Greetings, Yes, No, Extreme, Bounce, Floor, Ceiling,
 		Wall, Creature, Loop, Stop, Wait, Fail, Goto, Ready, Deselect, Select, Fire, AltFire,
-		Hold, AltHold, Flash, AltFlash, Reload, Zoom, Pickup, Use, Drop, Bright, Fast, NoDelay,
-		Idle, Active, Inactive, Light, Offset, Action, Native, Const, Enum, Replaces, LightDone,
-		Super, Spray, GenericFreezeDeath, GenericCrush,
+		Hold, AltHold, Flash, AltFlash, Reload, Zoom, Pickup, Use, Drop, Bright, Fast, Slow, NoDelay,
+		CanRaise, Idle, Active, Inactive, Light, Offset, Action, Native, Const, Enum, Replaces,
+		LightDone, Super, Spray, GenericFreezeDeath, GenericCrush,
 
 		// Actor properties
 		

--- a/dist/res/config/languages/zdoom.txt
+++ b/dist/res/config/languages/zdoom.txt
@@ -207,8 +207,8 @@ z_mapinfo {
 		// Skill definitions
 		Skill, ClearSkills, AmmoFactor, DropAmmoFactor, DoubleAmmoFactor, DamageFactor, RespawnTime, RespawnLimit,
 		Aggressiveness, SpawnFilter, ACSReturn, Key, MustConfirm, Name, PlayerClassName, PicName, TextColor, EasyBossBrain,
-		FastMonsters, DisableCheats, AutoUseHealth, ReplaceActor, MonsterHealth, FriendlyHealth, NoPain, DefaultSkill,
-		ArmorFactor, EasyKey,
+		FastMonsters, SlowMonsters, DisableCheats, AutoUseHealth, ReplaceActor, MonsterHealth, FriendlyHealth, NoPain,
+		DefaultSkill, ArmorFactor, EasyKey,
 
 		// GameInfo definitions
 		GameInfo, AddCreditPage, AddInfoPage, AddPlayerClasses, AddQuitMessages, AdvisoryTime, Border, BackpackType,
@@ -219,7 +219,7 @@ z_mapinfo {
 		Player5Start, PickupColor, QuitMessages, MenuFontColor_Title, MenuFontColor_Label, MenuFontColor_Value,
 		MenuFontColor_Action, MenuFontColor_Header, MenuFontColor_Highlight, MenuFontColor_Selection, MenuBackButton,
 		PlayerClasses, PauseSign, GibFactor, CursorPic, SwapMenu, TextScreenX, TextScreenY, DefaultEndSequence, MapArrow,
-		NoRandomPlayerclass, StatScreen_EnteringPatch, StatScreen_FinishedPatch, StatScreen_MapNameFont,
+		NoRandomPlayerclass, StatScreen_EnteringPatch, StatScreen_FinishedPatch, StatScreen_MapNameFont, NightmareFast,
 
 		// Intermission definitions
 		Intermission, Link, Cast, Fader, GotoTitle, Image, Scroller, TextScreen, Wiper, Background, CDMusic, Draw,


### PR DESCRIPTION
- Added CanRaise and Slow actor state keywords/flags.
- Added SlowMonsters skill definitions property, and a missing NightmareFast gameinfo definitions property.
