### PR TITLE
Fix for an architecture merging oversight

### DIFF
--- a/src/Main.h
+++ b/src/Main.h
@@ -114,3 +114,11 @@ enum MapTypes
 	MAP_UDMF,
 	MAP_UNKNOWN,	// Needed for maps in zip archives
 };
+
+const string MAP_TYPE_NAMES[] = {
+	"Doom",
+	"Hexen",
+	"Doom64",
+	"UDMF",
+	"Unknown",
+};

--- a/src/MapChecks.cpp
+++ b/src/MapChecks.cpp
@@ -395,11 +395,11 @@ public:
 			MapVertex* nv = map->createVertex(intersections[index].intersect_point.x, intersections[index].intersect_point.y, -1);
 
 			// Split first line
-			map->splitLine(line1->getIndex(), nv->getIndex());
+			map->splitLine(line1, nv);
 			MapLine* nl1 = map->getLine(map->nLines() - 1);
 
 			// Split second line
-			map->splitLine(line2->getIndex(), nv->getIndex());
+			map->splitLine(line2, nv);
 			MapLine* nl2 = map->getLine(map->nLines() - 1);
 
 			// Remove intersection

--- a/src/MapEditor.cpp
+++ b/src/MapEditor.cpp
@@ -1837,7 +1837,7 @@ void MapEditor::mergeLines(long move_time, vector<fpoint2_t>& merge_points)
 			MapVertex* split = map.lineCrossVertex(line->x1(), line->y1(), line->x2(), line->y2());
 			if (split)
 			{
-				map.splitLine(a, split->getIndex());
+				map.splitLine(line, split);
 				a = 0;
 			}
 		}
@@ -1888,7 +1888,7 @@ void MapEditor::splitLine(double x, double y, double min_dist)
 	MapVertex* vertex = map.createVertex(closest.x, closest.y);
 
 	// Do line split
-	map.splitLine(lindex, vertex->getIndex());
+	map.splitLine(line, vertex);
 
 	// Finish recording undo level
 	endUndoRecord();

