### PR TITLE
Added advanced file renaming syntax

### DIFF
--- a/src/ArchivePanel.cpp
+++ b/src/ArchivePanel.cpp
@@ -845,6 +845,9 @@ bool ArchivePanel::renameEntry(bool each)
 	// Begin recording undo level
 	undo_manager->beginRecord("Rename Entry");
 
+	/* Define alphabet */
+	const wxString alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
 	// Check any are selected
 	if (each || selection.size() == 1)
 	{
@@ -853,7 +856,7 @@ bool ArchivePanel::renameEntry(bool each)
 		{
 
 			// Prompt for a new name
-			string new_name = wxGetTextFromUser("Enter new entry name: (* = unchanged)", "Rename", selection[a]->getName());
+			string new_name = wxGetTextFromUser("Enter new entry name:", "Rename", selection[a]->getName());
 
 			// Rename entry (if needed)
 			if (!new_name.IsEmpty() && selection[a]->getName() != new_name)
@@ -871,7 +874,7 @@ bool ArchivePanel::renameEntry(bool each)
 		string filter = Misc::massRenameFilter(names);
 
 		// Prompt for a new name
-		string new_name = wxGetTextFromUser("Enter new entry name: (* = unchanged)", "Rename", filter);
+		string new_name = wxGetTextFromUser("Enter new entry name: (* = unchanged, ^ = alphabet letter, ^^ = lower case\n% = alphabet repeat number, & = entry number, %% or && = n-1)", "Rename", filter);
 
 		// Apply mass rename to list of names
 		if (!new_name.IsEmpty())
@@ -893,7 +896,17 @@ bool ArchivePanel::renameEntry(bool each)
 				// Rename the entry (if needed)
 				if (fn.GetName() != names[a])
 				{
-					fn.SetName(names[a]);							// Change name
+					wxString filename = names[a];
+					/* file renaming syntax */
+					int num = a / alphabet.size();
+					int cn = a-(num*alphabet.size());
+					filename.Replace("^^", alphabet.Lower()[cn]);
+					filename.Replace("^", alphabet[cn]);
+					filename.Replace("%%", wxString::FromDouble(num, 0));
+					filename.Replace("%", wxString::FromDouble(num+1, 0));
+					filename.Replace("&&", wxString::FromDouble(a, 0));
+					filename.Replace("&", wxString::FromDouble(a+1, 0));
+					fn.SetName(filename);							// Change name
 					archive->renameEntry(entry, fn.GetFullName());	// Rename in archive
 				}
 			}


### PR DESCRIPTION
This feature is extremely useful for renaming sprites and graphics (especially for me!), because it's " pain_in_ass" to rename each of ~500 and more lumps manually. I spend only 15-20 minutes for renaming 100 of them that's very very VERY annoying.

New syntax:
^ = paste alphabet letter (^^ = use lowercase characters)
% = paste alphabet repeat number  (%% = start from zero)
& = paste entry number (&& = start from zero)

How this works:
![sladetest2](https://cloud.githubusercontent.com/assets/3750982/6212981/997ecb78-b5f3-11e4-9d20-83ddfa81fdd5.png)

![sladetest3](https://cloud.githubusercontent.com/assets/3750982/6212984/ab2adcb8-b5f3-11e4-90eb-e0e07e913126.png)