### PR TITLE
List action specials in a more helpful order.

### DIFF
--- a/dist/res/config/ports/include/specials_zdoom.cfg
+++ b/dist/res/config/ports/include/specials_zdoom.cfg
@@ -497,7 +497,18 @@ action_specials
 			arg2 = "Speed";
 			arg3 = "Delay (in tics)";
 			arg4 = "Lift Type";
-			arg5 = "Value";
+			arg4 {
+				name = "Lift Type";
+				type = choice;
+				custom_values {
+					0 = "Raise by value * 8, lower after delay";
+					1 = "Lower to lowest floor, raise after delay";
+					2 = "Lower to nearest floor, raise after delay";
+					3 = "Lower to lowest ceiling, raise after delay";
+					4 = "Perpetual lift between lowest and highest floors";
+				}
+			}
+			arg5 = "Value (for lift type 0)";
 		}
 		special 206
 		{

--- a/dist/res/config/ports/include/specials_zdoom.cfg
+++ b/dist/res/config/ports/include/specials_zdoom.cfg
@@ -5,208 +5,173 @@
 action_specials
 {
 	clearexisting;
-	
-	group "PolyObjects"
-	{
-		special 1
-		{
-			name = "PolyObject Start Line";
-			arg1 = "PolyObject ID";
-			arg2 = "Mirror PolyObject ID";
-			arg3 = "Sound Sequence";
-		}
-		special 2
-		{
-			name = "Polyobj_RotateLeft";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-		}
-		special 3
-		{
-			name = "Polyobj_RotateRight";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-		}
-		special 4
-		{
-			name = "Polyobj_Move";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-			arg4 = "Distance";
-		}
-		special 5
-		{
-			name = "Polyobj_ExplicitLine";
-			arg1 = "PolyObject ID";
-			arg2 = "Rendering Order";
-			arg3 = "Mirror PolyObject ID";
-			arg4 = "Sound Sequence";
-			arg5 = "Line ID";				// Not in UDMF
-		}
-		special 6
-		{
-			name = "Polyobj_MoveTimes8";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-			arg4 = "Eighth of Distance";
-		}
-		special 7
-		{
-			name = "Polyobj_DoorSwing";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-			arg4 = "Close Delay";
-		}
-		special 8
-		{
-			name = "Polyobj_DoorSlide";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-			arg4 = "Distance";
-			arg5 = "Close Delay";
-		}
-		special 59
-		{
-			name = "Polyobj_OR_MoveToSpot";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Spot TID";
-		}
-		special 86
-		{
-			name = "Polyobj_MoveToSpot";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Spot TID";
-		}
-		special 87
-		{
-			name = "Polyobj_Stop";
-			arg1 = "PolyObject ID";
-		}
-		special 88
-		{
-			name = "Polyobj_MoveTo";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "X Position";
-			arg4 = "Y Position";
-		}
-		special 89
-		{
-			name = "Polyobj_OR_MoveTo";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "X Position";
-			arg4 = "Y Position";
-		}
-		special 90
-		{
-			name = "Polyobj_OR_RotateLeft";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-		}
-		special 91
-		{
-			name = "Polyobj_OR_RotateRight";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-		}
-		special 92
-		{
-			name = "Polyobj_OR_Move";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-			arg4 = "Distance";
-		}
-		special 93
-		{
-			name = "Polyobj_OR_MoveTimes8";
-			arg1 = "PolyObject ID";
-			arg2 = "Speed";
-			arg3 = "Byte Angle";
-			arg4 = "Eighth of Distance";
-		}
-	}
 
-	group "Doors"
+	group "Floors"
 	{
-		// Group defaults
 		tagged = sector_or_back;
 
-		special 10
+		special 200
 		{
-			name = "Door_Close";
+			name = "Generic_Floor";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 = "Light Tag";
+			arg3 = "Value";
+			arg4 = "Target Type";
+			arg5 = "Flags";
 		}
-		special 11
+		special 22
 		{
-			name = "Door_Open";
+			name = "Floor_LowerToNearest";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 = "Light Tag";
 		}
-		special 12
+		special 21
 		{
-			name = "Door_Raise";
+			name = "Floor_LowerToLowest";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 = "Delay";
-			arg4 = "Light Tag";
 		}
-		special 13
+		special 241
 		{
-			name = "Door_LockedRaise";
+			name = "Floor_LowerToLowestTxTy";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 = "Delay";
-			arg4 = "Lock";
-			arg5 = "Light Tag";
 		}
-		special 14
+		special 242
 		{
-			name = "Door_Animated";
+			name = "Floor_LowerToHighest";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 = "Delay";
-			arg4 = "Lock";
+			arg3 = "Lip + 128";
+			arg4 = "Always Adjust?", "If 1, the height adjustment is applied even if neighbouring sectors are at the same floor height";
 		}
-		special 202
+		special 20
 		{
-			name = "Generic_Door";
+			name = "Floor_LowerByValue";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 {
-				name = "Door Kind";
-				type = choice;
-				custom_values {
-					0 = "Raise door, close after delay";
-					1 = "Open door";
-					2 = "Close door, open after delay";
-					3 = "Close door";
-				}
-			}
-			arg4 = "Delay";
-			arg5 = "Lock";
+			arg3 = "Value";
 		}
-		special 249
+		special 36
 		{
-			name = "Door_CloseWaitOpen";
+			name = "Floor_LowerByValueTimes8";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 = "Delay";
-			arg4 = "Light Tag";
+			arg3 = "Eighth of Value";
+		}
+		special 66
+		{
+			name = "Floor_LowerInstant";
+			arg1 = "Sector Tag";
+			arg2 = "Unused";
+			arg3 = "Eighth of Value";
+		}
+		special 25
+		{
+			name = "Floor_RaiseToNearest";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
+		special 24
+		{
+			name = "Floor_RaiseToHighest";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
+		special 238
+		{
+			name = "Floor_RaiseToLowestCeiling";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
+		special 23
+		{
+			name = "Floor_RaiseByValue";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Value";
+		}
+		special 35
+		{
+			name = "Floor_RaiseByValueTimes8";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Eighth of Value";
+		}
+		special 239
+		{
+			name = "Floor_RaiseByValueTxTy";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Value";
+		}
+		special 240
+		{
+			name = "Floor_RaiseByTexture";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
+		special 67
+		{
+			name = "Floor_RaiseInstant";
+			arg1 = "Sector Tag";
+			arg2 = "Unused";
+			arg3 = "Eighth of Value";
+		}
+		special 28
+		{
+			name = "Floor_RaiseAndCrush";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Crush Damage";
+			arg4 = "Crush Mode";
+		}
+		special 46
+		{
+			name = "Floor_CrushStop";
+			arg1 = "Sector Tag";
+		}
+		special 37
+		{
+			name = "Floor_MoveToValue";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Value";
+			arg4 = "Negative?";
+		}
+		special 68
+		{
+			name = "Floor_MoveToValueTimes8";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Eighth of Value";
+			arg4 = "Negative?";
+		}
+		special 250
+		{
+			name = "Floor_Donut";
+			arg1 = "Pillar Sector Tag";
+			arg2 = "Pillar Speed";
+			arg3 = "Surrounding Speed";
+		}
+		special 138
+		{
+			name = "Floor_Waggle";
+			arg1 = "Sector Tag";
+			arg2 = "Amplitude";
+			arg3 = "Speed";
+			arg4 = "Phase Offset";
+			arg5 = "Duration (in seconds)";
+		}
+		special 235
+		{
+			name = "Floor_TransferTrigger";
+			arg1 = "Sector Tag";
+		}
+		special 236
+		{
+			name = "Floor_TransferNumeric";
+			arg1 = "Sector Tag";
 		}
 	}
 
@@ -214,14 +179,53 @@ action_specials
 	{
 		tagged = sector_or_back;
 
-		special 38 // [RH] Complement of Floor_Waggle
+		special 201
 		{
-			name = "Ceiling_Waggle";
+			name = "Generic_Ceiling";
 			arg1 = "Sector Tag";
-			arg2 = "Amplitude";
-			arg3 = "Speed";
-			arg4 = "Phase Offset";
-			arg5 = "Duration (in seconds)";
+			arg2 = "Speed";
+			arg3 = "Value";
+			arg4 = "Target Type";
+			arg5 = "Flags";
+		}
+		special 205
+		{
+			name = "Generic_Crusher";
+			arg1 = "Sector Tag";
+			arg2 = "Lowering Speed";
+			arg3 = "Raising Speed";
+			arg4 = "Silent?";
+			arg5 = "Crush Damage";
+		}
+		special 169
+		{
+			name = "Generic_Crusher2";
+			arg1 = "Sector Tag";
+			arg2 = "Lowering Speed";
+			arg3 = "Raising Speed";
+			arg4 {
+				name = "Silent?";
+				type = yesno;
+			}
+			arg5 = "Crush Damage";
+		}
+		special 253
+		{
+			name = "Ceiling_LowerToLowest";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
+		special 254
+		{
+			name = "Ceiling_LowerToFloor";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
+		special 192
+		{
+			name = "Ceiling_LowerToHighestFloor";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
 		}
 		special 40
 		{
@@ -230,6 +234,26 @@ action_specials
 			arg2 = "Speed";
 			arg3 = "Value";
 		}
+		special 199
+		{
+			name = "Ceiling_LowerByValueTimes8";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Eighth of Value";
+		}
+		special 193
+		{
+			name = "Ceiling_LowerInstant";
+			arg1 = "Sector Tag";
+			arg2 = "Unused";
+			arg3 = "Eighth of Value";
+		}
+		special 252
+		{
+			name = "Ceiling_RaiseToNearest";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
 		special 41
 		{
 			name = "Ceiling_RaiseByValue";
@@ -237,34 +261,19 @@ action_specials
 			arg2 = "Speed";
 			arg3 = "Value";
 		}
-		special 42
+		special 198
 		{
-			name = "Ceiling_CrushAndRaise";
+			name = "Ceiling_RaiseByValueTimes8";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 = "Crush Damage";
-			arg4 = "Crush Mode";
+			arg3 = "Eighth of Value";
 		}
-		special 43
+		special 194
 		{
-			name = "Ceiling_LowerAndCrush";
+			name = "Ceiling_RaiseInstant";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Crush Damage";
-			arg4 = "Crush Mode";
-		}
-		special 44
-		{
-			name = "Ceiling_CrushStop";
-			arg1 = "Sector Tag";
-		}
-		special 45
-		{
-			name = "Ceiling_CrushRaiseAndStay";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Crush Damage";
-			arg4 = "Crush Mode";
+			arg2 = "Unused";
+			arg3 = "Eighth of Value";
 		}
 		special 47
 		{
@@ -281,6 +290,23 @@ action_specials
 			arg2 = "Speed";
 			arg3 = "Eighth of Value";
 			arg4 = "Negative?";
+		}
+		special 38 // [RH] Complement of Floor_Waggle
+		{
+			name = "Ceiling_Waggle";
+			arg1 = "Sector Tag";
+			arg2 = "Amplitude";
+			arg3 = "Speed";
+			arg4 = "Phase Offset";
+			arg5 = "Duration (in seconds)";
+		}
+		special 43
+		{
+			name = "Ceiling_LowerAndCrush";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Crush Damage";
+			arg4 = "Crush Mode";
 		}
 		special 97
 		{
@@ -299,64 +325,13 @@ action_specials
 				}
 			}
 		}
-		special 104
+		special 42
 		{
-			name = "Ceiling_CrushAndRaiseSilentDist";
-			arg1 = "Sector Tag";
-			arg2 = "Distance to Floor";
-			arg3 = "Speed";
-			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
-		}
-		special 168
-		{
-			name = "Ceiling_CrushAndRaiseDist";
-			arg1 = "Sector Tag";
-			arg2 = "Distance to Floor";
-			arg3 = "Speed";
-			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
-		}
-		special 169
-		{
-			name = "Generic_Crusher2";
-			arg1 = "Sector Tag";
-			arg2 = "Lowering Speed";
-			arg3 = "Raising Speed";
-			arg4 {
-				name = "Silent?";
-				type = yesno;
-			}
-			arg5 = "Crush Damage";
-		}
-		special 192
-		{
-			name = "Ceiling_LowerToHighestFloor";
+			name = "Ceiling_CrushAndRaise";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-		}
-		special 193
-		{
-			name = "Ceiling_LowerInstant";
-			arg1 = "Sector Tag";
-			arg2 = "Unused";
-			arg3 = "Eighth of Value";
-		}
-		special 194
-		{
-			name = "Ceiling_RaiseInstant";
-			arg1 = "Sector Tag";
-			arg2 = "Unused";
-			arg3 = "Eighth of Value";
-		}
-		special 195
-		{
-			name = "Ceiling_CrushRaiseAndStayA";
-			arg1 = "Sector Tag";
-			arg2 = "Lowering Speed";
-			arg3 = "Raising Speed";
-			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
+			arg3 = "Crush Damage";
+			arg4 = "Crush Mode";
 		}
 		special 196
 		{
@@ -376,55 +351,40 @@ action_specials
 			arg4 = "Crush Damage";
 			arg5 = "Crush Mode";
 		}
-		special 198
+		special 168
 		{
-			name = "Ceiling_RaiseByValueTimes8";
+			name = "Ceiling_CrushAndRaiseDist";
+			arg1 = "Sector Tag";
+			arg2 = "Distance to Floor";
+			arg3 = "Speed";
+			arg4 = "Crush Damage";
+			arg5 = "Crush Mode";
+		}
+		special 104
+		{
+			name = "Ceiling_CrushAndRaiseSilentDist";
+			arg1 = "Sector Tag";
+			arg2 = "Distance to Floor";
+			arg3 = "Speed";
+			arg4 = "Crush Damage";
+			arg5 = "Crush Mode";
+		}
+		special 45
+		{
+			name = "Ceiling_CrushRaiseAndStay";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
-			arg3 = "Eighth of Value";
+			arg3 = "Crush Damage";
+			arg4 = "Crush Mode";
 		}
-		special 199
+		special 195
 		{
-			name = "Ceiling_LowerByValueTimes8";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Eighth of Value";
-		}
-		special 201
-		{
-			name = "Generic_Ceiling";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Value";
-			arg4 = "Target Type";
-			arg5 = "Flags";
-		}
-		special 205
-		{
-			name = "Generic_Crusher";
+			name = "Ceiling_CrushRaiseAndStayA";
 			arg1 = "Sector Tag";
 			arg2 = "Lowering Speed";
 			arg3 = "Raising Speed";
-			arg4 = "Silent?";
-			arg5 = "Crush Damage";
-		}
-		special 252
-		{
-			name = "Ceiling_RaiseToNearest";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 253
-		{
-			name = "Ceiling_LowerToLowest";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 254
-		{
-			name = "Ceiling_LowerToFloor";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg4 = "Crush Damage";
+			arg5 = "Crush Mode";
 		}
 		special 255
 		{
@@ -435,61 +395,89 @@ action_specials
 			arg4 = "Crush Damage";
 			arg5 = "Crush Mode";
 		}
+		special 44
+		{
+			name = "Ceiling_CrushStop";
+			arg1 = "Sector Tag";
+		}
+	}
+
+	group "Doors"
+	{
+		// Group defaults
+		tagged = sector_or_back;
+
+		special 202
+		{
+			name = "Generic_Door";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 {
+				name = "Door Kind";
+				type = choice;
+				custom_values {
+					0 = "Raise door, close after delay";
+					1 = "Open door";
+					2 = "Close door, open after delay";
+					3 = "Close door";
+				}
+			}
+			arg4 = "Delay";
+			arg5 = "Lock";
+		}
+		special 12
+		{
+			name = "Door_Raise";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay";
+			arg4 = "Light Tag";
+		}
+		special 13
+		{
+			name = "Door_LockedRaise";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay";
+			arg4 = "Lock";
+			arg5 = "Light Tag";
+		}
+		special 11
+		{
+			name = "Door_Open";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Light Tag";
+		}
+		special 10
+		{
+			name = "Door_Close";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Light Tag";
+		}
+		special 249
+		{
+			name = "Door_CloseWaitOpen";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay";
+			arg4 = "Light Tag";
+		}
+		special 14
+		{
+			name = "Door_Animated";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay";
+			arg4 = "Lock";
+		}
 	}
 
 	group "Platforms & Lifts"
 	{
 		tagged = sector_or_back;
 
-		special 60
-		{
-			name = "Plat_PerpetualRaise";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Delay (in tics)";
-		}
-		special 61
-		{
-			name = "Plat_Stop";
-			arg1 = "Sector Tag";
-		}
-		special 62
-		{
-			name = "Plat_DownWaitUpStay";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Delay (in tics)";
-		}
-		special 63
-		{
-			name = "Plat_DownByValue";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Delay (in tics)";
-			arg4 = "Eighth of Value";
-		}
-		special 64
-		{
-			name = "Plat_UpWaitDownStay";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Delay (in tics)";
-		}
-		special 65
-		{
-			name = "Plat_UpByValue";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Delay (in tics)";
-			arg4 = "Eighth of Value";
-		}
-		special 172
-		{
-			name = "Plat_UpNearestWaitDownStay";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Delay (in tics)";
-		}
 		special 203
 		{
 			name = "Generic_Lift";
@@ -510,6 +498,13 @@ action_specials
 			}
 			arg5 = "Value (for lift type 0)";
 		}
+		special 62
+		{
+			name = "Plat_DownWaitUpStay";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay (in tics)";
+		}
 		special 206
 		{
 			name = "Plat_DownWaitUpStayLip";
@@ -517,7 +512,64 @@ action_specials
 			arg2 = "Speed";
 			arg3 = "Delay (in tics)";
 			arg4 = "Lip";
-			arg5 = "Sound Type";
+			arg5 {
+				name = "Sound type";
+				type = choice;
+				custom_values {
+					0 = "Use platform sound";
+					1 = "Use moving floor sound";
+				}
+			}
+		}
+		special 63
+		{
+			name = "Plat_DownByValue";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay (in tics)";
+			arg4 = "Eighth of Value";
+		}
+		special 64
+		{
+			name = "Plat_UpWaitDownStay";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay (in tics)";
+		}
+		special 172
+		{
+			name = "Plat_UpNearestWaitDownStay";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay (in tics)";
+		}
+		special 65
+		{
+			name = "Plat_UpByValue";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay (in tics)";
+			arg4 = "Eighth of Value";
+		}
+		special 230
+		{
+			name = "Plat_UpByValueStayTx";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Eighth of Value";
+		}
+		special 228
+		{
+			name = "Plat_RaiseAndStayTx0";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
+		special 60
+		{
+			name = "Plat_PerpetualRaise";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Delay (in tics)";
 		}
 		special 207
 		{
@@ -527,281 +579,22 @@ action_specials
 			arg3 = "Delay (in tics)";
 			arg4 = "Lip";
 		}
-		special 228
-		{
-			name = "Plat_RaiseAndStayTx0";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 230
-		{
-			name = "Plat_UpByValueStayTx";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Eighth of Value";
-		}
 		special 231
 		{
 			name = "Plat_ToggleCeiling";
 			arg1 = "Sector Tag";
 		}
+		special 61
+		{
+			name = "Plat_Stop";
+			arg1 = "Sector Tag";
+		}
 	}
 
-	group "Floors"
+	group "Elevators & Pillars"
 	{
 		tagged = sector_or_back;
 
-		special 20
-		{
-			name = "Floor_LowerByValue";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Value";
-		}
-		special 21
-		{
-			name = "Floor_LowerToLowest";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 22
-		{
-			name = "Floor_LowerToNearest";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 23
-		{
-			name = "Floor_RaiseByValue";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Value";
-		}
-		special 24
-		{
-			name = "Floor_RaiseToHighest";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 25
-		{
-			name = "Floor_RaiseToNearest";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 28
-		{
-			name = "Floor_RaiseAndCrush";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Crush Damage";
-			arg4 = "Crush Mode";
-		}
-		special 35
-		{
-			name = "Floor_RaiseByValueTimes8";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Eighth of Value";
-		}
-		special 36
-		{
-			name = "Floor_LowerByValueTimes8";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Eighth of Value";
-		}
-		special 37
-		{
-			name = "Floor_MoveToValue";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Value";
-			arg4 = "Negative?";
-		}
-		special 46
-		{
-			name = "Floor_CrushStop";
-			arg1 = "Sector Tag";
-		}
-		special 66
-		{
-			name = "Floor_LowerInstant";
-			arg1 = "Sector Tag";
-			arg2 = "Unused";
-			arg3 = "Eighth of Value";
-		}
-		special 67
-		{
-			name = "Floor_RaiseInstant";
-			arg1 = "Sector Tag";
-			arg2 = "Unused";
-			arg3 = "Eighth of Value";
-		}
-		special 68
-		{
-			name = "Floor_MoveToValueTimes8";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Eighth of Value";
-			arg4 = "Negative?";
-		}
-		special 138
-		{
-			name = "Floor_Waggle";
-			arg1 = "Sector Tag";
-			arg2 = "Amplitude";
-			arg3 = "Speed";
-			arg4 = "Phase Offset";
-			arg5 = "Duration (in seconds)";
-		}
-		special 200
-		{
-			name = "Generic_Floor";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Value";
-			arg4 = "Target Type";
-			arg5 = "Flags";
-		}
-		special 235
-		{
-			name = "Floor_TransferTrigger";
-			arg1 = "Sector Tag";
-		}
-		special 236
-		{
-			name = "Floor_TransferNumeric";
-			arg1 = "Sector Tag";
-		}
-		special 238
-		{
-			name = "Floor_RaiseToLowestCeiling";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 239
-		{
-			name = "Floor_RaiseByValueTxTy";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Value";
-		}
-		special 240
-		{
-			name = "Floor_RaiseByTexture";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 241
-		{
-			name = "Floor_LowerToLowestTxTy";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-		}
-		special 242
-		{
-			name = "Floor_LowerToHighest";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Lip + 128";
-			arg4 = "Always Adjust?", "If 1, the height adjustment is applied even if neighbouring sectors are at the same floor height";
-		}
-		special 250
-		{
-			name = "Floor_Donut";
-			arg1 = "Pillar Sector Tag";
-			arg2 = "Pillar Speed";
-			arg3 = "Surrounding Speed";
-		}
-	}
-
-	group "Stair Builders"
-	{
-		tagged = sector;
-
-		special 26
-		{
-			name = "Stairs_BuildDown";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Step Height";
-			arg4 = "Step Delay (in tics)";
-			arg5 = "Reset Delay (in tics)";
-		}
-		special 27
-		{
-			name = "Stairs_BuildUp";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Step Height";
-			arg4 = "Step Delay (in tics)";
-			arg5 = "Reset Delay (in tics)";
-		}
-		special 31
-		{
-			name = "Stairs_BuildDownSync";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Step Height";
-			arg4 = "Reset Delay (in tics)";
-		}
-		special 32
-		{
-			name = "Stairs_BuildUpSync";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Step Height";
-			arg4 = "Reset Delay (in tics)";
-		}
-		special 204
-		{
-			name = "Generic_Stairs";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Step Height";
-			arg4 = "Flags";
-			arg5 = "Reset Delay (in tics)";
-		}
-		special 217
-		{
-			name = "Stairs_BuildUpDoom";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Step Height";
-			arg4 = "Step Delay (in tics)";
-			arg5 = "Reset Delay (in tics)";
-		}
-	}
-
-	group "Floors & Ceilings"
-	{
-		tagged = sector_or_back;
-
-		special 29
-		{
-			name = "Pillar_Build";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Floor Height", "0 = Halfway Point";
-		}
-		special 30
-		{
-			name = "Pillar_Open";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Floor Lower Value", "0 = Lowest Adjacent Floor";
-			arg4 = "Ceiling Raise Value", "0 = Highest Adjacent Ceiling";
-		}
-		special 94
-		{
-			name = "Pillar_BuildAndCrush";
-			arg1 = "Sector Tag";
-			arg2 = "Speed";
-			arg3 = "Floor Height", "0 = Halfway Point";
-			arg4 = "Crushing Damage";
-			arg5 = "Crushing Mode";
-		}
 		special 95
 		{
 			name = "FloorAndCeiling_LowerByValue";
@@ -824,6 +617,12 @@ action_specials
 			arg3 = "Ceiling Raise Speed";
 			arg4 = "Boom Bug Emulation", "Use value 1998 to emulate a Boom bug";
 		}
+		special 247
+		{
+			name = "Elevator_LowerToNearest";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+		}
 		special 245
 		{
 			name = "Elevator_RaiseToNearest";
@@ -836,592 +635,30 @@ action_specials
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
 		}
-		special 247
+		special 30
 		{
-			name = "Elevator_LowerToNearest";
+			name = "Pillar_Open";
 			arg1 = "Sector Tag";
 			arg2 = "Speed";
+			arg3 = "Floor Lower Value", "0 = Lowest Adjacent Floor";
+			arg4 = "Ceiling Raise Value", "0 = Highest Adjacent Ceiling";
 		}
-	}
-
-	group "Exits"
-	{
-		special 74
+		special 29
 		{
-			name = "Teleport_NewMap";
-			arg1 = "Map Levelnum";
-			arg2 = "Player Start", "Value of first argument of player start";
-			arg3 = "Keep Facing";
-		}
-		special 75 = "Teleport_EndGame";
-		special 243
-		{
-			name = "Exit_Normal";
-			arg1 = "Player Start", "Value of first argument of player start";
-		}
-		special 244
-		{
-			name = "Exit_Secret";
-			arg1 = "Player Start", "Value of first argument of player start";
-		}
-	}
-
-	group "Teleporters"
-	{
-		tagged = ex_1thing_2sector;
-
-		special 39 // [RH] Needed for Strife
-		{
-			name = "Teleport_ZombieChanger";
-			arg1 = "Dest Thing ID";
-			arg2 = "Dest Sector Tag";
-		}
-		special 70
-		{
-			name = "Teleport";
-			arg1 = "Dest Thing ID";
-			arg2 = "Dest Sector Tag";
-			arg3 = "No Source Fog?";
-		}
-		special 71
-		{
-			name = "Teleport_NoFog";
-			arg1 = "Dest Thing ID";
-			arg2 = "Change Facing?";
-			arg3 = "Dest Sector Tag";
-			tagged = ex_1thing_3sector;
-		}
-		special 76
-		{
-			name = "TeleportOther";
-			arg1 = "Target Thing ID";
-			arg2 = "Dest Thing ID";
-			arg3 = "Use Fog?";
-			tagged = ex_1thing_2thing;
-		}
-		special 77
-		{
-			name = "TeleportGroup";
-			arg1 = "Target Thing ID", "0 Teleports the activator";
-			arg2 = "Source Thing ID", "Must be a teleport destination";
-			arg3 = "Dest Thing ID", "Must be a teleport destination";
-			arg4 = "Move Source?";
-			arg5 = "Use Fog?";
-			tagged = ex_1thing_2thing_3thing;
-		}
-		special 78
-		{
-			name = "TeleportInSector";
+			name = "Pillar_Build";
 			arg1 = "Sector Tag";
-			arg2 = "Source Thing ID", "Must be a teleport destination";
-			arg3 = "Dest Thing ID", "Must be a teleport destination";
-			arg4 = "Use Fog?";
-			arg5 = "Group Thing ID";
-			tagged = ex_1sector_2thing_3thing_5thing;
+			arg2 = "Speed";
+			arg3 = "Floor Height", "0 = Halfway Point";
 		}
-		special 154
+		special 94
 		{
-			name = "Teleport_NoStop";
-			arg1 = "Thing Tag";
-			arg2 = "Sector Tag";
-			arg3 = "No Fog?";
-		}
-		special 215
-		{
-			name = "Teleport_Line";
-			arg1 = "This ID", "Line ID of the marked line (in UDMF, use line ID property instead!)";
-			arg2 = "Destination ID", "Line ID of the destination line";
-			arg3 = "Flip 180?";
-			tagged = ex_1lineid_2line;
-		}
-	}
-
-	group "Lighting"
-	{
-		tagged = sector;
-	
-		special 109
-		{
-			name = "Light_ForceLightning";
-			arg1 {
-				name = "Mode";
-				type = choice;
-				custom_values {
-					0 = "immediate flash and set lightning mode";
-					1 = "single flash without setting lightning mode";
-					2 = "unset lightning mode";
-				}
-			}
-			tagged = no;
-		}
-		special 110
-		{
-			name = "Light_RaiseByValue";
+			name = "Pillar_BuildAndCrush";
 			arg1 = "Sector Tag";
-			arg2 = "Value";
+			arg2 = "Speed";
+			arg3 = "Floor Height", "0 = Halfway Point";
+			arg4 = "Crushing Damage";
+			arg5 = "Crushing Mode";
 		}
-		special 111
-		{
-			name = "Light_LowerByValue";
-			arg1 = "Sector Tag";
-			arg2 = "Value";
-		}
-		special 112
-		{
-			name = "Light_ChangeToValue";
-			arg1 = "Sector Tag";
-			arg2 = "Value";
-		}
-		special 113
-		{
-			name = "Light_Fade";
-			arg1 = "Sector Tag";
-			arg2 = "Value";
-			arg3 = "Fade Length", "Number of tics to reach the new value";
-		}
-		special 114
-		{
-			name = "Light_Glow";
-			arg1 = "Sector Tag";
-			arg2 = "Upper Light Level";
-			arg3 = "Lower Light Level";
-			arg4 = "Fade Length", "Number of tics to alternate between both values";
-		}
-		special 115
-		{
-			name = "Light_Flicker";
-			arg1 = "Sector Tag";
-			arg2 = "Upper Light Level";
-			arg3 = "Lower Light Level";
-		}
-		special 116
-		{
-			name = "Light_Strobe";
-			arg1 = "Sector Tag";
-			arg2 = "Upper Light Level";
-			arg3 = "Lower Light Level";
-			arg4 = "Upper Length", "Number of tics to stay at upper level";
-			arg5 = "Lower Length", "Number of tics to stay at lower level";
-		}
-		special 117
-		{
-			name = "Light_Stop";
-			arg1 = "Sector Tag";
-		}
-		special 232
-		{
-			name = "Light_StrobeDoom";
-			arg1 = "Sector Tag";
-			arg2 = "Upper Length", "Number of tics to stay at normal level";
-			arg3 = "Lower Length", "Number of tics to stay at lowest neighboring level";
-		}
-		special 233
-		{
-			name = "Light_MinNeighbor";
-			arg1 = "Sector Tag";
-		}
-		special 234
-		{
-			name = "Light_MaxNeighbor";
-			arg1 = "Sector Tag";
-		}
-	}
-
-	group "Scrollers"
-	{
-		tagged = no;
-		
-		special 52
-		{
-			name = "Scroll_Wall";
-			arg1 = "Line ID", "Affected lines should not be 3D middle textures";
-			arg2 = "X Speed", "Horizontal speed per tic as fixed point value";
-			arg3 = "Y Speed", "Vertical speed per tic as fixed point value";
-			arg4 = "Line Side", "0 for front and 1 for back";
-			arg5 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "upper";
-					2 = "mid";
-					4 = "lower";
-				}
-			}
-			tagged = line;
-		}
-		special 100
-		{
-			name = "Scroll_Texture_Left";
-			arg1 = "Speed";
-			arg2 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "upper";
-					2 = "mid";
-					4 = "lower";
-				}
-			}
-		}
-		special 101
-		{
-			name = "Scroll_Texture_Right";
-			arg1 = "Speed";
-			arg2 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "upper";
-					2 = "mid";
-					4 = "lower";
-				}
-			}
-		}
-		special 102
-		{
-			name = "Scroll_Texture_Up";
-			arg1 = "Speed";
-			arg2 = "Flags", "1 for upper, 2 for mid, 4 for lower";
-		}
-		special 103
-		{
-			name = "Scroll_Texture_Down";
-			arg1 = "Speed";
-			arg2 = "Flags", "1 for upper, 2 for mid, 4 for lower";
-		}
-		special 221
-		{
-			name = "Scroll_Texture_Both";
-			arg1 = "Line ID";
-			arg2 = "Left Speed";
-			arg3 = "Right Speed";
-			arg4 = "Down Speed";
-			arg5 = "Up Speed";
-			tagged = line_negative;
-		}
-		special 222
-		{
-			name = "Scroll_Texture_Model";
-			arg1 = "Line ID";
-			arg2 = "Flags", "1: Displacement, 2: Accelerative";
-			tagged = lineid;
-		}
-		special 223
-		{
-			name = "Scroll_Floor";
-			arg1 = "Sector Tag";
-			arg2 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "Displacement";
-					2 = "Accelerative";
-					4 = "DX/DY from linedef";
-				}
-			}
-			arg3 {
-				name = "Type";
-				type = choice;
-				custom_values {
-					0 = "Scroll texture";
-					1 = "Carry actors";
-					2 = "Scroll and carry";
-				}
-			}
-			arg4 = "X Speed", "128 is no scroll, 0-127 is West, 129-255 is East";
-			arg5 = "Y Speed", "128 is no scroll, 0-127 is South, 129-255 is North";
-			tagged = sector;
-		}
-		special 224
-		{
-			name = "Scroll_Ceiling";
-			arg1 = "Sector Tag";
-			arg2 = "Flags", "1: Displacement, 2: Accelerative, 4: DX/DY from linedef";
-			arg3 = "Unused", "There are no scroll ceiling types, so this value is not used";
-			arg4 = "X Speed", "128 is no scroll, 0-127 is West, 129-255 is East";
-			arg5 = "Y Speed", "128 is no scroll, 0-127 is South, 129-255 is North";
-			tagged = sector;
-		}
-		special 225
-		{
-			name = "Scroll_Texture_Offsets";
-			arg1 = "Flag", "1 for upper, 2 for mid, 4 for lower";
-		}
-	}
-
-	group "Scripting"
-	{
-		special 15 = "Autosave";   // [RH] Save the game *now*
-		special 18
-		{
-			name = "StartConversation";
-			arg1 = "Thing ID", "TID of the talking actor";
-			arg2 = "Face Talker?", "Player turns to face talker if non-null";
-		}
-		special 80
-		{
-			name = "ACS_Execute";
-			arg1 = "Script Number";
-			arg2 = "Map Levelnum", "Use 0 for current map";
-			arg3 = "First Arg", "First argument passed to the script";
-			arg4 = "Second Arg", "Second argument passed to the script";
-			arg5 = "Third Arg", "Third argument passed to the script";
-		}
-		special 81
-		{
-			name = "ACS_Suspend";
-			arg1 = "Script Number";
-			arg2 = "Map Levelnum", "Use 0 for current map";
-		}
-		special 82
-		{
-			name = "ACS_Terminate";
-			arg1 = "Script Number";
-			arg2 = "Map Levelnum", "Use 0 for current map";
-		}
-		special 83
-		{
-			name = "ACS_LockedExecute";
-			arg1 = "Script Number";
-			arg2 = "Map Levelnum", "Use 0 for current map";
-			arg3 = "First Arg", "First argument passed to the script";
-			arg4 = "Second Arg", "Second argument passed to the script";
-			arg5 = "Lock Number", "Lock value as defined in LOCKDEFS";
-		}
-		special 84
-		{
-			name = "ACS_ExecuteWithResult";
-			arg1 = "Script Number";
-			arg2 = "First Arg", "First argument passed to the script";
-			arg3 = "Second Arg", "Second argument passed to the script";
-			arg4 = "Third Arg", "Third argument passed to the script";
-		}
-		special 85
-		{
-			name = "ACS_LockedExecuteDoor";
-			arg1 = "Script Number";
-			arg2 = "Map Levelnum", "Use 0 for current map";
-			arg3 = "First Arg", "First argument passed to the script";
-			arg4 = "Second Arg", "Second argument passed to the script";
-			arg5 = "Lock Number", "Lock value as defined in LOCKDEFS";
-		}
-		special 120  // Earthquake
-		{
-			name = "Radius_Quake";
-			arg1 = "Intensity", "Tremor intensity on a 1--9 scale";
-			arg2 = "Duration", "In tics";
-			arg3 = "Damage Radius", "Radius of damage in 64x64 cells";
-			arg4 = "Tremor Radius", "Radius of tremor in 64x64 cells";
-			arg5 = "Thing ID", "TID of the focus (0 = activator)";
-			tagged = ex_5thing;
-		}
-		special 129
-		{
-			name = "UsePuzzleItem";
-			arg1 = "Puzzle Number", "Value of the the item's PuzzleItem.Number property";
-			arg2 = "Script Number", "Script to run if item successfully used";
-			arg3 = "First Arg", "First argument passed to the script";
-			arg4 = "Second Arg", "Second argument passed to the script";
-			arg5 = "Third Arg", "Third argument passed to the script";
-		}
-		special 158
-		{
-			name = "FS_Execute";
-			arg1 = "Script Number", "FraggleScript script number";
-			arg2 = "Front Side Only?";
-			arg3 = "Lock Number", "Lock value as defined in LOCKDEFS";
-			arg4 = "Remote Message?", "If locked, determines whether unsuccessful use gives the 'open door' or 'activate object' message";
-		}
-		special 173
-		{
-			name = "NoiseAlert";
-			arg1 = "Target TID", "TID of the actor that is to be attacked by alerted monsters (0 = activator)";
-			arg2 = "Emitter TID", "TID of the actor from which the alert emanates (0 = activator)";
-			tagged = ex_1thing_2thing;
-		}
-		special 174
-		{
-			name = "SendToCommunicator";
-			arg1 = "Voc ID", "Number of the VOC lump to play and LOG lump to print";
-			arg2 = "Front Only?", "If non-zero, only activate on front side of the line";
-			arg3 = "Identity?", "If non-zero, also print the name of who sent the message";
-			arg4 = "No Log Message?", "If non-zero, the message will not be placed in the objectives popup";
-		}
-		special 179
-		{
-			name = "ChangeSkill";
-			arg1 = "Skill Number", "Number of the new skill (standard go from 0 for easiest to 5 for hardest)";
-		}
-		special 191
-		{
-			name = "SetPlayerProperty";
-			arg1 = "All Players?", "0 = only activator, 1 = all players";
-			arg2 = "Set?", "0 = turn property off, 1 = turn it on";
-			arg3 = "Property", "0 = frozen, 1 = no target, 2 = instant switch, 3 = fly, 4 = totally frozen, 5 = invulnerable, 16 = immortal";
-		}
-		special 226
-		{
-			name = "ACS_ExecuteAlways";
-			arg1 = "Script Number";
-			arg2 = "Map Levelnum", "Use 0 for current map";
-			arg3 = "First Arg", "First argument passed to the script";
-			arg4 = "Second Arg", "Second argument passed to the script";
-			arg5 = "Third Arg", "Third argument passed to the script";
-		}
-		special 237
-		{
-			name = "ChangeCamera";
-			arg1 = "Thing ID", "TID of the camera object";
-			arg2 = "All Players?", "0 = only activator, 1 = all players";
-			arg3 = "Move Reverts?", "Set to 1 if movement should cancel the special";
-			tagged = thing;
-		}
-	}
-
-	group "Renderer"
-	{
-		special 9 = "Line_Horizon";   // [RH] draw one-sided wall at horizon
-		special 16
-		{
-			name = "Transfer_WallLight";
-			arg1 = "Line ID";
-			arg2 = "Flags", "1: Transfer to front side, 2: Transfer to back side, 4: Absolute light transfer (ignore fake contrast)";
-			tagged = line;
-		}
-		special 50
-		{
-			name = "ExtraFloor_LightOnly";
-			arg1 = "Sector Tag";
-			arg2 {
-				name = "Light Type";
-				type = choice;
-				custom_values {
-					0 = "Control sector ceiling to top of other type 0 EF_LO";
-					1 = "Tagged ceiling to control sector floor";
-					2 = "Control sector ceiling to top of other EF_LO (any type)";
-				}
-			}
-			tagged = sector;
-		}
-		/*special 53
-		{
-			// This special can only be used in ACS
-			name = "Line_SetTextureOffset";
-		}*/
-		/*special 56
-		{
-			// This special can only be used in ACS
-			name = "Line_SetTextureScale";
-		}*/
-		special 57
-		{
-			name = "Sector_SetPortal";
-			arg1 = "Sector Tag", "Tag of the sectors in which the portal is seen. Sectors seen through the portal should not have this tag.";
-			arg2 {
-				name = "Portal Type";
-				type = choice;
-				custom_values {
-					0 = "Normal view";
-					1 = "Transferred view (copy another portal)";
-					2 = "Eternity-style skybox portal";
-				}
-			}
-			arg3 {
-				name = "Plane";
-				type = choice;
-				custom_values {
-					0 = "Floor portal";
-					1 = "Ceiling portal";
-					2 = "Floor & ceiling portal";
-				}
-			}
-			arg4 = "Misc", "Type 0: 1 if line belongs to sector seen, 0 if it belongs to sector viewing; Type 1: sector tag to copy";
-			arg5 = "Alpha", "Translucency value of the portal";
-			tagged = sector;
-		}
-		special 98
-		{
-			name = "Sector_SetTranslucent";
-			arg1 = "Sector Tag", "Tag of sectors containing portals to affect";
-			arg2 = "Plane", "0 = Floor, 1 = ceiling";
-			arg3 = "Alpha", "On a scale of 0--255 from fully transparent to fully opaque";
-			// Additive transparency is not implemented at the moment
-			//arg4 = "Transparency Type", "0 for normal, 1 for additive transparency";
-		}
-		special 157
-		{
-			name = "SetGlobalFogParameter (OpenGL)";
-			arg1 = "Property", "0 = fog density; 1 = outside fog density; 2 = sky fog";
-			arg2 = "Value";
-		}
-		special 159
-		{
-			name = "Sector_SetPlaneReflection (OpenGL)";
-			arg1 = "Sector Tag";
-			arg2 = "Floor Reflection", "On a 0--255 scale (255 is fully reflective)";
-			arg3 = "Ceiling Reflection", "On a 0--255 scale (255 is fully reflective)";
-			tagged = sector;
-		}
-		special 182 = "Line_Mirror";
-		special 183
-		{
-			name = "Line_AlignCeiling";
-			arg1 = "Line ID";
-			arg2 = "Back sector?", "0 is front sector, 1 is back sector";
-			tagged = line;
-		}
-		special 184
-		{
-			name = "Line_AlignFloor";
-			arg1 = "Line ID";
-			arg2 = "Back sector?", "0 is front sector, 1 is back sector";
-			tagged = line;
-		}
-		special 208
-		{
-			name = "TranslucentLine";
-			arg1 = "Line ID", "Lines to affect (0 = this one)";
-			arg2 = "Alpha", "On a scale of 0--255 from fully transparent to fully opaque";
-			arg3 = "Additive?";
-			arg4 = "Extra flags", "Do not use this in a UDMF map";
-			tagged = lineid;
-		}
-		special 209
-		{
-			name = "Transfer_Heights";
-			arg1 = "Sector Tag";
-			arg2 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "Always use transferred heights";
-					2 = "Only draw fake floor";
-					4 = "Improved texture control";
-					8 = "Swimmable";
-					16 = "Invisible fake planes";
-					32 = "Don't transfer light";
-				}
-			}
-			tagged = sector;
-		}
-		special 210
-		{
-			name = "Transfer_FloorLight";
-			arg1 = "Sector Tag";
-			tagged = sector;
-		}
-		special 211
-		{
-			name = "Transfer_CeilingLight";
-			arg1 = "Sector Tag";
-			tagged = sector;
-		}
-	}
-
-	group "Sector"
-	{
-		tagged = sector;
-
 		special 48
 		{
 			name = "Sector_Attach3dMidtex";
@@ -1436,6 +673,104 @@ action_specials
 				}
 			}
 			tagged = ex_1line_2sector;
+		}
+	}
+
+	group "Stair Builders"
+	{
+		tagged = sector;
+
+		special 204
+		{
+			name = "Generic_Stairs";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Step Height";
+			arg4 = "Flags";
+			arg5 = "Reset Delay (in tics)";
+		}
+		special 26
+		{
+			name = "Stairs_BuildDown";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Step Height";
+			arg4 = "Step Delay (in tics)";
+			arg5 = "Reset Delay (in tics)";
+		}
+		special 31
+		{
+			name = "Stairs_BuildDownSync";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Step Height";
+			arg4 = "Reset Delay (in tics)";
+		}
+		special 27
+		{
+			name = "Stairs_BuildUp";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Step Height";
+			arg4 = "Step Delay (in tics)";
+			arg5 = "Reset Delay (in tics)";
+		}
+		special 32
+		{
+			name = "Stairs_BuildUpSync";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Step Height";
+			arg4 = "Reset Delay (in tics)";
+		}
+		special 217
+		{
+			name = "Stairs_BuildUpDoom";
+			arg1 = "Sector Tag";
+			arg2 = "Speed";
+			arg3 = "Step Height";
+			arg4 = "Step Delay (in tics)";
+			arg5 = "Reset Delay (in tics)";
+		}
+	}
+
+	group "Sector"
+	{
+		tagged = sector;
+
+		special 181
+		{
+			name = "Plane_Align";
+			arg1 {
+				name = "Floor";
+				type = choice;
+				custom_values {
+					0 = "don't align";
+					1 = "align front to back";
+					2 = "align back to front";
+				}
+			}
+			arg2 {
+				name = "Ceiling";
+				type = choice;
+				custom_values {
+					0 = "don't align";
+					1 = "align front to back";
+					2 = "align back to front";
+				}
+			}
+			arg3 = "Line ID";
+			tagged = ex_3lineid;
+		}
+		special 118
+		{
+			name = "Plane_Copy";
+			arg1 = "Front Floor Tag";
+			arg2 = "Front Ceiling Tag";
+			arg3 = "Back Floor Tag";
+			arg4 = "Back Ceiling Tag";
+			arg5 = "Share Flags", "1: Copy floor front to back, 2: copy floor back to front, 4: copy ceiling front to back, 8: copy ceiling back to front";
+			tagged = ex_1sector_2sector_3sector_4sector;
 		}
 		special 51
 		{
@@ -1462,6 +797,15 @@ action_specials
 			}
 			tagged = ex_1sector_2sector;
 		}
+		special 190
+		{
+			name = "Static_Init";
+			arg1 = "Sector Tag/Line ID";
+			arg2 = "Property", "0 = gravity, 1 = light or fog color from upper/lower texture, 2 = damage from linedef length, 3 = sector link, 255 = set sky from upper texture";
+			arg3 = "Ceiling/Flip?", "Property 3: use ceiling instead of floor as control surface; Property 255: flip sky texture horizontally";
+			arg4 = "Move Type", "Property 3: 1: floor to surface, 2: ceiling to surface, 4: invert floor movement, 8: invert ceiling movement";
+			tagged = ex_sector_2is3_line;
+		}
 		special 54
 		{
 			name = "Sector_ChangeFlags";
@@ -1487,125 +831,11 @@ action_specials
 				}
 			}
 		}
-		special 58
-		{
-			name = "Sector_CopyScroller";
-			arg1 = "Sector Tag", "Tag of the sector to copy";
-			arg2 = "Flags", "1: Copy ceiling scrolling, 2: copy floor scrolling, 4: copy actor carrying";
-		}
-		special 118
-		{
-			name = "Plane_Copy";
-			arg1 = "Front Floor Tag";
-			arg2 = "Front Ceiling Tag";
-			arg3 = "Back Floor Tag";
-			arg4 = "Back Ceiling Tag";
-			arg5 = "Share Flags", "1: Copy floor front to back, 2: copy floor back to front, 4: copy ceiling front to back, 8: copy ceiling back to front";
-			tagged = ex_1sector_2sector_3sector_4sector;
-		}
 		special 140
 		{
 			name = "Sector_ChangeSound";
 			arg1 = "Sector Tag";
 			arg2 = "Sound Sequence", "Index of sequence in SNDSEQ";
-		}
-		special 160
-		{
-			name = "Sector_Set3DFloor";
-			arg1 = "Sector Tag";
-			arg2 {
-				name = "Type";
-				type = flags;
-				custom_flags {
-					0 = "Vavoom";
-					1 = "Solid";
-					2 = "Swimmable";
-					3 = "Non-solid";
-					8 = "Arg 5 is LineID (don't use in UDMF)";
-					16 = "invert visibility";
-					32 = "invert shootability";
-				}
-			}
-			arg3 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "disable lighting effects";
-					2 = "restrict lighting to inside of floor";
-					4 = "pseudo-fog";
-					8 = "flat floor at ceiling height";
-					16 = "use upper texture";
-					32 = "use lower texture";
-					64 = "use additive translucency";
-				}
-			}
-			arg4 = "Opacity", "On a 0--255 scale from fully transparent to fully opaque";
-			arg5 = "Hi-Tag/Line ID", "Don't use this one in UDMF";
-		}
-		special 161
-		{
-			name = "Sector_SetContents";
-			arg1 {
-				name = "Content Type";
-				type = choice;
-				custom_values {
-					0 = "empty";
-					1 = "water";
-					2 = "lava";
-					3 = "nukage";
-					4 = "slime";
-					5 = "hellslime";
-					6 = "blood";
-					7 = "sludge";
-					8 = "hazard";
-					9 = "Boom water";
-				}
-			}
-			arg2 = "Translucency %", "0 is fully opaque, 100 is invisible";
-			arg3 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "don't block movement";
-					2 = "don't block sight";
-					4 = "don't block shooting";
-					8 = "use additive translucency";
-				}
-			}
-		}
-		/*special 170
-		{
-			// This special can only be used in ACS
-			name = "Sector_SetCeilingScale2";
-		}
-		special 171
-		{
-			// This special can only be used in ACS
-			name = "Sector_SetFloorScale2";
-		}*/
-		special 181
-		{
-			name = "Plane_Align";
-			arg1 {
-				name = "Floor";
-				type = choice;
-				custom_values {
-					0 = "don't align";
-					1 = "align front to back";
-					2 = "align back to front";
-				}
-			}
-			arg2 {
-				name = "Ceiling";
-				type = choice;
-				custom_values {
-					0 = "don't align";
-					1 = "align front to back";
-					2 = "align back to front";
-				}
-			}
-			arg3 = "Line ID";
-			tagged = ex_3lineid;
 		}
 		special 185
 		{
@@ -1613,15 +843,6 @@ action_specials
 			arg1 = "Sector Tag";
 			arg2 = "Floor Angle";
 			arg3 = "Ceiling Angle";
-		}
-		special 186
-		{
-			name = "Sector_SetCeilingPanning";
-			arg1 = "Sector Tag";
-			arg2 = "U Offset";
-			arg3 = "V Offset";
-			arg4 = "U Frac", "One hundredth of this value is added to U offset";
-			arg5 = "V Frac", "One hundredth of this value is added to V offset";
 		}
 		special 187
 		{
@@ -1632,13 +853,13 @@ action_specials
 			arg4 = "U Frac", "One hundredth of this value is added to U offset";
 			arg5 = "V Frac", "One hundredth of this value is added to V offset";
 		}