--- a/src/MapEditor.cpp
+++ b/src/MapEditor.cpp
@@ -206,15 +206,19 @@ public:
 	void checkChanges()
 	{
 		SLADEMap* map = UndoRedo::currentMap();
-		MapVertex* lv = map->getVertex(map->nVertices() - 1);
-		MapLine* ll = map->getLine(map->nLines() - 1);
-		MapSide* lsd = map->getSide(map->nSides() - 1);
-		MapSector* ls = map->getSector(map->nSectors() - 1);
-		MapThing* lt = map->getThing(map->nThings() - 1);
 
 		// Check vertices changed
-		if (map->nVertices() == vertices.size() &&
-			(!lv || lv->getId() == vertices.back()))
+		bool vertices_changed = false;
+		if (map->nVertices() != vertices.size())
+			vertices_changed = true;
+		else
+			for (unsigned a = 0; a < map->nVertices(); a++)
+				if (map->getSector(a)->getId() != vertices[a])
+				{
+					vertices_changed = true;
+					break;
+				}
+		if (!vertices_changed)
 		{
 			// No change, clear
 			vertices.clear();
@@ -223,8 +227,17 @@ public:
 		}
 
 		// Check lines changed
-		if (map->nLines() == lines.size() &&
-			(!ll || ll->getId() == lines.back()))
+		bool lines_changed = false;
+		if (map->nLines() != lines.size())
+			lines_changed = true;
+		else
+			for (unsigned a = 0; a < map->nLines(); a++)
+				if (map->getLine(a)->getId() != lines[a])
+				{
+					lines_changed = true;
+					break;
+				}
+		if (!lines_changed)
 		{
 			// No change, clear
 			lines.clear();
@@ -233,8 +246,17 @@ public:
 		}
 
 		// Check sides changed
-		if (map->nSides() == sides.size() &&
-			(!lsd || lsd->getId() == sides.back()))
+		bool sides_changed = false;
+		if (map->nSides() != sides.size())
+			sides_changed = true;
+		else
+			for (unsigned a = 0; a < map->nSides(); a++)
+				if (map->getSide(a)->getId() != sides[a])
+				{
+					sides_changed = true;
+					break;
+				}
+		if (!sides_changed)
 		{
 			// No change, clear
 			sides.clear();
@@ -243,8 +265,17 @@ public:
 		}
 
 		// Check sectors changed
-		if (map->nSectors() == sectors.size() &&
-			(!ls || ls->getId() == sectors.back()))
+		bool sectors_changed = false;
+		if (map->nSectors() != sectors.size())
+			sectors_changed = true;
+		else
+			for (unsigned a = 0; a < map->nSectors(); a++)
+				if (map->getSector(a)->getId() != sectors[a])
+				{
+					sectors_changed = true;
+					break;
+				}
+		if (!sectors_changed)
 		{
 			// No change, clear
 			sectors.clear();
@@ -253,8 +284,17 @@ public:
 		}
 
 		// Check things changed
-		if (map->nThings() == things.size() &&
-			(!lt || lt->getId() == things.back()))
+		bool things_changed = false;
+		if (map->nThings() != things.size())
+			things_changed = true;
+		else
+			for (unsigned a = 0; a < map->nThings(); a++)
+				if (map->getThing(a)->getId() != things[a])
+				{
+					things_changed = true;
+					break;
+				}
+		if (!things_changed)
 		{
 			// No change, clear
 			things.clear();

--- a/src/MapEditorConfigDialog.cpp
+++ b/src/MapEditorConfigDialog.cpp
@@ -120,15 +120,21 @@ public:
 		sizer->Add(choice_mapformat, wxGBPosition(1, 1), wxDefaultSpan, wxEXPAND);
 
 		// Add possible map formats to the combo box
-		if (theGameConfiguration->mapFormatSupported(MAP_DOOM, game, port))
-			choice_mapformat->Append("Doom");
-		if (theGameConfiguration->mapFormatSupported(MAP_HEXEN, game, port))
-			choice_mapformat->Append("Hexen");
-		if (theGameConfiguration->mapFormatSupported(MAP_UDMF, game, port))
-			choice_mapformat->Append("UDMF");
-		if (theGameConfiguration->mapFormatSupported(MAP_DOOM64, game, port))
-			choice_mapformat->Append("Doom64");
-		choice_mapformat->SetSelection(0);
+		uint8_t default_format = MAP_UNKNOWN;
+		if (! maps.empty())
+			default_format = maps[0].format;
+		for (uint8_t map_type = 0; map_type < MAP_UNKNOWN; map_type++)
+		{
+			if (theGameConfiguration->mapFormatSupported(map_type, game, port))
+			{
+				choice_mapformat->Append(MAP_TYPE_NAMES[map_type]);
+				if (map_type == default_format)
+					choice_mapformat->SetSelection(choice_mapformat->GetCount() - 1);
+			}
+		}
+		// Default to the "best" supported format, the last one in the list
+		if (choice_mapformat->GetSelection() == wxNOT_FOUND)
+			choice_mapformat->SetSelection(choice_mapformat->GetCount() - 1);
 
 		// Add dialog buttons
 		sizer->Add(CreateButtonSizer(wxOK|wxCANCEL), wxGBPosition(2, 0), wxGBSpan(1, 2), wxEXPAND);
@@ -434,12 +440,12 @@ Archive::mapdesc_t MapEditorConfigDialog::selectedMap()
 
 			// Get selected map format
 			int map_format = MAP_DOOM;
-			if (dlg.getMapFormat() == "Hexen")
-				map_format = MAP_HEXEN;
-			else if (dlg.getMapFormat() == "UDMF")
-				map_format = MAP_UDMF;
-			else if (dlg.getMapFormat() == "Doom64")
-				map_format = MAP_DOOM64;
+			for (uint8_t map_type = 0; map_type < MAP_UNKNOWN; map_type++)
+				if (dlg.getMapFormat() == MAP_TYPE_NAMES[map_type])
+				{
+					map_format = map_type;
+					break;
+				}
 			mdesc.format = map_format;
 
 			return mdesc;
@@ -574,12 +580,12 @@ void MapEditorConfigDialog::onBtnNewMap(wxCommandEvent& e)
 
 		// Get selected map format
 		int map_format = MAP_DOOM;
-		if (dlg.getMapFormat() == "Hexen")
-			map_format = MAP_HEXEN;
-		else if (dlg.getMapFormat() == "UDMF")
-			map_format = MAP_UDMF;
-		else if (dlg.getMapFormat() == "Doom64")
-			map_format = MAP_DOOM64;
+		for (uint8_t map_type = 0; map_type < MAP_UNKNOWN; map_type++)
+			if (dlg.getMapFormat() == MAP_TYPE_NAMES[map_type])
+			{
+				map_format = map_type;
+				break;
+			}
 
 		// Check archive type
 		if (archive->getType() == ARCHIVE_WAD)

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -3968,7 +3968,7 @@ MapVertex* SLADEMap::createVertex(double x, double y, double split_dist)
 			if (lines[a]->distanceTo(x, y) < split_dist)
 			{
 				//wxLogMessage("Vertex at (%1.2f,%1.2f) splits line %d", x, y, a);
-				splitLine(a, nv->index);
+				splitLine(lines[a], nv);
 			}
 		}
 	}
