### PR TITLE
Make 3D mode actually work again.

### DIFF
--- a/src/MapCanvas.cpp
+++ b/src/MapCanvas.cpp
@@ -1966,6 +1966,7 @@ void MapCanvas::update(long frametime)
 void MapCanvas::mouseToCenter()
 {
 	wxRect rect = GetScreenRect();
+	mouse_warp = true;
 	sf::Mouse::setPosition(sf::Vector2i(rect.x + int(rect.width*0.5), rect.y + int(rect.height*0.5)));
 }
 


### PR DESCRIPTION
As described in the commit message:

> It appears it was broken (at least on Linux) because it "captures" the
> mouse, by moving it to the center of the window every frame -- but this
> movement caused a new mouse movement event to fire, so the event queue
> was constantly full, and paint events never got through.
> 
> There was even code to fix this problem, but it only existed on an SFML
> 1.x compat codepath, and was deleted a few months ago.  Apparently it's
> needed with SFML 2.0, too, at least with GTK.  Whoops.

Now, it works on my machine.™  Should fix #207.
