### PR TITLE
[WIP] Basic slope support

### DIFF
--- a/src/MapLine.cpp
+++ b/src/MapLine.cpp
@@ -543,52 +543,49 @@ int MapLine::needsTexture()
 	if (!backSector())
 		return TEX_FRONT_MIDDLE;
 
-	// ZDoom's Plane_Align ensures a slope will hide the lower or upper texture
-	// of one side
-	bool aligned_floor = false;
-	bool aligned_ceiling = false;
-	if (special)
-	{
-		ActionSpecial* as = theGameConfiguration->actionSpecial(special);
-		if (as->getName() == "Plane_Align")
-		{
-			int prop;
-			prop = intProperty("arg0");
-			aligned_floor = (prop == 1 || prop == 2);
-			prop = intProperty("arg1");
-			aligned_ceiling = (prop == 1 || prop == 2);
-		}
-	}
+	// Get sector planes
+	plane_t floor_front = frontSector()->getFloorPlane();
+	plane_t ceiling_front = frontSector()->getCeilingPlane();
+	plane_t floor_back = backSector()->getFloorPlane();
+	plane_t ceiling_back = backSector()->getCeilingPlane();
 
-
-	// Get sector heights
-	int floor_front = frontSector()->getFloorHeight();
-	int ceiling_front = frontSector()->getCeilingHeight();
-	int floor_back = backSector()->getFloorHeight();
-	int ceiling_back = backSector()->getCeilingHeight();
+	float front_height, back_height;
 
 	int tex = 0;
-	if (aligned_floor)
-		;
 
-	// Front lower
-	else if (floor_front < floor_back)
+	// Check the floor
+	front_height = floor_front.height_at(x1(), y1());
+	back_height = floor_back.height_at(x1(), y1());
+
+	if (front_height - back_height > 0.001)
+		tex |= TEX_BACK_LOWER;
+	if (back_height - front_height > 0.001)
 		tex |= TEX_FRONT_LOWER;
 
-	// Back lower
-	else if (floor_front > floor_back)
+	front_height = floor_front.height_at(x2(), y2());
+	back_height = floor_back.height_at(x2(), y2());
+
+	if (front_height - back_height > 0.001)
 		tex |= TEX_BACK_LOWER;
+	if (back_height - front_height > 0.001)
+		tex |= TEX_FRONT_LOWER;
 
-	if (aligned_ceiling)
-		;
+	// Check the ceiling
+	front_height = ceiling_front.height_at(x1(), y1());
+	back_height = ceiling_back.height_at(x1(), y1());
 
-	// Front upper
-	else if (ceiling_front > ceiling_back)
+	if (back_height - front_height > 0.001)
+		tex |= TEX_BACK_UPPER;
+	if (front_height - back_height > 0.001)
 		tex |= TEX_FRONT_UPPER;
 
-	// Back upper
-	else if (ceiling_front < ceiling_back)
+	front_height = ceiling_front.height_at(x2(), y2());
+	back_height = ceiling_back.height_at(x2(), y2());
+
+	if (back_height - front_height > 0.001)
 		tex |= TEX_BACK_UPPER;
+	if (front_height - back_height > 0.001)
+		tex |= TEX_FRONT_UPPER;
 
 	return tex;
 }

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -1171,7 +1171,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Create quad
-		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), ceiling1, floor1);
+		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), line->frontSector()->getCeilingPlane(), line->frontSector()->getFloorPlane());
 		quad.colour = colour1;
 		quad.light = light1;
 		quad.texture = theMapEditor->textureManager().getTexture(line->s1()->getTexMiddle(), mixed);
@@ -1328,7 +1328,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Create quad
-		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), ceiling1, ceiling2);
+		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), line->backSector()->getCeilingPlane(), line->frontSector()->getCeilingPlane());
 		quad.colour = colour1;
 		quad.light = light1;
 		quad.texture = theMapEditor->textureManager().getTexture(line->s1()->getTexUpper(), mixed);
@@ -1470,7 +1470,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Create quad
-		setupQuad(&quad, line->x2(), line->y2(), line->x1(), line->y1(), ceiling2, ceiling1);
+		setupQuad(&quad, line->x2(), line->y2(), line->x1(), line->y1(), line->frontSector()->getCeilingPlane(), line->backSector()->getCeilingPlane());
 		quad.colour = colour2;
 		quad.light = light2;
 		quad.texture = theMapEditor->textureManager().getTexture(line->s2()->getTexUpper(), mixed);

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -816,10 +816,7 @@ void MapRenderer3D::updateSector(unsigned index)
 	floors[index].colour = sector->getColour(1, true);
 	floors[index].light = sector->getLight(1);
 	floors[index].flags = 0;
-	floors[index].plane.a = 0;
-	floors[index].plane.b = 0;
-	floors[index].plane.c = 1;
-	floors[index].plane.d = sector->getFloorHeight();
+	floors[index].plane = sector->getFloorPlane();
 	if (sector->getFloorTex() == theGameConfiguration->skyFlat())
 		floors[index].flags |= SKY;
 