@@ -4224,15 +4224,10 @@ MapVertex* SLADEMap::mergeVerticesPoint(double x, double y)
 /* SLADEMap::splitLine
  * Splits [line] at [vertex]
  *******************************************************************/
-void SLADEMap::splitLine(unsigned line, unsigned vertex)
+void SLADEMap::splitLine(MapLine* l, MapVertex* v)
 {
-	// Check indices
-	if (line >= lines.size() || vertex >= vertices.size())
+	if (!l || !v)
 		return;
-
-	// Get objects
-	MapLine* l = lines[line];
-	MapVertex* v = vertices[vertex];
 
 	// Shorten line
 	MapVertex* v2 = l->vertex2;
@@ -4336,7 +4331,7 @@ void SLADEMap::splitLinesAt(MapVertex* vertex, double split_dist)
 		if (lines[a]->distanceTo(vertex->x, vertex->y) < split_dist)
 		{
 			LOG_MESSAGE(2, "Vertex at (%1.2f,%1.2f) splits line %u", vertex->x, vertex->y, a);
-			splitLine(a, vertex->index);
+			splitLine(lines[a], vertex);
 		}
 	}
 }
@@ -4418,7 +4413,7 @@ void SLADEMap::splitLinesByLine(MapLine* split_line)
 		if (MathStuff::linesIntersect(x1, y1, x2, y2, lines[a]->x1(), lines[a]->y1(), lines[a]->x2(), lines[a]->y2(), ix, iy))
 		{
 			MapVertex* v = createVertex(ix, iy, 0.9);
-			//splitLine(a, v->getIndex());
+			//splitLine(lines[a], v);
 		}
 	}
 }
@@ -4567,9 +4562,9 @@ bool SLADEMap::mergeArch(vector<MapVertex*> vertices)
 				merged_vertices.push_back(nv);
 
 				// Split lines
-				splitLine(line1->getIndex(), nv->getIndex());
+				splitLine(line1, nv);
 				connected_lines.push_back(lines.back());
-				splitLine(line2->getIndex(), nv->getIndex());
+				splitLine(line2, nv);
 				connected_lines.push_back(lines.back());
 
 				LOG_MESSAGE(4, "Lines %u and %u intersect", line1->getIndex(), line2->getIndex());

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -4576,9 +4576,28 @@ bool SLADEMap::mergeArch(vector<MapVertex*> vertices)
 	}
 
 	// Split lines (by vertices)
-	int nl_start = lines.size();
+	const double split_dist = 0.1;
+	// Split existing lines that vertices moved onto
 	for (unsigned a = 0; a < merged_vertices.size(); a++)
