### PR TITLE
ZDoom language configurations update

### DIFF
--- a/dist/res/config/languages/acs.txt
+++ b/dist/res/config/languages/acs.txt
@@ -238,7 +238,8 @@ acs_z : acs {
 
 		STYLE_None, STYLE_Normal, STYLE_Fuzzy, STYLE_SoulTrans, STYLE_Stencil, 
 		STYLE_OptFuzzy, STYLE_Translucent, STYLE_Add, STYLE_Shaded, 
-		STYLE_TranslucentStencil, STYLE_Shadow, STYLE_Subtract,
+		STYLE_TranslucentStencil, STYLE_Shadow, STYLE_Subtract, STYLE_AddStencil,
+		STYLE_AddShaded,
 
 		LEVELINFO_PAR_TIME, LEVELINFO_CLUSTERNUM, LEVELINFO_LEVELNUM, 
 		LEVELINFO_TOTAL_SECRETS, LEVELINFO_FOUND_SECRETS, LEVELINFO_TOTAL_ITEMS, 
@@ -606,6 +607,8 @@ acs_z : acs {
 		ActivatorTID;
 		AmbientSound = "str sound, int volume";
 		CancelFade;
+		ChangeActorAngle = "int tid, int angle, [bool interpolate]";
+		ChangeActorPitch = "int tid, int pitch, [bool interpolate]";
 		ChangeCeiling = "int tag, str flatname";
 		ChangeFloor = "int tag, str flatname";
 		ChangeLevel = "str mapname, int position, int flags,[ int skill]";
@@ -713,7 +716,7 @@ acs_z : acs {
 		ScriptWait = "int script";
 		SectorDamage = "int tag, int amount, str type, str protection_item, int flags";
 		SectorSound = "str sound, int volume";
-		SetActivator = "int tid[, pointer_selector]";
+		SetActivator = "int tid[, int pointer_selector]";
 		SetActivatorToTarget = "int tid";
 		SetActorAngle = "int tid, int angle";
 		SetActorPitch = "int tid, int pitch";

--- a/dist/res/config/languages/decorate.txt
+++ b/dist/res/config/languages/decorate.txt
@@ -43,8 +43,8 @@ decorate : cstyle {
 		Speed, VSpeed, FastSpeed, FloatSpeed,
 		
 		// Rendering
-		RenderStyle, None, Normal, Fuzzy, OptFuzzy, Translucent, SoulTrans, Stencil, StencilColor, Shaded, 
-		Shadow, Add, Subtract, DefaultAlpha, Alpha, XScale, YScale, Scale, Translation,
+		RenderStyle, None, Normal, Fuzzy, OptFuzzy, Translucent, SoulTrans, Stencil, AddStencil, StencilColor, Shaded, 
+		AddShaded, Shadow, Add, Subtract, DefaultAlpha, Alpha, XScale, YScale, Scale, Translation,
 		BloodColor, BloodType, Decal, FloatBobPhase,
 		
 		// Sounds
@@ -199,7 +199,7 @@ decorate : cstyle {
 		BLOCKF_CREATURES, BLOCKF_EVERYTHING, BLOCKF_FLOATERS, BLOCKF_MONSTERS, BLOCKF_PLAYERS,
 		BLOCKF_PROJECTILES, BLOCKF_RAILING, BLOCKF_USE,
 		CBAF_AIMFACING, CBAF_EXPLICITANGLE, CBAF_NOPITCH, CBAF_NORANDOM, CBAF_NORANDOMPUFFZ,
-		CHAN_AUTO, CHAN_BODY, CHAN_ITEM, CHAN_LISTENERZ, CHAN_MAYBE_LOCAL,
+		CHAN_5, CHAN_6, CHAN_7, CHAN_AUTO, CHAN_BODY, CHAN_ITEM, CHAN_LISTENERZ, CHAN_MAYBE_LOCAL,
 		CHAN_NOPAUSE, CHAN_UI, CHAN_VOICE, CHAN_WEAPON,
 		CHF_DONTMOVE, CHF_FASTCHASE, CHF_NIGHTMAREFAST, CHF_NOPLAYACTIVE, CHF_RESURRECT, CMF_ABSOLUTEANGLE,
 		CLOFF_NOAIM_VERT, CLOFF_NOAIM_HORZ, CLOFF_AIM_VERT_NOOFFSET, CLOFF_FROMBASE, CLOFF_MUL_HEIGHT,
@@ -232,7 +232,7 @@ decorate : cstyle {
 		RTF_AFFECTSOURCE, RTF_NOIMPACTDAMAGE, RTF_NOTMISSILE,
 		SF_NORANDOM, SF_NOUSEAMMO, SF_NOUSEAMMOMISS, SF_RANDOMLIGHTBOTH, SF_RANDOMLIGHTHIT, SF_RANDOMLIGHTMISS,
 		SMF_CURSPEED, SMF_LOOK, SMF_PRECISE,
-		SPF_FORCECLAMP,
+		SPF_FORCECLAMP, SPF_INTERPOLATE,
 		SXF_ABSOLUTEANGLE, SXF_ABSOLUTEMOMENTUM, SXF_ABSOLUTEPOSITION, SXF_ABSOLUTEVELOCITY, SXF_CLIENTSIDE,
 		SXF_NOCHECKPOSITION, SXF_SETMASTER, SXF_TELEFRAG, SXF_TRANSFERAMBUSHFLAG, SXF_TRANSFERPITCH,
 		SXF_TRANSFERPOINTERS, SXF_TRANSFERTRANSLATION, SXF_USEBLOODCOLOR, SXF_CLEARCALLERTID, SXF_MULTIPLYSPEED, 
@@ -429,7 +429,7 @@ decorate : cstyle {
 		A_QueueCorpse;
 		A_DeQueueCorpse;
 		A_Respawn = "[int flags]";
-		A_SetAngle = "[float angle]";
+		A_SetAngle = "[float angle], [int flags]";
 		A_SetArg = "int position, int value";
 		A_SetDamageType = "string damagetype";
 		A_SetPitch = "float pitch, [int flags]";

--- a/dist/res/config/languages/zdoom.txt
+++ b/dist/res/config/languages/zdoom.txt
@@ -220,6 +220,7 @@ z_mapinfo {
 		MenuFontColor_Action, MenuFontColor_Header, MenuFontColor_Highlight, MenuFontColor_Selection, MenuBackButton,
 		PlayerClasses, PauseSign, GibFactor, CursorPic, SwapMenu, TextScreenX, TextScreenY, DefaultEndSequence, MapArrow,
 		NoRandomPlayerclass, StatScreen_EnteringPatch, StatScreen_FinishedPatch, StatScreen_MapNameFont, NightmareFast,
+		DontCrunchCorpses,
 
 		// Intermission definitions
 		Intermission, Link, Cast, Fader, GotoTitle, Image, Scroller, TextScreen, Wiper, Background, CDMusic, Draw,


### PR DESCRIPTION
- ACS:
  - Added STYLE_AddStencil and STYLE_AddShaded constants.
  - Added ChangeActorAngle and ChangeActorPitch functions.
  - A minor fix in SetActivator syntax.
- DECORATE:
  - Added AddStencil and AddShaded render styles.
  - Added CHAN_\* and SPF_INTERPOLATE constants.
  - Added "flags" parameter for A_SetAngle.
- MAPINFO: Added DontCrunchCorpses flag for gameinfo block.