-		special 188
+		special 186
 		{
-			name = "Sector_SetCeilingScale";
+			name = "Sector_SetCeilingPanning";
 			arg1 = "Sector Tag";
 			arg2 = "U Offset";
-			arg3 = "U Frac", "One hundredth of this value is added to U offset";
-			arg4 = "V Offset";
+			arg3 = "V Offset";
+			arg4 = "U Frac", "One hundredth of this value is added to U offset";
 			arg5 = "V Frac", "One hundredth of this value is added to V offset";
 		}
 		special 189
@@ -1650,14 +871,28 @@ action_specials
 			arg4 = "V Offset";
 			arg5 = "V Frac", "One hundredth of this value is added to V offset";
 		}
-		special 190
+		special 188
 		{
-			name = "Static_Init";
-			arg1 = "Sector Tag/Line ID";
-			arg2 = "Property", "0 = gravity, 1 = light or fog color from upper/lower texture, 2 = damage from linedef length, 3 = sector link, 255 = set sky from upper texture";
-			arg3 = "Ceiling/Flip?", "Property 3: use ceiling instead of floor as control surface; Property 255: flip sky texture horizontally";
-			arg4 = "Move Type", "Property 3: 1: floor to surface, 2: ceiling to surface, 4: invert floor movement, 8: invert ceiling movement";
-			tagged = ex_sector_2is3_line;
+			name = "Sector_SetCeilingScale";
+			arg1 = "Sector Tag";
+			arg2 = "U Offset";
+			arg3 = "U Frac", "One hundredth of this value is added to U offset";
+			arg4 = "V Offset";
+			arg5 = "V Frac", "One hundredth of this value is added to V offset";
+		}
+		special 184
+		{
+			name = "Line_AlignFloor";
+			arg1 = "Line ID";
+			arg2 = "Back sector?", "0 is front sector, 1 is back sector";
+			tagged = line;
+		}
+		special 183
+		{
+			name = "Line_AlignCeiling";
+			arg1 = "Line ID";
+			arg2 = "Back sector?", "0 is front sector, 1 is back sector";
+			tagged = line;
 		}
 		special 212
 		{
@@ -1721,80 +956,214 @@ action_specials
 			arg4 = "Use Line?", "If 1, pusher/puller strength is derived from the length of the linedef itself, instead of previous arg.";
 			tagged = ex_1sector_2thing;
 		}