-		splitLinesAt(merged_vertices[a], 0.1);
+		splitLinesAt(merged_vertices[a], split_dist);
+
+	// Split lines that moved onto existing vertices
+	unsigned nlines = connected_lines.size();
+	for (unsigned a = 0; a < nlines; a++)
+	{
+		unsigned nvertices = this->vertices.size();
+		for (unsigned b = 0; b < nvertices; b++)
+		{
+			MapVertex* vertex = this->vertices[b];
+
+			// Skip line if it shares the vertex
+			if (connected_lines[a]->v1() == vertex || connected_lines[a]->v2() == vertex)
+				continue;
+
+			if (connected_lines[a]->distanceTo(vertex->x, vertex->y) < split_dist)
+				splitLine(connected_lines[a], vertex);
+		}
+	}
 
 	// Refresh connected lines
 	connected_lines.clear();

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -4614,17 +4614,12 @@ bool SLADEMap::mergeArch(vector<MapVertex*> vertices)
 			if ((line1->vertex1 == line2->vertex1 && line1->vertex2 == line2->vertex2) ||
 				(line1->vertex1 == line2->vertex2 && line1->vertex2 == line2->vertex1))
 			{
-				VECTOR_ADD_UNIQUE(remove_lines, mergeOverlappingLines(line2, line1));
-				//// Prioritise removing 2-sided lines
-				//if (line1->side2 && !line2->side2)
-				//{
-				//	VECTOR_ADD_UNIQUE(remove_lines, line1);
-				//	break;
-				//}
-				//else
-				//{
-				//	VECTOR_ADD_UNIQUE(remove_lines, line2);
-				//}
+				MapLine* remove_line = mergeOverlappingLines(line2, line1);
+				VECTOR_ADD_UNIQUE(remove_lines, remove_line);
+
+				// Don't check against any more lines if we just decided to remove this one
+				if (remove_line == line1)
+					break;
 			}
 		}
 	}

--- a/src/SLADEMap.h
+++ b/src/SLADEMap.h
@@ -248,7 +248,7 @@ public:
 	void		moveVertex(unsigned vertex, double nx, double ny);
 	void		mergeVertices(unsigned vertex1, unsigned vertex2);
 	MapVertex*	mergeVerticesPoint(double x, double y);
-	void		splitLine(unsigned line, unsigned vertex);
+	void		splitLine(MapLine* line, MapVertex* vertex);
 	void		moveThing(unsigned thing, double nx, double ny);
 	void		splitLinesAt(MapVertex* vertex, double split_dist = 0);
 	bool		setLineSector(unsigned line, unsigned sector, bool front = true);

--- a/src/SectorBuilder.cpp
+++ b/src/SectorBuilder.cpp
@@ -100,7 +100,7 @@ bool SectorBuilder::edgeSideCreated(unsigned index)
  * Finds the next adjacent edge to [edge], ie the adjacent edge that
  * creates the smallest angle
  *******************************************************************/
-SectorBuilder::edge_t SectorBuilder::nextEdge(SectorBuilder::edge_t edge)
+SectorBuilder::edge_t SectorBuilder::nextEdge(SectorBuilder::edge_t edge, MapLineSet& visited_lines)
 {
 	// Get relevant vertices
 	MapVertex* vertex = edge.line->v2();		// Vertex to be tested
@@ -120,6 +120,10 @@ SectorBuilder::edge_t SectorBuilder::nextEdge(SectorBuilder::edge_t edge)
 
 		// Ignore original line
 		if (line == edge.line)
+			continue;
+
+		// Ignore already-traversed lines
+		if (visited_lines.count(line))
 			continue;
 
 		// Ignore if zero-length
@@ -152,6 +156,7 @@ SectorBuilder::edge_t SectorBuilder::nextEdge(SectorBuilder::edge_t edge)
 	}
 
 	// Return the next edge found
+	visited_lines[next.line] = true;
 	return next;
 }
 
@@ -171,6 +176,7 @@ bool SectorBuilder::traceOutline(MapLine* line, bool front)
 	edge_t edge(line, front);
 	o_edges.push_back(edge);
 	double edge_sum = 0;
+	MapLineSet visited_lines;
 
 	// Begin tracing
 	vertex_right = edge.line->v1();
@@ -189,7 +195,7 @@ bool SectorBuilder::traceOutline(MapLine* line, bool front)
 			vertex_right = edge.line->v2();
 
 		// Get next edge
-		edge_t edge_next = nextEdge(edge);
+		edge_t edge_next = nextEdge(edge, visited_lines);
 		LOG_MESSAGE(4, "Got next edge line %d", edge_next.line ? edge_next.line->getIndex() : -1);
 
 		// Check if no valid next edge was found

--- a/src/SectorBuilder.h
+++ b/src/SectorBuilder.h
@@ -2,12 +2,16 @@
 #ifndef __SECTOR_BUILDER_H__
 #define __SECTOR_BUILDER_H__
 
