### PR TITLE
Fix 64-bit portability issue in Wad2 Archive on non-Windows OSes

### DIFF
--- a/src/Wad2Archive.cpp
+++ b/src/Wad2Archive.cpp
@@ -371,8 +371,8 @@ bool Wad2Archive::isWad2Archive(MemChunk& mc)
 		return false;
 
 	// Get number of lumps and directory offset
-	long num_lumps = 0;
-	long dir_offset = 0;
+	int32_t num_lumps = 0;
+	int32_t dir_offset = 0;
 	mc.seek(4, SEEK_SET);
 	mc.read(&num_lumps, 4);
 	mc.read(&dir_offset, 4);
@@ -414,8 +414,8 @@ bool Wad2Archive::isWad2Archive(string filename)
 		return false;
 
 	// Get number of lumps and directory offset
-	long num_lumps = 0;
-	long dir_offset = 0;
+	int32_t num_lumps = 0;
+	int32_t dir_offset = 0;
 	file.Read(&num_lumps, 4);
 	file.Read(&dir_offset, 4);
 

--- a/src/Wad2Archive.h
+++ b/src/Wad2Archive.h
@@ -7,12 +7,12 @@
 // From http://www.gamers.org/dEngine/quake/spec/quake-spec31.html#CWADF
 struct wad2entry_t
 {
-	long offset;                 // Position of the entry in WAD
-	long dsize;                  // Size of the entry in WAD file
-	long size;                   // Size of the entry in memory
+	int32_t offset;                 // Position of the entry in WAD
+	int32_t dsize;                  // Size of the entry in WAD file
+	int32_t size;                   // Size of the entry in memory
 	char type;                   // type of entry
 	char cmprs;                  // Compression. 0 if none.
-	short dummy;                 // Not used
+	int16_t dummy;                 // Not used
 	char name[16];               // 1 to 16 characters, '\0'-padded
 };
 


### PR DESCRIPTION
Windows is LLP64/IL32P64, most of non-Windows OSes are LP64/I32LP64
https://en.wikipedia.org/wiki/64-bit_computing

Fixes #281