+		special 161
+		{
+			name = "Sector_SetContents";
+			arg1 {
+				name = "Content Type";
+				type = choice;
+				custom_values {
+					0 = "empty";
+					1 = "water";
+					2 = "lava";
+					3 = "nukage";
+					4 = "slime";
+					5 = "hellslime";
+					6 = "blood";
+					7 = "sludge";
+					8 = "hazard";
+					9 = "Boom water";
+				}
+			}
+			arg2 = "Translucency %", "0 is fully opaque, 100 is invisible";
+			arg3 {
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "don't block movement";
+					2 = "don't block sight";
+					4 = "don't block shooting";
+					8 = "use additive translucency";
+				}
+			}
+		}
+		/*special 170
+		{
+			// This special can only be used in ACS
+			name = "Sector_SetCeilingScale2";
+		}
+		special 171
+		{
+			// This special can only be used in ACS
+			name = "Sector_SetFloorScale2";
+		}*/
+	}
+
+	group "Lighting"
+	{
+		tagged = sector;
+
+		special 109
+		{
+			name = "Light_ForceLightning";
+			arg1 {
+				name = "Mode";
+				type = choice;
+				custom_values {
+					0 = "immediate flash and set lightning mode";
+					1 = "single flash without setting lightning mode";
+					2 = "unset lightning mode";
+				}
+			}
+			tagged = no;
+		}
+		special 233
+		{
+			name = "Light_MinNeighbor";
+			arg1 = "Sector Tag";
+		}
+		special 111
+		{
+			name = "Light_LowerByValue";
+			arg1 = "Sector Tag";
+			arg2 = "Value";
+		}
+		special 234
+		{
+			name = "Light_MaxNeighbor";
+			arg1 = "Sector Tag";
+		}
+		special 110
+		{
+			name = "Light_RaiseByValue";
+			arg1 = "Sector Tag";
+			arg2 = "Value";
+		}
+		special 112
+		{
+			name = "Light_ChangeToValue";
+			arg1 = "Sector Tag";
+			arg2 = "Value";
+		}
+		special 113
+		{
+			name = "Light_Fade";
+			arg1 = "Sector Tag";
+			arg2 = "Value";
+			arg3 = "Fade Length", "Number of tics to reach the new value";
+		}
+		special 114
+		{
+			name = "Light_Glow";
+			arg1 = "Sector Tag";
+			arg2 = "Upper Light Level";
+			arg3 = "Lower Light Level";
+			arg4 = "Fade Length", "Number of tics to alternate between both values";
+		}
+		special 115
+		{
+			name = "Light_Flicker";
+			arg1 = "Sector Tag";
+			arg2 = "Upper Light Level";
+			arg3 = "Lower Light Level";
+		}
+		special 116
+		{
+			name = "Light_Strobe";
+			arg1 = "Sector Tag";
+			arg2 = "Upper Light Level";
+			arg3 = "Lower Light Level";
+			arg4 = "Upper Length", "Number of tics to stay at upper level";
+			arg5 = "Lower Length", "Number of tics to stay at lower level";
+		}
+		special 232
+		{
+			name = "Light_StrobeDoom";
+			arg1 = "Sector Tag";
+			arg2 = "Upper Length", "Number of tics to stay at normal level";
+			arg3 = "Lower Length", "Number of tics to stay at lowest neighboring level";
+		}
+		special 117
+		{
+			name = "Light_Stop";
+			arg1 = "Sector Tag";
+		}
+	}
+
+	group "Teleporters"
+	{
+		tagged = ex_1thing_2sector;
+
+		special 70
+		{
+			name = "Teleport";
+			arg1 = "Dest Thing ID";
+			arg2 = "Dest Sector Tag";
+			arg3 = "No Source Fog?";
+		}
+		special 39 // [RH] Needed for Strife
+		{
+			name = "Teleport_ZombieChanger";
+			arg1 = "Dest Thing ID";
+			arg2 = "Dest Sector Tag";
+		}
+		special 71
+		{
+			name = "Teleport_NoFog";
+			arg1 = "Dest Thing ID";
+			arg2 = "Change Facing?";
+			arg3 = "Dest Sector Tag";
+			tagged = ex_1thing_3sector;
+		}
+		special 76
+		{
+			name = "TeleportOther";
+			arg1 = "Target Thing ID";
+			arg2 = "Dest Thing ID";
+			arg3 = "Use Fog?";
+			tagged = ex_1thing_2thing;
+		}
+		special 77
+		{
+			name = "TeleportGroup";
+			arg1 = "Target Thing ID", "0 Teleports the activator";
+			arg2 = "Source Thing ID", "Must be a teleport destination";
+			arg3 = "Dest Thing ID", "Must be a teleport destination";
+			arg4 = "Move Source?";
+			arg5 = "Use Fog?";
+			tagged = ex_1thing_2thing_3thing;
+		}
+		special 78
+		{
+			name = "TeleportInSector";
+			arg1 = "Sector Tag";
+			arg2 = "Source Thing ID", "Must be a teleport destination";
+			arg3 = "Dest Thing ID", "Must be a teleport destination";
+			arg4 = "Use Fog?";
+			arg5 = "Group Thing ID";
+			tagged = ex_1sector_2thing_3thing_5thing;
+		}
+		special 154
+		{
+			name = "Teleport_NoStop";
+			arg1 = "Thing Tag";
+			arg2 = "Sector Tag";
+			arg3 = "No Fog?";
+		}
+		special 215
+		{
+			name = "Teleport_Line";
+			arg1 = "This ID", "Line ID of the marked line (in UDMF, use line ID property instead!)";
+			arg2 = "Destination ID", "Line ID of the destination line";
+			arg3 = "Flip 180?";
+			tagged = ex_1lineid_2line;
+		}
 	}
 
 	group "Things"
 	{
 		tagged = thing;
-	
-		special 17
-		{
-			name = "Thing_Raise";
-			arg1 = "Thing ID";
-		}
-		special 19
-		{
-			name = "Thing_Stop";
-			arg1 = "Thing ID";
-		}
-		special 72
-		{
-			name = "ThrustThing";
-			arg1 {
-				name = "Angle";
-				desc = "Byte angle: 0 = East, 64 = North, 128 = West, 192 = South";
-				type = angle;
-			}
-			arg2 = "Force", "In map unit per tics";
-			arg3 = "No limit", "Should be set to 1 for forces above 30";
-			arg4 = "Thing ID";
-			tagged = ex_4thing;
-		}
-		special 73
-		{
-			name = "DamageThing";
-			arg1 = "Amount", "0 is a guaranteed kill";
-			arg2 = "Mean of Death", "0 = default, 5 = rocket, 6 = rocket splash, 7 = plasma, 8 = BFG ball, 9 = BFG tracer, 10 = chainsaw, 11 = shotgun, 12 = drowning, 13 = slime, 14 = lava/fire, 15 = crush, 16 = telefrag, 17 = fall, 18 = suicide, 19 = barrel, 20 = exit, 21 = splash damage, 22 = melee, 23 = railgun, 24 = ice, 25 = disintegrate, 26 = poison, 27 = electricity, 1000 = massacre";
-			tagged = no;
-		}
-		special 79
-		{
-			name = "Thing_SetConversation";
-			arg1 = "Thing ID";
-			arg2 = "Conversation ID", "0 = remove all conversation from tagged actors";
-		}
-		special 119
-		{
-			name = "Thing_Damage";
-			arg1 = "Thing ID";
-			arg2 = "Amount";
-			arg3 = "Mean of Death", "0 = default, 5 = rocket, 6 = rocket splash, 7 = plasma, 8 = BFG ball, 9 = BFG tracer, 10 = chainsaw, 11 = shotgun, 12 = drowning, 13 = slime, 14 = lava/fire, 15 = crush, 16 = telefrag, 17 = fall, 18 = suicide, 19 = barrel, 20 = exit, 21 = splash damage, 22 = melee, 23 = railgun, 24 = ice, 25 = disintegrate, 26 = poison, 27 = electricity, 1000 = massacre";
-		}
-		special 125
-		{
-			name = "Thing_Move";
-			arg1 = "Thing ID";
-			arg2 = "Destination TID";
-			arg3 = "No Fog?";
-			tagged = ex_1thing_2thing;
-		}
-		special 127
-		{
-			name = "Thing_SetSpecial";
-			arg1 = "Thing ID";
-			arg2 = "Special";
-			arg3 = "First Special Arg";
-			arg4 = "Second Special Arg";
-			arg5 = "Third Special Arg";
-		}
-		special 128
-		{
-			name = "ThrustThingZ";
-			arg1 = "Thing ID";
-			arg2 = "Force", "Vertical movement in quarter of unit per tic";
-			arg3 = "Down?", "Default is up";
-			arg4 = "Add?", "Default is to ignore existing vertical velocity";
-		}
+
 		special 130
 		{
 			name = "Thing_Activate";
@@ -1805,31 +1174,16 @@ action_specials
 			name = "Thing_Deactivate";
 			arg1 = "Thing ID";
 		}
-		special 132
+		special 248
 		{
-			name = "Thing_Remove";
+			name = "HealThing";
 			arg1 = "Thing ID";
+			arg2 = "Amount";
 		}
-		special 133
+		special 17
 		{
-			name = "Thing_Destroy";
+			name = "Thing_Raise";
 			arg1 = "Thing ID";
-			arg2 = "Extreme?";
-			arg3 = "Sector Tag";
-			tagged = ex_1thing_3sector;
-		}
-		special 134
-		{
-			name = "Thing_Projectile";
-			arg1 = "Thing ID";
-			arg2 = "Type", "Spawn ID of the projectile";
-			arg3 {
-				name = "Angle";
-				desc = "Byte angle: 0 = East, 64 = North, 128 = West, 192 = South";
-				type = angle;
-			}
-			arg4 = "H Speed", "Horizontal speed of the projectile in units per 8 tics";
-			arg5 = "V Speed", "Vertical speed of the projectile in units per 8 tics (up is positive)";
 		}
 		special 135
 		{
@@ -1838,15 +1192,6 @@ action_specials
 			arg2 = "Type", "Spawn ID of the projectile";
 			arg3 = "Angle", "Byte angle: 0 = East, 64 = North, 128 = West, 192 = South";
 			arg4 = "New TID", "TID to give spawned thing";
-		}
-		special 136
-		{
-			name = "Thing_ProjectileGravity";
-			arg1 = "Thing ID";
-			arg2 = "Type", "Spawn ID of the projectile";
-			arg3 = "Angle", "Byte angle: 0 = East, 64 = North, 128 = West, 192 = South";
-			arg4 = "H Speed", "Horizontal speed of the projectile in units per 8 tics";
-			arg5 = "V Speed", "Vertical speed of the projectile in units per 8 tics (up is positive)";
 		}
 		special 137
 		{
@@ -1864,6 +1209,38 @@ action_specials
 			arg3 = "No Fog?";
 			arg4 = "New TID", "TID to give spawned thing";
 		}
+		special 134
+		{
+			name = "Thing_Projectile";
+			arg1 = "Thing ID";
+			arg2 = "Type", "Spawn ID of the projectile";
+			arg3 {
+				name = "Angle";
+				desc = "Byte angle: 0 = East, 64 = North, 128 = West, 192 = South";
+				type = angle;
+			}
+			arg4 = "H Speed", "Horizontal speed of the projectile in units per 8 tics";
+			arg5 = "V Speed", "Vertical speed of the projectile in units per 8 tics (up is positive)";
+		}
+		special 136
+		{
+			name = "Thing_ProjectileGravity";
+			arg1 = "Thing ID";
+			arg2 = "Type", "Spawn ID of the projectile";
+			arg3 = "Angle", "Byte angle: 0 = East, 64 = North, 128 = West, 192 = South";
+			arg4 = "H Speed", "Horizontal speed of the projectile in units per 8 tics";
+			arg5 = "V Speed", "Vertical speed of the projectile in units per 8 tics (up is positive)";
+		}
+		special 178
+		{
+			name = "Thing_ProjectileAimed";
+			arg1 = "Thing ID";
+			arg2 = "Type", "Spawn ID of the projectile";
+			arg3 = "Speed", "Speed of the projectile in units per 8 tics";
+			arg4 = "Target TID";
+			arg5 = "New TID", "TID to give spawned thing";
+			tagged = ex_1thing_4thing;
+		}
 		special 175
 		{
 			name = "Thing_ProjectileIntercept";
@@ -1873,6 +1250,82 @@ action_specials
 			arg4 = "Target TID";
 			arg5 = "New TID", "TID to give spawned thing";
 			tagged = ex_1thing_4thing;
+		}
+		special 73
+		{
+			name = "DamageThing";
+			arg1 = "Amount", "0 is a guaranteed kill";
+			arg2 = "Mean of Death", "0 = default, 5 = rocket, 6 = rocket splash, 7 = plasma, 8 = BFG ball, 9 = BFG tracer, 10 = chainsaw, 11 = shotgun, 12 = drowning, 13 = slime, 14 = lava/fire, 15 = crush, 16 = telefrag, 17 = fall, 18 = suicide, 19 = barrel, 20 = exit, 21 = splash damage, 22 = melee, 23 = railgun, 24 = ice, 25 = disintegrate, 26 = poison, 27 = electricity, 1000 = massacre";
+			tagged = no;
+		}
+		special 119
+		{
+			name = "Thing_Damage";
+			arg1 = "Thing ID";
+			arg2 = "Amount";
+			arg3 = "Mean of Death", "0 = default, 5 = rocket, 6 = rocket splash, 7 = plasma, 8 = BFG ball, 9 = BFG tracer, 10 = chainsaw, 11 = shotgun, 12 = drowning, 13 = slime, 14 = lava/fire, 15 = crush, 16 = telefrag, 17 = fall, 18 = suicide, 19 = barrel, 20 = exit, 21 = splash damage, 22 = melee, 23 = railgun, 24 = ice, 25 = disintegrate, 26 = poison, 27 = electricity, 1000 = massacre";
+		}
+		special 133
+		{
+			name = "Thing_Destroy";
+			arg1 = "Thing ID";
+			arg2 = "Extreme?";
+			arg3 = "Sector Tag";
+			tagged = ex_1thing_3sector;
+		}
+		special 132
+		{
+			name = "Thing_Remove";
+			arg1 = "Thing ID";
+		}
+		special 125
+		{
+			name = "Thing_Move";
+			arg1 = "Thing ID";
+			arg2 = "Destination TID";
+			arg3 = "No Fog?";
+			tagged = ex_1thing_2thing;
+		}
+		special 72
+		{
+			name = "ThrustThing";
+			arg1 {
+				name = "Angle";
+				desc = "Byte angle: 0 = East, 64 = North, 128 = West, 192 = South";
+				type = angle;
+			}
+			arg2 = "Force", "In map unit per tics";
+			arg3 = "No limit", "Should be set to 1 for forces above 30";
+			arg4 = "Thing ID";
+			tagged = ex_4thing;
+		}
+		special 128
+		{
+			name = "ThrustThingZ";
+			arg1 = "Thing ID";
+			arg2 = "Force", "Vertical movement in quarter of unit per tic";
+			arg3 = "Down?", "Default is up";
+			arg4 = "Add?", "Default is to ignore existing vertical velocity";
+		}
+		special 19
+		{
+			name = "Thing_Stop";
+			arg1 = "Thing ID";
+		}
+		special 79
+		{
+			name = "Thing_SetConversation";
+			arg1 = "Thing ID";
+			arg2 = "Conversation ID", "0 = remove all conversation from tagged actors";
+		}
+		special 127
+		{
+			name = "Thing_SetSpecial";
+			arg1 = "Thing ID";
+			arg2 = "Special";
+			arg3 = "First Special Arg";
+			arg4 = "Second Special Arg";
+			arg5 = "Third Special Arg";
 		}
 		special 176
 		{
@@ -1886,16 +1339,6 @@ action_specials
 			arg1 = "Hater TID";
 			arg2 = "Hated TID";
 			arg3 = "Hate Type", "0 = hate once, 1 = retaliate against players, 2 = also hunt enemies, 3 = also hunt players, 4 = also hunt monsters, 5 = ignore player attacks, 6 = ignore attacks but hunt enemies";
-		}
-		special 178
-		{
-			name = "Thing_ProjectileAimed";
-			arg1 = "Thing ID";
-			arg2 = "Type", "Spawn ID of the projectile";
-			arg3 = "Speed", "Speed of the projectile in units per 8 tics";
-			arg4 = "Target TID";
-			arg5 = "New TID", "TID to give spawned thing";
-			tagged = ex_1thing_4thing;
 		}
 		special 180
 		{
@@ -1912,18 +1355,31 @@ action_specials
 			arg4 = "Don't Chase Target?", "If 1, the monster will attack enemies on its way but still go towards the goal instead of any other target";
 			tagged = ex_1thing_2thing;
 		}
-		special 248
-		{
-			name = "HealThing";
-			arg1 = "Thing ID";
-			arg2 = "Amount";
-		}
 	}
 
 	group "Lines"
 	{
 		tagged = line;
-		
+
+#ifdef MAP_HEXEN	// Disable this special in UDMF mode
+		special 121
+		{
+			name = "Line_SetIdentification";
+			arg1 = "Line ID";
+			arg2 = "Extra Flags", "1: zone boundary, 2: railing, 4: block floaters, 8: clip midtextures, 16: wrap midtextures, 32: 3D middle texture, 64: check switch height";
+			arg3 = "Don't Use";
+			arg4 = "Don't Use";
+			arg5 = "Line ID high";
+			tagged = lineid_hi5;
+		}
+#endif
+		special 55
+		{
+			name = "Line_SetBlocking";
+			arg1 = "Line ID";
+			arg2 = "Set Flags", "1: Creatures, 2: Monsters, 4: Players, 8: Floaters, 16: Projectiles, 32: Everything, 64: Railing, 128: Use, 256: Sight";
+			arg3 = "Clear Flags", "1: Creatures, 2: Monsters, 4: Players, 8: Floaters, 16: Projectiles, 32: Everything, 64: Railing, 128: Use, 256: Sight";
+		}
 		special 33 = "ForceField"; // [RH] Strife's forcefield special (148)
 		special 34    // [RH] Remove Strife's forcefield from tagged sectors
 		{
@@ -1937,25 +1393,576 @@ action_specials
 			arg1 = "Don't Spawn Junk?", "Set to 1 to avoid spawning seven 'glass junk' actors";
 			tagged = no;
 		}
-		special 55
+	}
+
+	group "Scrollers"
+	{
+		tagged = no;
+
+		special 102
 		{
-			name = "Line_SetBlocking";
-			arg1 = "Line ID";
-			arg2 = "Set Flags", "1: Creatures, 2: Monsters, 4: Players, 8: Floaters, 16: Projectiles, 32: Everything, 64: Railing, 128: Use, 256: Sight";
-			arg3 = "Clear Flags", "1: Creatures, 2: Monsters, 4: Players, 8: Floaters, 16: Projectiles, 32: Everything, 64: Railing, 128: Use, 256: Sight";
+			name = "Scroll_Texture_Up";
+			arg1 = "Speed";
+			arg2 = "Flags", "1 for upper, 2 for mid, 4 for lower";
 		}
-#ifdef MAP_HEXEN	// Disable this special in UDMF mode
-		special 121
+		special 103
 		{
-			name = "Line_SetIdentification";
-			arg1 = "Line ID";
-			arg2 = "Extra Flags", "1: zone boundary, 2: railing, 4: block floaters, 8: clip midtextures, 16: wrap midtextures, 32: 3D middle texture, 64: check switch height";
-			arg3 = "Don't Use";
-			arg4 = "Don't Use";
-			arg5 = "Line ID high";
-			tagged = lineid_hi5;
+			name = "Scroll_Texture_Down";
+			arg1 = "Speed";
+			arg2 = "Flags", "1 for upper, 2 for mid, 4 for lower";
 		}
-#endif
+		special 100
+		{
+			name = "Scroll_Texture_Left";
+			arg1 = "Speed";
+			arg2 {
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "upper";
+					2 = "mid";
+					4 = "lower";
+				}
+			}
+		}
+		special 101
+		{
+			name = "Scroll_Texture_Right";
+			arg1 = "Speed";
+			arg2 {
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "upper";
+					2 = "mid";
+					4 = "lower";
+				}
+			}
+		}
+		special 221
+		{
+			name = "Scroll_Texture_Both";
+			arg1 = "Line ID";
+			arg2 = "Left Speed";
+			arg3 = "Right Speed";
+			arg4 = "Down Speed";
+			arg5 = "Up Speed";
+			tagged = line_negative;
+		}
+		special 52
+		{
+			name = "Scroll_Wall";
+			arg1 = "Line ID", "Affected lines should not be 3D middle textures";
+			arg2 = "X Speed", "Horizontal speed per tic as fixed point value";
+			arg3 = "Y Speed", "Vertical speed per tic as fixed point value";
+			arg4 = "Line Side", "0 for front and 1 for back";
+			arg5 {
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "upper";
+					2 = "mid";
+					4 = "lower";
+				}
+			}
+			tagged = line;
+		}
+		special 225
+		{
+			name = "Scroll_Texture_Offsets";
+			arg1 = "Flag", "1 for upper, 2 for mid, 4 for lower";
+		}
+		special 222
+		{
+			name = "Scroll_Texture_Model";
+			arg1 = "Line ID";
+			arg2 = "Flags", "1: Displacement, 2: Accelerative";
+			tagged = lineid;
+		}
+		special 223
+		{
+			name = "Scroll_Floor";
+			arg1 = "Sector Tag";
+			arg2 {
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "Displacement";
+					2 = "Accelerative";
+					4 = "DX/DY from linedef";
+				}
+			}
+			arg3 {
+				name = "Type";
+				type = choice;
+				custom_values {
+					0 = "Scroll texture";
+					1 = "Carry actors";
+					2 = "Scroll and carry";
+				}
+			}
+			arg4 = "X Speed", "128 is no scroll, 0-127 is West, 129-255 is East";
+			arg5 = "Y Speed", "128 is no scroll, 0-127 is South, 129-255 is North";
+			tagged = sector;
+		}
+		special 224
+		{
+			name = "Scroll_Ceiling";
+			arg1 = "Sector Tag";
+			arg2 = "Flags", "1: Displacement, 2: Accelerative, 4: DX/DY from linedef";
+			arg3 = "Unused", "There are no scroll ceiling types, so this value is not used";
+			arg4 = "X Speed", "128 is no scroll, 0-127 is West, 129-255 is East";
+			arg5 = "Y Speed", "128 is no scroll, 0-127 is South, 129-255 is North";
+			tagged = sector;
+		}
+		special 58
+		{
+			name = "Sector_CopyScroller";
+			arg1 = "Sector Tag", "Tag of the sector to copy";
+			arg2 = "Flags", "1: Copy ceiling scrolling, 2: copy floor scrolling, 4: copy actor carrying";
+		}
+	}
+
+	group "PolyObjects"
+	{
+		special 1
+		{
+			name = "PolyObject Start Line";
+			arg1 = "PolyObject ID";
+			arg2 = "Mirror PolyObject ID";
+			arg3 = "Sound Sequence";
+		}
+		special 5
+		{
+			name = "Polyobj_ExplicitLine";
+			arg1 = "PolyObject ID";
+			arg2 = "Rendering Order";
+			arg3 = "Mirror PolyObject ID";
+			arg4 = "Sound Sequence";
+			arg5 = "Line ID";				// Not in UDMF
+		}
+		special 2
+		{
+			name = "Polyobj_RotateLeft";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+		}
+		special 90
+		{
+			name = "Polyobj_OR_RotateLeft";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+		}
+		special 3
+		{
+			name = "Polyobj_RotateRight";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+		}
+		special 91
+		{
+			name = "Polyobj_OR_RotateRight";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+		}
+		special 4
+		{
+			name = "Polyobj_Move";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+			arg4 = "Distance";
+		}
+		special 92
+		{
+			name = "Polyobj_OR_Move";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+			arg4 = "Distance";
+		}
+		special 6
+		{
+			name = "Polyobj_MoveTimes8";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+			arg4 = "Eighth of Distance";
+		}
+		special 93
+		{
+			name = "Polyobj_OR_MoveTimes8";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+			arg4 = "Eighth of Distance";
+		}
+		special 7
+		{
+			name = "Polyobj_DoorSwing";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+			arg4 = "Close Delay";
+		}
+		special 8
+		{
+			name = "Polyobj_DoorSlide";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Byte Angle";
+			arg4 = "Distance";
+			arg5 = "Close Delay";
+		}
+		special 86
+		{
+			name = "Polyobj_MoveToSpot";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Spot TID";
+		}
+		special 59
+		{
+			name = "Polyobj_OR_MoveToSpot";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "Spot TID";
+		}
+		special 88
+		{
+			name = "Polyobj_MoveTo";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "X Position";
+			arg4 = "Y Position";
+		}
+		special 89
+		{
+			name = "Polyobj_OR_MoveTo";
+			arg1 = "PolyObject ID";
+			arg2 = "Speed";
+			arg3 = "X Position";
+			arg4 = "Y Position";
+		}
+		special 87
+		{
+			name = "Polyobj_Stop";
+			arg1 = "PolyObject ID";
+		}
+	}
+
+	group "Exits"
+	{
+		special 243
+		{
+			name = "Exit_Normal";
+			arg1 = "Player Start", "Value of first argument of player start";
+		}
+		special 244
+		{
+			name = "Exit_Secret";
+			arg1 = "Player Start", "Value of first argument of player start";
+		}
+		special 74
+		{
+			name = "Teleport_NewMap";
+			arg1 = "Map Levelnum";
+			arg2 = "Player Start", "Value of first argument of player start";
+			arg3 = "Keep Facing";
+		}
+		special 75 = "Teleport_EndGame";
+	}
+
+	group "Renderer"
+	{
+		special 9 = "Line_Horizon";   // [RH] draw one-sided wall at horizon
+		special 182 = "Line_Mirror";
+		special 16
+		{
+			name = "Transfer_WallLight";
+			arg1 = "Line ID";
+			arg2 = "Flags", "1: Transfer to front side, 2: Transfer to back side, 4: Absolute light transfer (ignore fake contrast)";
+			tagged = line;
+		}
+		special 210
+		{
+			name = "Transfer_FloorLight";
+			arg1 = "Sector Tag";
+			tagged = sector;
+		}
+		special 211
+		{
+			name = "Transfer_CeilingLight";
+			arg1 = "Sector Tag";
+			tagged = sector;
+		}
+		special 50
+		{
+			name = "ExtraFloor_LightOnly";
+			arg1 = "Sector Tag";
+			arg2 {
+				name = "Light Type";
+				type = choice;
+				custom_values {
+					0 = "Control sector ceiling to top of other type 0 EF_LO";
+					1 = "Tagged ceiling to control sector floor";
+					2 = "Control sector ceiling to top of other EF_LO (any type)";
+				}
+			}
+			tagged = sector;
+		}
+		special 57
+		{
+			name = "Sector_SetPortal";
+			arg1 = "Sector Tag", "Tag of the sectors in which the portal is seen. Sectors seen through the portal should not have this tag.";
+			arg2 {
+				name = "Portal Type";
+				type = choice;
+				custom_values {
+					0 = "Normal view";
+					1 = "Transferred view (copy another portal)";
+					2 = "Eternity-style skybox portal";
+				}
+			}
+			arg3 {
+				name = "Plane";
+				type = choice;
+				custom_values {
+					0 = "Floor portal";
+					1 = "Ceiling portal";
+					2 = "Floor & ceiling portal";
+				}
+			}
+			arg4 = "Misc", "Type 0: 1 if line belongs to sector seen, 0 if it belongs to sector viewing; Type 1: sector tag to copy";
+			arg5 = "Alpha", "Translucency value of the portal";
+			tagged = sector;
+		}
+		special 98
+		{
+			name = "Sector_SetTranslucent";
+			arg1 = "Sector Tag", "Tag of sectors containing portals to affect";
+			arg2 = "Plane", "0 = Floor, 1 = ceiling";
+			arg3 = "Alpha", "On a scale of 0--255 from fully transparent to fully opaque";
+			// Additive transparency is not implemented at the moment
+			//arg4 = "Transparency Type", "0 for normal, 1 for additive transparency";
+		}
+		special 157
+		{
+			name = "SetGlobalFogParameter (OpenGL)";
+			arg1 = "Property", "0 = fog density; 1 = outside fog density; 2 = sky fog";
+			arg2 = "Value";
+		}
+		special 159
+		{
+			name = "Sector_SetPlaneReflection (OpenGL)";
+			arg1 = "Sector Tag";
+			arg2 = "Floor Reflection", "On a 0--255 scale (255 is fully reflective)";
+			arg3 = "Ceiling Reflection", "On a 0--255 scale (255 is fully reflective)";
+			tagged = sector;
+		}
+		special 208
+		{
+			name = "TranslucentLine";
+			arg1 = "Line ID", "Lines to affect (0 = this one)";
+			arg2 = "Alpha", "On a scale of 0--255 from fully transparent to fully opaque";
+			arg3 = "Additive?";
+			arg4 = "Extra flags", "Do not use this in a UDMF map";
+			tagged = lineid;
+		}
+		special 160
+		{
+			name = "Sector_Set3DFloor";
+			arg1 = "Sector Tag";
+			arg2 {
+				name = "Type";
+				type = flags;
+				custom_flags {
+					0 = "Vavoom";
+					1 = "Solid";
+					2 = "Swimmable";
+					3 = "Non-solid";
+					8 = "Arg 5 is LineID (don't use in UDMF)";
+					16 = "invert visibility";
+					32 = "invert shootability";
+				}
+			}
+			arg3 {
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "disable lighting effects";
+					2 = "restrict lighting to inside of floor";
+					4 = "pseudo-fog";
+					8 = "flat floor at ceiling height";
+					16 = "use upper texture";
+					32 = "use lower texture";
+					64 = "use additive translucency";
+				}
+			}
+			arg4 = "Opacity", "On a 0--255 scale from fully transparent to fully opaque";
+			arg5 = "Hi-Tag/Line ID", "Don't use this one in UDMF";
+		}
+		special 209
+		{
+			name = "Transfer_Heights";
+			arg1 = "Sector Tag";
+			arg2 {
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "Always use transferred heights";
+					2 = "Only draw fake floor";
+					4 = "Improved texture control";
+					8 = "Swimmable";
+					16 = "Invisible fake planes";
+					32 = "Don't transfer light";
+				}
+			}
+			tagged = sector;
+		}
+		/*special 53
+		{
+			// This special can only be used in ACS
+			name = "Line_SetTextureOffset";
+		}*/
+		/*special 56
+		{
+			// This special can only be used in ACS
+			name = "Line_SetTextureScale";
+		}*/
+	}
+
+	group "Scripting"
+	{
+		special 80
+		{
+			name = "ACS_Execute";
+			arg1 = "Script Number";
+			arg2 = "Map Levelnum", "Use 0 for current map";
+			arg3 = "First Arg", "First argument passed to the script";
+			arg4 = "Second Arg", "Second argument passed to the script";
+			arg5 = "Third Arg", "Third argument passed to the script";
+		}
+		special 83
+		{
+			name = "ACS_LockedExecute";
+			arg1 = "Script Number";
+			arg2 = "Map Levelnum", "Use 0 for current map";
+			arg3 = "First Arg", "First argument passed to the script";
+			arg4 = "Second Arg", "Second argument passed to the script";
+			arg5 = "Lock Number", "Lock value as defined in LOCKDEFS";
+		}
+		special 85
+		{
+			name = "ACS_LockedExecuteDoor";
+			arg1 = "Script Number";
+			arg2 = "Map Levelnum", "Use 0 for current map";
+			arg3 = "First Arg", "First argument passed to the script";
+			arg4 = "Second Arg", "Second argument passed to the script";
+			arg5 = "Lock Number", "Lock value as defined in LOCKDEFS";
+		}
+		special 84
+		{
+			name = "ACS_ExecuteWithResult";
+			arg1 = "Script Number";
+			arg2 = "First Arg", "First argument passed to the script";
+			arg3 = "Second Arg", "Second argument passed to the script";
+			arg4 = "Third Arg", "Third argument passed to the script";
+		}
+		special 226
+		{
+			name = "ACS_ExecuteAlways";
+			arg1 = "Script Number";
+			arg2 = "Map Levelnum", "Use 0 for current map";
+			arg3 = "First Arg", "First argument passed to the script";
+			arg4 = "Second Arg", "Second argument passed to the script";
+			arg5 = "Third Arg", "Third argument passed to the script";
+		}
+		special 81
+		{
+			name = "ACS_Suspend";
+			arg1 = "Script Number";
+			arg2 = "Map Levelnum", "Use 0 for current map";
+		}
+		special 82
+		{
+			name = "ACS_Terminate";
+			arg1 = "Script Number";
+			arg2 = "Map Levelnum", "Use 0 for current map";
+		}
+		special 158
+		{
+			name = "FS_Execute";
+			arg1 = "Script Number", "FraggleScript script number";
+			arg2 = "Front Side Only?";
+			arg3 = "Lock Number", "Lock value as defined in LOCKDEFS";
+			arg4 = "Remote Message?", "If locked, determines whether unsuccessful use gives the 'open door' or 'activate object' message";
+		}
+		special 191
+		{
+			name = "SetPlayerProperty";
+			arg1 = "All Players?", "0 = only activator, 1 = all players";
+			arg2 = "Set?", "0 = turn property off, 1 = turn it on";
+			arg3 = "Property", "0 = frozen, 1 = no target, 2 = instant switch, 3 = fly, 4 = totally frozen, 5 = invulnerable, 16 = immortal";
+		}
+		special 237
+		{
+			name = "ChangeCamera";
+			arg1 = "Thing ID", "TID of the camera object";
+			arg2 = "All Players?", "0 = only activator, 1 = all players";
+			arg3 = "Move Reverts?", "Set to 1 if movement should cancel the special";
+			tagged = thing;
+		}
+		special 15 = "Autosave";   // [RH] Save the game *now*
+		special 179
+		{
+			name = "ChangeSkill";
+			arg1 = "Skill Number", "Number of the new skill (standard go from 0 for easiest to 5 for hardest)";
+		}
+		special 18
+		{
+			name = "StartConversation";
+			arg1 = "Thing ID", "TID of the talking actor";
+			arg2 = "Face Talker?", "Player turns to face talker if non-null";
+		}
+		special 120  // Earthquake
+		{
+			name = "Radius_Quake";
+			arg1 = "Intensity", "Tremor intensity on a 1--9 scale";
+			arg2 = "Duration", "In tics";
+			arg3 = "Damage Radius", "Radius of damage in 64x64 cells";
+			arg4 = "Tremor Radius", "Radius of tremor in 64x64 cells";
+			arg5 = "Thing ID", "TID of the focus (0 = activator)";
+			tagged = ex_5thing;
+		}
+		special 129
+		{
+			name = "UsePuzzleItem";
+			arg1 = "Puzzle Number", "Value of the the item's PuzzleItem.Number property";
+			arg2 = "Script Number", "Script to run if item successfully used";
+			arg3 = "First Arg", "First argument passed to the script";
+			arg4 = "Second Arg", "Second argument passed to the script";
+			arg5 = "Third Arg", "Third argument passed to the script";
+		}
+		special 173
+		{
+			name = "NoiseAlert";
+			arg1 = "Target TID", "TID of the actor that is to be attacked by alerted monsters (0 = activator)";
+			arg2 = "Emitter TID", "TID of the actor from which the alert emanates (0 = activator)";
+			tagged = ex_1thing_2thing;
+		}
+		special 174
+		{
+			name = "SendToCommunicator";
+			arg1 = "Voc ID", "Number of the VOC lump to play and LOG lump to print";
+			arg2 = "Front Only?", "If non-zero, only activate on front side of the line";
+			arg3 = "Identity?", "If non-zero, also print the name of who sent the message";
+			arg4 = "No Log Message?", "If non-zero, the message will not be placed in the objectives popup";
+		}
 	}
 }
 #endif // NAMESPACE_ZDOOM