+#include <wx/hashmap.h>
+
 // Forward declarations
 class MapLine;
 class MapVertex;
 class MapSector;
 class MapSide;
 class SLADEMap;
+
+WX_DECLARE_HASH_MAP(MapLine*, bool, wxPointerHash, wxPointerEqual, MapLineSet);
 
 class SectorBuilder
 {
@@ -47,7 +51,7 @@ public:
 	bool		edgeIsFront(unsigned index);
 	bool		edgeSideCreated(unsigned index);
 
-	edge_t		nextEdge(edge_t edge);
+	edge_t		nextEdge(edge_t edge, MapLineSet& visited_lines);
 	bool		traceOutline(MapLine* line, bool front = true);
 	int			nearestEdge(double x, double y);
 	bool		pointWithinOutline(double x, double y);

--- a/src/UndoRedo.cpp
+++ b/src/UndoRedo.cpp
@@ -79,7 +79,7 @@ string UndoLevel::getTimeStamp(bool date, bool time)
  *******************************************************************/
 bool UndoLevel::doUndo()
 {
-	LOG_MESSAGE(3, "Performing undo \"%s\" (%d steps)", name, undo_steps.size());
+	LOG_MESSAGE(3, "Performing undo \"%s\" (%lu steps)", name, undo_steps.size());
 	bool ok = true;
 	for (int a = (int)undo_steps.size() - 1; a >= 0; a--)
 	{
@@ -95,7 +95,7 @@ bool UndoLevel::doUndo()
  *******************************************************************/
 bool UndoLevel::doRedo()
 {
-	LOG_MESSAGE(3, "Performing redo \"%s\" (%d steps)", name, undo_steps.size());
+	LOG_MESSAGE(3, "Performing redo \"%s\" (%lu steps)", name, undo_steps.size());
 	bool ok = true;
 	for (unsigned a = 0; a < undo_steps.size(); a++)
 	{


### PR DESCRIPTION
Draw some architecture like this:

    +-------+
    |       |
    |       |
    |   +---+
    |   |
    +---+

Enter lines mode, and drag the bottom wall up and to the right so it _overlaps_ the middle wall, like this:

    +-------+
    \       |
     \      |
      +-+-+-+

Result: when you let go of mouse2, SLADE freezes for several minutes.  Once it's unfrozen, if you try to undo, the result is broken — the middle vertical wall is now two-sided, facing outwards, and _sharing a side_ with the left wall!  This is totally impossible to fix without editing the map manually; if you try to fix the side reference on either line, SLADE thinks that side index is now free for the next side you create.

It turns out I trip over this _a lot_, because I'll forget that a single solid wall is actually composed of two lines, like this:

    +-----------+----------+

And I'll try to move the wall to the left or the right, and accidentally make one piece overlap the other.  Now SLADE is frozen and my map is irreversibly screwed up.

Good news: I fixed it!

----

This was all super gnarly to figure out so I hope you can appreciate this tale of diving down a rabbit hole  :)

The initial problem, the freezing, is addressed by the first commit. For pathological architecture, `traceOutline` would sometimes end up in a loop, doomed to never return to its starting point.  It gives up after ten thousand steps, which is why SLADE _only_ freezes for a few minutes.  I taught it to also never try to follow a line it's already followed once, which eliminates this problem.

Once I'd fixed that, there was another problem: the merge failed spectacularly, producing two lines that overlap and two lines with no sides whatsoever.  Ultimately this wasn't so much a bug as an oversight: `mergeArch` knows to split existing lines when a vertex moves on top of them, but it doesn't check for lines that have moved onto an existing vertex.

After fixing _that_, undoing the merge produced garbage!  And _that_ was because `MapObjectCreateDeleteUS` tries to guesstimate whether any objects were created or deleted by comparing the lengths of lists and their last elements...  but in the test case above, the splitting and merging of lines ends up replacing a line in the middle of the lines list, and the undo system
thought nothing had changed.

Now, at last, this works perfectly.

----

I also snuck in a completely irrelevant UI improvement: the "new map" dialog now defaults to the format of the first map in the wad, or the best format supported by the game otherwise.  After a few dozen trials I realized I was a little sad that SLADE wanted me to make Doom-format maps for ZDoom  :)