### PR TITLE
Build slade.pk3 with CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,3 +35,4 @@ OPTION(USE_WEBVIEW_STARTPAGE "Use wxWebView to display the start page" OFF)
 OPTION(USE_SFML_RENDERWINDOW "Use SFML RenderWindow for OpenGL displays" OFF)
 
 add_subdirectory(src)
+add_subdirectory(dist)

--- a/README-unix
+++ b/README-unix
@@ -34,6 +34,19 @@ b) CMake Compilation
 -cd to the 'dist' directory
 -Enter the following commands: 'cmake ..' then 'make'
 
+4) Build slade.pk3
+
+If you build SLADE3 with cmake, the essential slade.pk3 will also be
+built for you. The only requirement is that you have either 7z or zip
+programs in your path. This will also work on MS Windows.
+
+7z is preferred as it's faster at checking if any modifications
+need to be done to existing archive.
+
+If you have neither program, or choose not to use cmake, you can build
+slade.pk3 manually by zipping up contents of dist/res directory.
+
+
 And that should be it. There are some more detailed instructions on the SLADE wiki here: http://slade-editor.wikia.com/wiki/Compilation
 
 If you are having problems I can be contacted via email:

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -1,0 +1,18 @@
+find_program(ZIPTOOL_ZIP_EXECUTABLE zip)
+find_program(ZIPTOOL_7Z_EXECUTABLE 7z "$ENV{ProgramFiles}/7-Zip")
+
+if(ZIPTOOL_7Z_EXECUTABLE)
+	set(ZIP_COMMAND "${ZIPTOOL_7Z_EXECUTABLE}" u -tzip -r "${CMAKE_BINARY_DIR}/slade.pk3" .)
+elseif(ZIPTOOL_ZIP_EXECUTABLE)
+	set(ZIP_COMMAND "${ZIPTOOL_ZIP_EXECUTABLE}" -r "${CMAKE_BINARY_DIR}/slade.pk3" .)
+else()
+	message(STATUS "no zip executable, slade.pk3 won't build")
+endif()
+
+if(ZIP_COMMAND)
+	message(STATUS "run `pk3` target to build slade.pk3")
+	add_custom_target(pk3 ALL
+		COMMAND ${ZIP_COMMAND}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/res
+		VERBATIM)
+endif()


### PR DESCRIPTION
If either 7z or zip programs are in path
you can now build slade.pk3 with 'pk3' target.