--- a/dist/res/config/ports/zdoom.cfg
+++ b/dist/res/config/ports/zdoom.cfg
@@ -21,7 +21,6 @@ port zdoom
 	games = doom, doom2, heretic, hexen, strife, chex1, chex3, ad2;
 	
 	// Supported map formats
-	// Technically supports doom format, but no configs exist for it currently
 	map_formats = doom, hexen, udmf;
 	
 #ifdef MAP_DOOM

--- a/src/Clipboard.cpp
+++ b/src/Clipboard.cpp
@@ -358,7 +358,7 @@ void MapArchClipboardItem::addLines(vector<MapLine*> lines)
  *******************************************************************/
 string MapArchClipboardItem::getInfo()
 {
-	return S_FMT("%d Vertices, %d Lines, %d Sides and %d Sectors",
+	return S_FMT("%lu Vertices, %lu Lines, %lu Sides and %lu Sectors",
 	             vertices.size(), lines.size(), sides.size(), sectors.size());
 }
 

--- a/src/GameConfiguration.cpp
+++ b/src/GameConfiguration.cpp
@@ -725,6 +725,7 @@ void GameConfiguration::readActionSpecials(ParseTreeNode* node, ActionSpecial* g
 			if (!action_specials[special].special)
 			{
 				action_specials[special].special = new ActionSpecial();
+				action_specials[special].number = special;
 				action_specials[special].index = action_specials.size();
 			}
 
@@ -1570,7 +1571,7 @@ vector<as_t> GameConfiguration::allActionSpecials()
 	{
 		if (i->second.special)
 		{
-			as_t as(i->second.special);
+			as_t as(i->second);
 			as.number = i->first;
 			ret.push_back(as);
 		}

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -994,7 +994,7 @@ void MainWindow::onHTMLLinkClicked(wxEvent& e)
 		rs.ToULong(&index);
 		index++;
 
-		panel_archivemanager->handleAction(S_FMT("aman_recent%d", index));
+		panel_archivemanager->handleAction(S_FMT("aman_recent%lu", index));
 	}
 	else if (href.StartsWith("action://"))
 	{


### PR DESCRIPTION
Action specials were actually in semi-random order; they were sorted by their `index`, but due to a copying oversight, every `as_t` used to build the action special panel had an `index` of zero.  No wonder I can never find anything  :)

The easiest way to rearrange them was just to rearrange the config file, so the resulting diff is a bit of a mess.  I tried to put similar things together, and put simpler specials towards the top of the list.  I also shuffled a couple around — `Line_AlignFloor` and `Ceiling` now live in Sector alongside `Sector_SetFloorPanning` and `Sector_SetFloorScale`; `Sector_Set3dFloor` lives in the renderer section next to `Transfer_Heights`; and `Sector_Set3dMidtex` lives with the floor/ceiling specials.