@@ -829,7 +826,7 @@ void MapRenderer3D::updateSector(unsigned index)
 		updateFlatTexCoords(index, true);
 		glBindBuffer(GL_ARRAY_BUFFER, vbo_floors);
 		Polygon2D::setupVBOPointers();
-		sector->getPolygon()->setZ(sector->getFloorPlane());
+		sector->getPolygon()->setZ(floors[index].plane);
 		sector->getPolygon()->updateVBOData();
 	}
 
@@ -839,10 +836,7 @@ void MapRenderer3D::updateSector(unsigned index)
 	ceilings[index].colour = sector->getColour(2, true);
 	ceilings[index].light = sector->getLight(2);
 	ceilings[index].flags = CEIL;
-	ceilings[index].plane.a = 0;
-	ceilings[index].plane.b = 0;
-	ceilings[index].plane.c = 1;
-	ceilings[index].plane.d = sector->getCeilingHeight();
+	ceilings[index].plane = sector->getCeilingPlane();
 	if (sector->getCeilingTex() == theGameConfiguration->skyFlat())
 		ceilings[index].flags |= SKY;
 
@@ -852,7 +846,7 @@ void MapRenderer3D::updateSector(unsigned index)
 		updateFlatTexCoords(index, false);
 		glBindBuffer(GL_ARRAY_BUFFER, vbo_ceilings);
 		Polygon2D::setupVBOPointers();
-		sector->getPolygon()->setZ(sector->getCeilingPlane());
+		sector->getPolygon()->setZ(ceilings[index].plane);
 		sector->getPolygon()->updateVBOData();
 	}
 

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -1328,7 +1328,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Create quad
-		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), line->backSector()->getCeilingPlane(), line->frontSector()->getCeilingPlane());
+		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), line->frontSector()->getCeilingPlane(), line->backSector()->getCeilingPlane());
 		quad.colour = colour1;
 		quad.light = light1;
 		quad.texture = theMapEditor->textureManager().getTexture(line->s1()->getTexUpper(), mixed);
@@ -1470,7 +1470,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Create quad
-		setupQuad(&quad, line->x2(), line->y2(), line->x1(), line->y1(), line->frontSector()->getCeilingPlane(), line->backSector()->getCeilingPlane());
+		setupQuad(&quad, line->x2(), line->y2(), line->x1(), line->y1(), line->backSector()->getCeilingPlane(), line->frontSector()->getCeilingPlane());
 		quad.colour = colour2;
 		quad.light = light2;
 		quad.texture = theMapEditor->textureManager().getTexture(line->s2()->getTexUpper(), mixed);

--- a/src/MapRenderer3D.h
+++ b/src/MapRenderer3D.h
@@ -153,7 +153,11 @@ public:
 	void	renderFlatSelection(vector<selection_3d_t>& selection, float alpha = 1.0f);
 
 	// Walls
-	void	setupQuad(quad_3d_t* quad, double x1, double y1, double x2, double y2, double top, double bottom);
+	void	setupQuad(quad_3d_t* quad, double x1, double y1, double x2, double y2, double top, double bottom)
+	{
+		return setupQuad(quad, x1, y1, x2, y2, plane_t::flat(top), plane_t::flat(bottom));
+	}
+	void	setupQuad(quad_3d_t* quad, double x1, double y1, double x2, double y2, plane_t top, plane_t bottom);
 	void	setupQuadTexCoords(quad_3d_t* quad, int length, double left, double top, bool pegbottom = false, double sx = 1, double sy = 1);
 	void	updateLine(unsigned index);
 	void	renderQuad(quad_3d_t* quad, float alpha = 1.0f);

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -447,6 +447,7 @@ plane_t MapSector::getPlane()
 	// Deal with slopes, in REVERSE order from ZDoom -- it applies slopes to
 	// sectors at startup, so later slopes override older ones, whereas we just
 	// want to use the first we find.
+	plane_t ret;
 
 	// Check for slope alignment things.
 	// TODO there doesn't seem to be a helper anywhere for getting all the
@@ -493,7 +494,9 @@ plane_t MapSector::getPlane()
 			// point finishes it up.
 			fpoint3_t norm = vec1.cross(vec2);
 			double dot = norm.dot(thing->getPoint(0));
-			return plane_t(norm.x, norm.y, norm.z, dot);
+			ret = plane_t(norm.x, norm.y, norm.z, dot);
+			ret.normalize();
+			return ret;
 		}
 	}
 
@@ -580,14 +583,18 @@ plane_t MapSector::getPlane()
 					// Procedure to get a plane from two vectors
 					fpoint3_t norm = vec1.cross(vec2);
 					double dot = norm.dot(pt1);
-					return plane_t(norm.x, norm.y, norm.z, dot);
+					ret = plane_t(norm.x, norm.y, norm.z, dot);
+					ret.normalize();
+					return ret;
 				}
 			}
 		}
 	}
 
 	// Default to a flat plane
-	return plane_t::flat(getPlaneHeight<p>());
+	ret = plane_t::flat(getPlaneHeight<p>());
+	ret.normalize();
+	return ret;
 }
 
 /* MapSector::getLight

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -493,7 +493,7 @@ plane_t MapSector::getPlane()
 			// Cross product gives a normal vector, and dot product with our
 			// point finishes it up.
 			fpoint3_t norm = vec1.cross(vec2);
-			double dot = norm.dot(thing->getPoint(0));
+			double dot = norm.dot(point);
 			ret = plane_t(norm.x, norm.y, norm.z, dot);
 			ret.normalize();
 			return ret;

--- a/src/MapSector.h
+++ b/src/MapSector.h
@@ -33,6 +33,12 @@ struct doom64sector_t
 	uint16_t	flags;
 };
 
+enum PlaneType
+{
+	FLOOR_PLANE,
+	CEILING_PLANE,
+};
+
 class MapSector : public MapObject
 {
 	friend class SLADEMap;
@@ -87,12 +93,18 @@ public:
 	bool				getLines(vector<MapLine*>& list);
 	bool				getVertices(vector<MapVertex*>& list);
 	bool				getVertices(vector<MapObject*>& list);
-	plane_t				getFloorPlane();
-	plane_t				getCeilingPlane();
+	plane_t				getFloorPlane() { return getPlane<FLOOR_PLANE>(); }
+	plane_t				getCeilingPlane() { return getPlane<CEILING_PLANE>(); }
 	uint8_t				getLight(int where = 0);
 	void				changeLight(int amount, int where = 0);
 	rgba_t				getColour(int where = 0, bool fullbright = false);
 	long				geometryUpdatedTime() { return geometry_updated; }
+
+	template<PlaneType p>
+	short getPlaneHeight();
+
+	template<PlaneType p>
+	plane_t getPlane();
 
 	void	connectSide(MapSide* side);
 	void	disconnectSide(MapSide* side);

--- a/src/MapSector.h
+++ b/src/MapSector.h
@@ -4,6 +4,7 @@
 
 #include "MapObject.h"
 #include "Polygon2D.h"
+#include "Structs.h"
 
 class MapSide;
 class MapLine;
@@ -86,6 +87,8 @@ public:
 	bool				getLines(vector<MapLine*>& list);
 	bool				getVertices(vector<MapVertex*>& list);
 	bool				getVertices(vector<MapObject*>& list);
+	plane_t				getFloorPlane();
+	plane_t				getCeilingPlane();
 	uint8_t				getLight(int where = 0);
 	void				changeLight(int amount, int where = 0);
 	rgba_t				getColour(int where = 0, bool fullbright = false);

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -391,6 +391,7 @@ fpoint2_t MathStuff::vectorAngle(double angle_rad)
 
 /* MathStuff::distanceRayPlane
  * Returns the distance along the ray [r_o -> r_v] to [plane]
+ * [plane] MUST be normalized!
  *******************************************************************/
 double MathStuff::distanceRayPlane(fpoint3_t r_o, fpoint3_t r_v, plane_t plane)
 {

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -623,10 +623,21 @@ struct frect_t
 };
 
 
-// plane_t: A 3d plane
+// plane_t: A 3d plane described by ax + by + cz = d
 struct plane_t
 {
 	float a, b, c, d;
+
+	plane_t() : a(0.0), b(0.0), c(0.0), d(0.0) {}
+	plane_t(float a, float b, float c, float d) : a(a), b(b), c(c), d(d) {}
+
+	/** Construct a flat plane (perpendicular to the z axis) at the given height.
+	 */
+	static plane_t flat(float height)
+	{
+		// The equation is just z = height
+		return plane_t(0.0, 0.0, 1.0, height);
+	}
 
 	fpoint3_t normal()
 	{


### PR DESCRIPTION
I like slopes, which has made 3D mode a little less than useful, so I took a crack at this.

It even correctly avoids warning about missing textures in basin-style architecture!

Only understands `Plane_Align` and tilt things at the moment, because those are all I'm using at the moment.  Also has a lot of TODOs.  And could probably stand to compute the floor/ceiling planes _once_ rather than over and over all the time.  And some other things.  But it's a start.

I went off the beaten path a bit and wrote the slope-finding function as a `template<PlaneType>`, where `PlaneType` is just an enum of floor and ceiling.  A couple similarly-templated helpers took care of the details, and I only had to write the code once.  I'm hoping this can cut down on the need to copy/paste to handle both floors and ceilings.

![z8lfksf](https://cloud.githubusercontent.com/assets/94112/5057184/de9cb860-6c64-11e4-8c43-aba2d42c9acf.png)