### PR TITLE
More work on specials and their arguments

### DIFF
--- a/dist/res/config/ports/include/props_zdoom.cfg
+++ b/dist/res/config/ports/include/props_zdoom.cfg
@@ -23,20 +23,29 @@ udmf_properties
 			default = false;
 			show_always = false;
 
-			property repeatspecial		= "Repeatable";
-			property playeruseback		= "Usable From Back";
-			property monsteractivate	= "Monsters Activate";
 			property blockplayers		= "Blocks Players";
+			property blockprojectiles	= "Blocks Projectiles";
 			property blockeverything	= "Blocks Everything";
-			property firstsideonly		= "Activate Front Only";
+			property blockuse			= "Blocks Use";
+			property blocksight			= "Blocks Monster Sight";
 			property zoneboundary		= "Reverb Zone Boundary";
 			property clipmidtex			= "Clip MidTex";
 			property wrapmidtex			= "Wrap MidTex";
 			property midtex3d			= "3D MidTex";
+		}
+
+		group "Special Activation"
+		{
+			trigger = true;
+			type = bool;
+			default = false;
+			show_always = false;
+
+			property repeatspecial		= "Repeatable";
+			property monsteractivate	= "Monsters Activate";
 			property checkswitchrange	= "Check Switch Range";
-			property blockprojectiles	= "Blocks Projectiles";
-			property blockuse			= "Blocks Use";
-			property blocksight			= "Blocks Monster Sight";
+			property playeruseback		= "Usable From Back";
+			property firstsideonly		= "Activate Front Only";
 		}
 
 		group "Special Triggers"

--- a/dist/res/config/ports/include/props_zdoom.cfg
+++ b/dist/res/config/ports/include/props_zdoom.cfg
@@ -46,15 +46,15 @@ udmf_properties
 			default = false;
 			show_always = false;
 
-			property playercross	= "Player Cross";
-			property playeruse		= "Player Uses";
-			property monstercross	= "Monster Cross";
-			property monsteruse		= "Monster Uses";
-			property impact			= "Attack Hit";
+			property playeruse		= "Player Use";
 			property playerpush		= "Player Bump";
+			property playercross	= "Player Cross";
+			property monsteruse		= "Monster Use";
 			property monsterpush	= "Monster Bump";
+			property monstercross	= "Monster Cross";
 			property missilecross	= "Missile Cross";
 			property anycross		= "Anything Cross";
+			property impact			= "Attack Hit";
 		}
 
 		group "Rendering"

--- a/dist/res/config/ports/include/specials_zdoom.cfg
+++ b/dist/res/config/ports/include/specials_zdoom.cfg
@@ -53,7 +53,7 @@ action_specials
 		{
 			name = "Generic_Floor";
 			arg1 = "Sector Tag";
-			arg2 = $speed;
+			arg2 = $generic_speed;
 			arg3 = "Value";
 			arg4 = "Target Type";
 			arg5 = "Flags";
@@ -62,25 +62,25 @@ action_specials
 		{
 			name = "Floor_LowerToNearest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 21
 		{
 			name = "Floor_LowerToLowest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 241
 		{
 			name = "Floor_LowerToLowestTxTy";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 242
 		{
 			name = "Floor_LowerToHighest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Lip + 128";
 			arg4 = "Always Adjust?", "If 1, the height adjustment is applied even if neighbouring sectors are at the same floor height";
 		}
@@ -88,14 +88,14 @@ action_specials
 		{
 			name = "Floor_LowerByValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 		}
 		special 36
 		{
 			name = "Floor_LowerByValueTimes8";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Eighth of Value";
 		}
 		special 66
@@ -109,46 +109,46 @@ action_specials
 		{
 			name = "Floor_RaiseToNearest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 24
 		{
 			name = "Floor_RaiseToHighest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 238
 		{
 			name = "Floor_RaiseToLowestCeiling";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 23
 		{
 			name = "Floor_RaiseByValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 		}
 		special 35
 		{
 			name = "Floor_RaiseByValueTimes8";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Eighth of Value";
 		}
 		special 239
 		{
 			name = "Floor_RaiseByValueTxTy";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 		}
 		special 240
 		{
 			name = "Floor_RaiseByTexture";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 67
 		{
@@ -161,7 +161,7 @@ action_specials
 		{
 			name = "Floor_RaiseAndCrush";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
 			arg4 = "Crush Mode";
 		}
@@ -174,7 +174,7 @@ action_specials
 		{
 			name = "Floor_MoveToValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 			arg4 = "Negative?";
 		}
@@ -182,7 +182,7 @@ action_specials
 		{
 			name = "Floor_MoveToValueTimes8";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Eighth of Value";
 			arg4 = "Negative?";
 		}
@@ -198,7 +198,7 @@ action_specials
 			name = "Floor_Waggle";
 			arg1 = "Sector Tag";
 			arg2 = "Amplitude";
-			arg3 = "Speed";
+			arg3 = $generic_speed;
 			arg4 = "Phase Offset";
 			arg5 = "Duration (in seconds)";
 		}
@@ -222,7 +222,7 @@ action_specials
 		{
 			name = "Generic_Ceiling";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 			arg4 = "Target Type";
 			arg5 = "Flags";
@@ -252,32 +252,32 @@ action_specials
 		{
 			name = "Ceiling_LowerToLowest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 254
 		{
 			name = "Ceiling_LowerToFloor";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 192
 		{
 			name = "Ceiling_LowerToHighestFloor";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 40
 		{
 			name = "Ceiling_LowerByValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 		}
 		special 199
 		{
 			name = "Ceiling_LowerByValueTimes8";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Eighth of Value";
 		}
 		special 193
@@ -291,20 +291,20 @@ action_specials
 		{
 			name = "Ceiling_RaiseToNearest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 41
 		{
 			name = "Ceiling_RaiseByValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 		}
 		special 198
 		{
 			name = "Ceiling_RaiseByValueTimes8";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Eighth of Value";
 		}
 		special 194
@@ -318,7 +318,7 @@ action_specials
 		{
 			name = "Ceiling_MoveToValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 			arg4 = "Negative?";
 		}
@@ -326,7 +326,7 @@ action_specials
 		{
 			name = "Ceiling_MoveToValueTimes8";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Eighth of Value";
 			arg4 = "Negative?";
 		}
@@ -335,7 +335,7 @@ action_specials
 			name = "Ceiling_Waggle";
 			arg1 = "Sector Tag";
 			arg2 = "Amplitude";
-			arg3 = "Speed";
+			arg3 = $generic_speed;
 			arg4 = "Phase Offset";
 			arg5 = "Duration (in seconds)";
 		}
@@ -343,7 +343,7 @@ action_specials
 		{
 			name = "Ceiling_LowerAndCrush";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
 			arg4 = "Crush Mode";
 		}
@@ -351,7 +351,7 @@ action_specials
 		{
 			name = "Ceiling_LowerAndCrushDist";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
 			arg4 = "Distance to Floor";
 			arg5 {
@@ -368,7 +368,7 @@ action_specials
 		{
 			name = "Ceiling_CrushAndRaise";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
 			arg4 = "Crush Mode";
 		}
@@ -395,7 +395,7 @@ action_specials
 			name = "Ceiling_CrushAndRaiseDist";
 			arg1 = "Sector Tag";
 			arg2 = "Distance to Floor";
-			arg3 = "Speed";
+			arg3 = $generic_speed;
 			arg4 = "Crush Damage";
 			arg5 = "Crush Mode";
 		}
@@ -404,7 +404,7 @@ action_specials
 			name = "Ceiling_CrushAndRaiseSilentDist";
 			arg1 = "Sector Tag";
 			arg2 = "Distance to Floor";
-			arg3 = "Speed";
+			arg3 = $generic_speed;
 			arg4 = "Crush Damage";
 			arg5 = "Crush Mode";
 		}
@@ -412,7 +412,7 @@ action_specials
 		{
 			name = "Ceiling_CrushRaiseAndStay";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
 			arg4 = "Crush Mode";
 		}
@@ -468,7 +468,7 @@ action_specials
 		{
 			name = "Door_Raise";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay";
 			arg4 = "Light Tag";
 		}
@@ -476,7 +476,7 @@ action_specials
 		{
 			name = "Door_LockedRaise";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay";
 			arg4 = "Lock";
 			arg5 = "Light Tag";
@@ -485,21 +485,21 @@ action_specials
 		{
 			name = "Door_Open";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Light Tag";
 		}
 		special 10
 		{
 			name = "Door_Close";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Light Tag";
 		}
 		special 249
 		{
 			name = "Door_CloseWaitOpen";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay";
 			arg4 = "Light Tag";
 		}
@@ -507,7 +507,7 @@ action_specials
 		{
 			name = "Door_Animated";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay";
 			arg4 = "Lock";
 		}
@@ -521,7 +521,7 @@ action_specials
 		{
 			name = "Generic_Lift";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 			arg4 = "Lift Type";
 			arg4 {
@@ -541,14 +541,14 @@ action_specials
 		{
 			name = "Plat_DownWaitUpStay";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 		}
 		special 206
 		{
 			name = "Plat_DownWaitUpStayLip";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 			arg4 = "Lip";
 			arg5 {
@@ -564,7 +564,7 @@ action_specials
 		{
 			name = "Plat_DownByValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 			arg4 = "Eighth of Value";
 		}
@@ -572,21 +572,21 @@ action_specials
 		{
 			name = "Plat_UpWaitDownStay";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 		}
 		special 172
 		{
 			name = "Plat_UpNearestWaitDownStay";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 		}
 		special 65
 		{
 			name = "Plat_UpByValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 			arg4 = "Eighth of Value";
 		}
@@ -594,27 +594,27 @@ action_specials
 		{
 			name = "Plat_UpByValueStayTx";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Eighth of Value";
 		}
 		special 228
 		{
 			name = "Plat_RaiseAndStayTx0";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 60
 		{
 			name = "Plat_PerpetualRaise";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 		}
 		special 207
 		{
 			name = "Plat_PerpetualRaiseLip";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Delay (in tics)";
 			arg4 = "Lip";
 		}
@@ -638,14 +638,14 @@ action_specials
 		{
 			name = "FloorAndCeiling_LowerByValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 		}
 		special 96
 		{
 			name = "FloorAndCeiling_RaiseByValue";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Value";
 		}
 		special 251
@@ -660,25 +660,25 @@ action_specials
 		{
 			name = "Elevator_LowerToNearest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 245
 		{
 			name = "Elevator_RaiseToNearest";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 246
 		{
 			name = "Elevator_MoveToFloor";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 		}
 		special 30
 		{
 			name = "Pillar_Open";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Floor Lower Value", "0 = Lowest Adjacent Floor";
 			arg4 = "Ceiling Raise Value", "0 = Highest Adjacent Ceiling";
 		}
@@ -686,14 +686,14 @@ action_specials
 		{
 			name = "Pillar_Build";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Floor Height", "0 = Halfway Point";
 		}
 		special 94
 		{
 			name = "Pillar_BuildAndCrush";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Floor Height", "0 = Halfway Point";
 			arg4 = "Crushing Damage";
 			arg5 = "Crushing Mode";
@@ -723,16 +723,26 @@ action_specials
 		{
 			name = "Generic_Stairs";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Step Height";
-			arg4 = "Flags";
+			arg4
+			{
+				name = "Flags";
+				type = flags;
+				custom_flags
+				{
+					0 = "build stairs down";
+					1 = "build stairs up";
+					2 = "ignore floor textures when finding stairs";
+				}
+			}
 			arg5 = "Reset Delay (in tics)";
 		}
 		special 26
 		{
 			name = "Stairs_BuildDown";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Step Height";
 			arg4 = "Step Delay (in tics)";
 			arg5 = "Reset Delay (in tics)";
@@ -741,7 +751,7 @@ action_specials
 		{
 			name = "Stairs_BuildDownSync";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Step Height";
 			arg4 = "Reset Delay (in tics)";
 		}
@@ -749,7 +759,7 @@ action_specials
 		{
 			name = "Stairs_BuildUp";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Step Height";
 			arg4 = "Step Delay (in tics)";
 			arg5 = "Reset Delay (in tics)";
@@ -758,7 +768,7 @@ action_specials
 		{
 			name = "Stairs_BuildUpSync";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Step Height";
 			arg4 = "Reset Delay (in tics)";
 		}
@@ -766,7 +776,7 @@ action_specials
 		{
 			name = "Stairs_BuildUpDoom";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Step Height";
 			arg4 = "Step Delay (in tics)";
 			arg5 = "Reset Delay (in tics)";
@@ -1320,7 +1330,7 @@ action_specials
 			name = "Thing_ProjectileAimed";
 			arg1 = "Thing ID";
 			arg2 = "Type", "Spawn ID of the projectile";
-			arg3 = "Speed", "Speed of the projectile in units per 8 tics";
+			arg3 = $generic_speed;
 			arg4 = "Target TID";
 			arg5 = "New TID", "TID to give spawned thing";
 			tagged = ex_1thing_4thing;
@@ -1330,7 +1340,7 @@ action_specials
 			name = "Thing_ProjectileIntercept";
 			arg1 = "Thing ID";
 			arg2 = "Type", "Spawn ID of the projectile";
-			arg3 = "Speed", "Speed of the projectile in units per 8 tics";
+			arg3 = $generic_speed;
 			arg4 = "Target TID";
 			arg5 = "New TID", "TID to give spawned thing";
 			tagged = ex_1thing_4thing;
@@ -1569,25 +1579,25 @@ action_specials
 		special 102
 		{
 			name = "Scroll_Texture_Up";
-			arg1 = "Speed";
+			arg1 = $generic_speed;
 			arg2 = $scroll_texture_flags;
 		}
 		special 103
 		{
 			name = "Scroll_Texture_Down";
-			arg1 = "Speed";
+			arg1 = $generic_speed;
 			arg2 = $scroll_texture_flags;
 		}
 		special 100
 		{
 			name = "Scroll_Texture_Left";
-			arg1 = "Speed";
+			arg1 = $generic_speed;
 			arg2 = $scroll_texture_flags;
 		}
 		special 101
 		{
 			name = "Scroll_Texture_Right";
-			arg1 = "Speed";
+			arg1 = $generic_speed;
 			arg2 = $scroll_texture_flags;
 		}
 		special 221
@@ -1725,7 +1735,7 @@ action_specials
 		{
 			name = "Polyobj_Move";
 			arg1 = "PolyObject ID";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Byte Angle";
 			arg4 = "Distance";
 		}
@@ -1733,7 +1743,7 @@ action_specials
 		{
 			name = "Polyobj_OR_Move";
 			arg1 = "PolyObject ID";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Byte Angle";
 			arg4 = "Distance";
 		}
@@ -1741,7 +1751,7 @@ action_specials
 		{
 			name = "Polyobj_MoveTimes8";
 			arg1 = "PolyObject ID";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Byte Angle";
 			arg4 = "Eighth of Distance";
 		}
@@ -1749,7 +1759,7 @@ action_specials
 		{
 			name = "Polyobj_OR_MoveTimes8";
 			arg1 = "PolyObject ID";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Byte Angle";
 			arg4 = "Eighth of Distance";
 		}
@@ -1765,7 +1775,7 @@ action_specials
 		{
 			name = "Polyobj_DoorSlide";
 			arg1 = "PolyObject ID";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 = "Byte Angle";
 			arg4 = "Distance";
 			arg5 = "Close Delay";

--- a/dist/res/config/ports/include/specials_zdoom.cfg
+++ b/dist/res/config/ports/include/specials_zdoom.cfg
@@ -11,6 +11,17 @@ action_specials
 		name = "Speed";
 		type = speed;
 	}
+	arg crush_mode
+	{
+		name = "Crush mode";
+		type = choice;
+		custom_values
+		{
+			0 = "use current game's default";
+			1 = "Doom mode (keep moving while crushing)";
+			2 = "Hexen mode (stop moving until actor dies/leaves)";
+		}
+	}
 	arg means_of_death
 	{
 		name = "Means of death";
@@ -163,7 +174,7 @@ action_specials
 			arg1 = "Sector Tag";
 			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
-			arg4 = "Crush Mode";
+			arg4 = $crush_mode;
 		}
 		special 46
 		{
@@ -345,7 +356,7 @@ action_specials
 			arg1 = "Sector Tag";
 			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
-			arg4 = "Crush Mode";
+			arg4 = $crush_mode;
 		}
 		special 97
 		{
@@ -354,15 +365,7 @@ action_specials
 			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
 			arg4 = "Distance to Floor";
-			arg5 {
-				name = "Crush Mode";
-				type = choice;
-				custom_values {
-					0 = "Game default";
-					1 = "Doom mode (keep moving while crushing)";
-					2 = "Hexen mode (pause movement until crushed actor dies)";
-				}
-			}
+			arg5 = $crush_mode;
 		}
 		special 42
 		{
@@ -370,7 +373,7 @@ action_specials
 			arg1 = "Sector Tag";
 			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
-			arg4 = "Crush Mode";
+			arg4 = $crush_mode;
 		}
 		special 196
 		{
@@ -379,7 +382,7 @@ action_specials
 			arg2 = "Lowering Speed";
 			arg3 = "Raising Speed";
 			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
+			arg5 = $crush_mode;
 		}
 		special 197
 		{
@@ -388,7 +391,7 @@ action_specials
 			arg2 = "Lowering Speed";
 			arg3 = "Raising Speed";
 			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
+			arg5 = $crush_mode;
 		}
 		special 168
 		{
@@ -397,7 +400,7 @@ action_specials
 			arg2 = "Distance to Floor";
 			arg3 = $generic_speed;
 			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
+			arg5 = $crush_mode;
 		}
 		special 104
 		{
@@ -406,7 +409,7 @@ action_specials
 			arg2 = "Distance to Floor";
 			arg3 = $generic_speed;
 			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
+			arg5 = $crush_mode;
 		}
 		special 45
 		{
@@ -414,7 +417,7 @@ action_specials
 			arg1 = "Sector Tag";
 			arg2 = $generic_speed;
 			arg3 = "Crush Damage";
-			arg4 = "Crush Mode";
+			arg4 = $crush_mode;
 		}
 		special 195
 		{
@@ -423,7 +426,7 @@ action_specials
 			arg2 = "Lowering Speed";
 			arg3 = "Raising Speed";
 			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
+			arg5 = $crush_mode;
 		}
 		special 255
 		{
@@ -432,7 +435,7 @@ action_specials
 			arg2 = "Lowering Speed";
 			arg3 = "Raising Speed";
 			arg4 = "Crush Damage";
-			arg5 = "Crush Mode";
+			arg5 = $crush_mode;
 		}
 		special 44
 		{

--- a/dist/res/config/ports/include/specials_zdoom.cfg
+++ b/dist/res/config/ports/include/specials_zdoom.cfg
@@ -6,6 +6,11 @@ action_specials
 {
 	clearexisting;
 
+	arg generic_speed
+	{
+		name = "Speed";
+		type = speed;
+	}
 	arg means_of_death
 	{
 		name = "Means of death";
@@ -445,7 +450,7 @@ action_specials
 		{
 			name = "Generic_Door";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $generic_speed;
 			arg3 {
 				name = "Door Kind";
 				type = choice;

--- a/dist/res/config/ports/include/specials_zdoom.cfg
+++ b/dist/res/config/ports/include/specials_zdoom.cfg
@@ -6,6 +6,40 @@ action_specials
 {
 	clearexisting;
 
+	arg means_of_death
+	{
+		name = "Means of death";
+		type = choice;
+		custom_values
+		{
+			0 = "generic damage";
+			5 = "rocket";
+			6 = "rocket splash damage";
+			7 = "plasma";
+			8 = "BFG ball";
+			9 = "BFG tracer";
+			10 = "chainsaw";
+			11 = "shotgun";
+			12 = "drowning";
+			13 = "slime (Doom's damaging floors)";
+			14 = "lava/fire";
+			15 = "crusher";
+			16 = "telefrag";
+			17 = "falling";
+			18 = "suicide";
+			19 = "barrel";
+			20 = "exit (used in deathmatch)";
+			21 = "generic splash damage";
+			22 = "generic melee damage";
+			23 = "railgun";
+			24 = "ice";
+			25 = "disintegration";
+			26 = "poison";
+			27 = "electricity";
+			1000 = "massacre (console cheat)";
+		}
+	}
+
 	group "Floors"
 	{
 		tagged = sector_or_back;
@@ -14,7 +48,7 @@ action_specials
 		{
 			name = "Generic_Floor";
 			arg1 = "Sector Tag";
-			arg2 = "Speed";
+			arg2 = $speed;
 			arg3 = "Value";
 			arg4 = "Target Type";
 			arg5 = "Flags";
@@ -916,7 +950,7 @@ action_specials
 			name = "Sector_SetDamage";
 			arg1 = "Sector Tag";
 			arg2 = "Amount";
-			arg3 = "Means of Death", "0 = default, 5 = rocket, 6 = rocket splash, 7 = plasma, 8 = BFG ball, 9 = BFG tracer, 10 = chainsaw, 11 = shotgun, 12 = drowning, 13 = slime, 14 = lava/fire, 15 = crush, 16 = telefrag, 17 = fall, 18 = suicide, 19 = barrel, 20 = exit, 21 = splash damage, 22 = melee, 23 = railgun, 24 = ice, 25 = disintegrate, 26 = poison, 27 = electricity, 1000 = massacre";
+			arg3 = $means_of_death;
 		}
 		special 216
 		{
@@ -1255,7 +1289,7 @@ action_specials
 		{
 			name = "DamageThing";
 			arg1 = "Amount", "0 is a guaranteed kill";
-			arg2 = "Mean of Death", "0 = default, 5 = rocket, 6 = rocket splash, 7 = plasma, 8 = BFG ball, 9 = BFG tracer, 10 = chainsaw, 11 = shotgun, 12 = drowning, 13 = slime, 14 = lava/fire, 15 = crush, 16 = telefrag, 17 = fall, 18 = suicide, 19 = barrel, 20 = exit, 21 = splash damage, 22 = melee, 23 = railgun, 24 = ice, 25 = disintegrate, 26 = poison, 27 = electricity, 1000 = massacre";
+			arg2 = $means_of_death;
 			tagged = no;
 		}
 		special 119
@@ -1263,7 +1297,7 @@ action_specials
 			name = "Thing_Damage";
 			arg1 = "Thing ID";
 			arg2 = "Amount";
-			arg3 = "Mean of Death", "0 = default, 5 = rocket, 6 = rocket splash, 7 = plasma, 8 = BFG ball, 9 = BFG tracer, 10 = chainsaw, 11 = shotgun, 12 = drowning, 13 = slime, 14 = lava/fire, 15 = crush, 16 = telefrag, 17 = fall, 18 = suicide, 19 = barrel, 20 = exit, 21 = splash damage, 22 = melee, 23 = railgun, 24 = ice, 25 = disintegrate, 26 = poison, 27 = electricity, 1000 = massacre";
+			arg3 = $means_of_death;
 		}
 		special 133
 		{

--- a/dist/res/config/ports/include/specials_zdoom.cfg
+++ b/dist/res/config/ports/include/specials_zdoom.cfg
@@ -803,7 +803,18 @@ action_specials
 			arg2 = "Front Ceiling Tag";
 			arg3 = "Back Floor Tag";
 			arg4 = "Back Ceiling Tag";
-			arg5 = "Share Flags", "1: Copy floor front to back, 2: copy floor back to front, 4: copy ceiling front to back, 8: copy ceiling back to front";
+			arg5
+			{
+				name = "Share Flags";
+				type = flags;
+				custom_flags
+				{
+					1 = "copy floor front to back";
+					2 = "copy floor back to front";
+					4 = "copy ceiling front to back";
+					8 = "copy ceiling back to front";
+				}
+			}
 			tagged = ex_1sector_2sector_3sector_4sector;
 		}
 		special 51
@@ -835,9 +846,33 @@ action_specials
 		{
 			name = "Static_Init";
 			arg1 = "Sector Tag/Line ID";
-			arg2 = "Property", "0 = gravity, 1 = light or fog color from upper/lower texture, 2 = damage from linedef length, 3 = sector link, 255 = set sky from upper texture";
+			arg2
+			{
+				name = "Property";
+				type = "choice";
+				custom_values
+				{
+					0 = "set gravity";
+					1 = "set light or fog color from upper/lower texture";
+					2 = "set damage from linedef length";
+					3 = "sector link";
+					255 = "set sky from upper texture";
+				}
+			}
 			arg3 = "Ceiling/Flip?", "Property 3: use ceiling instead of floor as control surface; Property 255: flip sky texture horizontally";
-			arg4 = "Move Type", "Property 3: 1: floor to surface, 2: ceiling to surface, 4: invert floor movement, 8: invert ceiling movement";
+			arg4
+			{
+				name = "Move Type";
+				desc = "Only used when Property is 3";
+				type = flags;
+				custom_flags
+				{
+					1 = "floor to surface";
+					2 = "ceiling to surface";
+					4 = "invert floor movement";
+					8 = "invert ceiling movement";
+				}
+			}
 			tagged = ex_sector_2is3_line;
 		}
 		special 54
@@ -914,18 +949,28 @@ action_specials
 			arg4 = "V Offset";
 			arg5 = "V Frac", "One hundredth of this value is added to V offset";
 		}
+		arg line_align_sector
+		{
+			name = "Align to";
+			type = choice;
+			custom_values
+			{
+				0 = "front sector";
+				1 = "back sector";
+			}
+		}
 		special 184
 		{
 			name = "Line_AlignFloor";
 			arg1 = "Line ID";
-			arg2 = "Back sector?", "0 is front sector, 1 is back sector";
+			arg2 = $line_align_sector;
 			tagged = line;
 		}
 		special 183
 		{
 			name = "Line_AlignCeiling";
 			arg1 = "Line ID";
-			arg2 = "Back sector?", "0 is front sector, 1 is back sector";
+			arg2 = $line_align_sector;
 			tagged = line;
 		}
 		special 212
@@ -992,7 +1037,7 @@ action_specials
 		}
 		special 161
 		{
-			name = "Sector_SetContents";
+			name = "Sector_SetContents (OpenGL)";
 			arg1 {
 				name = "Content Type";
 				type = choice;
@@ -1372,7 +1417,21 @@ action_specials
 			name = "Thing_Hate";
 			arg1 = "Hater TID";
 			arg2 = "Hated TID";
-			arg3 = "Hate Type", "0 = hate once, 1 = retaliate against players, 2 = also hunt enemies, 3 = also hunt players, 4 = also hunt monsters, 5 = ignore player attacks, 6 = ignore attacks but hunt enemies";
+			arg3
+			{
+				name = "Hate Type";
+				type = choice;
+				custom_values
+				{
+					0 = "hate once";
+					1 = "retaliate against players";
+					2 = "also hunt enemies";
+					3 = "also hunt players";
+					4 = "also hunt monsters";
+					5 = "ignore player attacks";
+					6 = "ignore attacks but hunt enemies";
+				}
+			}
 		}
 		special 180
 		{
@@ -1400,7 +1459,21 @@ action_specials
 		{
 			name = "Line_SetIdentification";
 			arg1 = "Line ID";
-			arg2 = "Extra Flags", "1: zone boundary, 2: railing, 4: block floaters, 8: clip midtextures, 16: wrap midtextures, 32: 3D middle texture, 64: check switch height";
+			arg2
+			{
+				name = "Extra Flags";
+				type = flags;
+				custom_flags
+				{
+					1 = "zone boundary";
+					2 = "railing";
+					4 = "block floaters";
+					8 = "clip midtextures";
+					16 = "wrap midtextures";
+					32 = "3D middle texture";
+					64 = "check switch height";
+				}
+			}
 			arg3 = "Don't Use";
 			arg4 = "Don't Use";
 			arg5 = "Line ID high";
@@ -1411,8 +1484,42 @@ action_specials
 		{
 			name = "Line_SetBlocking";
 			arg1 = "Line ID";
-			arg2 = "Set Flags", "1: Creatures, 2: Monsters, 4: Players, 8: Floaters, 16: Projectiles, 32: Everything, 64: Railing, 128: Use, 256: Sight";
-			arg3 = "Clear Flags", "1: Creatures, 2: Monsters, 4: Players, 8: Floaters, 16: Projectiles, 32: Everything, 64: Railing, 128: Use, 256: Sight";
+			arg2
+			{
+				name = "Set Flags";
+				type = flags;
+				custom_flags
+				{
+					1 = "creatures";
+					2 = "monsters";
+					4 = "players";
+					8 = "floaters";
+					16 = "projectiles";
+					32 = "everything above";
+					64 = "Strife railing (only bottom 32 units block)";
+					128 = "switch use";
+					256 = "monster sight";
+					512 = "hitscan attacks";
+				}
+			}
+			arg3
+			{
+				name = "Clear Flags";
+				type = flags;
+				custom_flags
+				{
+					1 = "creatures";
+					2 = "monsters";
+					4 = "players";
+					8 = "floaters";
+					16 = "projectiles";
+					32 = "everything above";
+					64 = "Strife railing (only bottom 32 units block)";
+					128 = "switch use";
+					256 = "monster sight";
+					512 = "hitscan attacks";
+				}
+			}
 		}
 		special 33 = "ForceField"; // [RH] Strife's forcefield special (148)
 		special 34    // [RH] Remove Strife's forcefield from tagged sectors
@@ -1433,45 +1540,50 @@ action_specials
 	{
 		tagged = no;
 
+		arg scroll_texture_flags
+		{
+			name = "Flags";
+			type = flags;
+			custom_flags {
+				1 = "upper";
+				2 = "mid";
+				4 = "lower";
+			}
+		}
+		arg scroll_flat_flags
+		{
+			name = "Flags";
+			type = flags;
+			custom_flags {
+				1 = "Displacement";
+				2 = "Accelerative";
+				4 = "DX/DY from linedef";
+			}
+		}
+
 		special 102
 		{
 			name = "Scroll_Texture_Up";
 			arg1 = "Speed";
-			arg2 = "Flags", "1 for upper, 2 for mid, 4 for lower";
+			arg2 = $scroll_texture_flags;
 		}
 		special 103
 		{
 			name = "Scroll_Texture_Down";
 			arg1 = "Speed";
-			arg2 = "Flags", "1 for upper, 2 for mid, 4 for lower";
+			arg2 = $scroll_texture_flags;
 		}
 		special 100
 		{
 			name = "Scroll_Texture_Left";
 			arg1 = "Speed";
-			arg2 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "upper";
-					2 = "mid";
-					4 = "lower";
-				}
-			}
+			arg2 = $scroll_texture_flags;
 		}
 		special 101
 		{
 			name = "Scroll_Texture_Right";
 			arg1 = "Speed";
-			arg2 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "upper";
-					2 = "mid";
-					4 = "lower";
-				}
-			}
+			arg2 = $scroll_texture_flags;
 		}
 		special 221
 		{
@@ -1490,42 +1602,34 @@ action_specials
 			arg2 = "X Speed", "Horizontal speed per tic as fixed point value";
 			arg3 = "Y Speed", "Vertical speed per tic as fixed point value";
 			arg4 = "Line Side", "0 for front and 1 for back";
-			arg5 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "upper";
-					2 = "mid";
-					4 = "lower";
-				}
-			}
+			arg5 = $scroll_texture_flags;
 			tagged = line;
 		}
 		special 225
 		{
 			name = "Scroll_Texture_Offsets";
-			arg1 = "Flag", "1 for upper, 2 for mid, 4 for lower";
+			arg1 = $scroll_texture_flags;
 		}
 		special 222
 		{
 			name = "Scroll_Texture_Model";
 			arg1 = "Line ID";
-			arg2 = "Flags", "1: Displacement, 2: Accelerative";
+			arg2
+			{
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "Displacement";
+					2 = "Accelerative";
+				}
+			}
 			tagged = lineid;
 		}
 		special 223
 		{
 			name = "Scroll_Floor";
 			arg1 = "Sector Tag";
-			arg2 {
-				name = "Flags";
-				type = flags;
-				custom_flags {
-					1 = "Displacement";
-					2 = "Accelerative";
-					4 = "DX/DY from linedef";
-				}
-			}
+			arg2 = $scroll_flag_flags;
 			arg3 {
 				name = "Type";
 				type = choice;
@@ -1543,7 +1647,7 @@ action_specials
 		{
 			name = "Scroll_Ceiling";
 			arg1 = "Sector Tag";
-			arg2 = "Flags", "1: Displacement, 2: Accelerative, 4: DX/DY from linedef";
+			arg2 = $scroll_flag_flags;
 			arg3 = "Unused", "There are no scroll ceiling types, so this value is not used";
 			arg4 = "X Speed", "128 is no scroll, 0-127 is West, 129-255 is East";
 			arg5 = "Y Speed", "128 is no scroll, 0-127 is South, 129-255 is North";
@@ -1553,7 +1657,16 @@ action_specials
 		{
 			name = "Sector_CopyScroller";
 			arg1 = "Sector Tag", "Tag of the sector to copy";
-			arg2 = "Flags", "1: Copy ceiling scrolling, 2: copy floor scrolling, 4: copy actor carrying";
+			arg2
+			{
+				name = "Flags";
+				type = flags;
+				custom_flags {
+					1 = "copy ceiling scrolling";
+					2 = "copy floor scrolling";
+					4 = "copy actor carrying";
+				}
+			}
 		}
 	}
 
@@ -1719,7 +1832,17 @@ action_specials
 		{
 			name = "Transfer_WallLight";
 			arg1 = "Line ID";
-			arg2 = "Flags", "1: Transfer to front side, 2: Transfer to back side, 4: Absolute light transfer (ignore fake contrast)";
+			arg2
+			{
+				name = "Flags";
+				type = flags;
+				custom_flags
+				{
+					1 = "transfer to front side";
+					2 = "transfer to back side";
+					4 = "absolute light transfer (ignore fake contrast)";
+				}
+			}
 			tagged = line;
 		}
 		special 210
@@ -1816,10 +1939,11 @@ action_specials
 				type = flags;
 				custom_flags {
 					0 = "Vavoom";
-					1 = "Solid";
-					2 = "Swimmable";
-					3 = "Non-solid";
-					8 = "Arg 5 is LineID (don't use in UDMF)";
+					1 = "solid";
+					2 = "swimmable";
+					3 = "non-solid";
+					4 = "draw inside of floor (don't use with Vavoom)";
+					8 = "arg 5 is LineID (don't use in UDMF)";
 					16 = "invert visibility";
 					32 = "invert shootability";
 				}
@@ -1848,12 +1972,12 @@ action_specials
 				name = "Flags";
 				type = flags;
 				custom_flags {
-					1 = "Always use transferred heights";
-					2 = "Only draw fake floor";
-					4 = "Improved texture control";
-					8 = "Swimmable";
-					16 = "Invisible fake planes";
-					32 = "Don't transfer light";
+					1 = "always use transferred heights";
+					2 = "only draw fake floor";
+					4 = "improved texture control";
+					8 = "swimmable";
+					16 = "invisible fake planes";
+					32 = "don't transfer light";
 				}
 			}
 			tagged = sector;
@@ -1936,18 +2060,52 @@ action_specials
 			arg3 = "Lock Number", "Lock value as defined in LOCKDEFS";
 			arg4 = "Remote Message?", "If locked, determines whether unsuccessful use gives the 'open door' or 'activate object' message";
 		}
+
+		arg which_players
+		{
+			name = "Who";
+			type = choice;
+			custom_values
+			{
+				0 = "activator only";
+				1 = "all players";
+			}
+		}
 		special 191
 		{
 			name = "SetPlayerProperty";
-			arg1 = "All Players?", "0 = only activator, 1 = all players";
-			arg2 = "Set?", "0 = turn property off, 1 = turn it on";
-			arg3 = "Property", "0 = frozen, 1 = no target, 2 = instant switch, 3 = fly, 4 = totally frozen, 5 = invulnerable, 16 = immortal";
+			arg1 = $which_players;
+			arg2
+			{
+				name = "Set?";
+				type = choice;
+				custom_values
+				{
+					0 = "turn off";
+					1 = "turn on";
+				}
+			}
+			arg3
+			{
+				name = "Property";
+				type = choice;
+				custom_values
+				{
+					0 = "cannot move";
+					1 = "not auto targeted by monsters";
+					2 = "instant switch";
+					3 = "fly";
+					4 = "totally frozen";
+					5 = "invulnerable";
+					16 = "buddha mode (cannot drop below 1 health)";
+				}
+			}
 		}
 		special 237
 		{
 			name = "ChangeCamera";
 			arg1 = "Thing ID", "TID of the camera object";
-			arg2 = "All Players?", "0 = only activator, 1 = all players";
+			arg2 = $which_players;
 			arg3 = "Move Reverts?", "Set to 1 if movement should cancel the special";
 			tagged = thing;
 		}

--- a/src/ActionSpecial.cpp
+++ b/src/ActionSpecial.cpp
@@ -205,6 +205,8 @@ void ActionSpecial::parseArg(ParseTreeNode* node, SpecialArgMap* shared_args, ar
 			arg.type = ARGT_CHOICE;
 		else if (S_CMPNOCASE(atype, "flags"))
 			arg.type = ARGT_FLAGS;
+		else if (S_CMPNOCASE(atype, "speed"))
+			arg.type = ARGT_SPEED;
 		else
 			arg.type = ARGT_NUMBER;
 

--- a/src/ActionSpecial.h
+++ b/src/ActionSpecial.h
@@ -34,6 +34,7 @@ public:
 
 	void	reset();
 	void	parse(ParseTreeNode* node);
+	static void	parseArg(ParseTreeNode* node, arg_t& arg);
 	string	stringDesc();
 };
 

--- a/src/ActionSpecial.h
+++ b/src/ActionSpecial.h
@@ -4,6 +4,8 @@
 
 #include "Args.h"
 
+WX_DECLARE_STRING_HASH_MAP(arg_t, SpecialArgMap);
+
 class ParseTreeNode;
 class ActionSpecial
 {
@@ -33,8 +35,8 @@ public:
 	string	getArgsString(int args[5]);
 
 	void	reset();
-	void	parse(ParseTreeNode* node);
-	static void	parseArg(ParseTreeNode* node, arg_t& arg);
+	void	parse(ParseTreeNode* node, SpecialArgMap* shared_args);
+	static void	parseArg(ParseTreeNode* node, SpecialArgMap* shared_args, arg_t& arg);
 	string	stringDesc();
 };
 

--- a/src/ActionSpecialDialog.cpp
+++ b/src/ActionSpecialDialog.cpp
@@ -827,6 +827,8 @@ ActionSpecialPanel::~ActionSpecialPanel()
 {
 }
 
+WX_DECLARE_STRING_HASH_MAP(wxFlexGridSizer*, NamedFlexGridMap);
+
 /* ActionSpecialPanel::setupSpecialPanel
  * Creates and sets up the action special panel
  *******************************************************************/
@@ -857,45 +859,36 @@ void ActionSpecialPanel::setupSpecialPanel()
 
 			// Get all UDMF trigger properties
 			vector<string> triggers;
+			NamedFlexGridMap named_flexgrids;
 			for (unsigned a = 0; a < props.size(); a++)
 			{
-				if (props[a].property->isTrigger())
+				UDMFProperty* property = props[a].property;
+				if (!property->isTrigger())
+					continue;
+
+				string group = property->getGroup();
+				wxFlexGridSizer* frame_sizer = named_flexgrids[group];
+				if (!frame_sizer)
 				{
-					triggers.push_back(props[a].property->getName());
-					triggers_udmf.push_back(props[a].property->getProperty());
-				}
-			}
+					wxStaticBox* frame_triggers = new wxStaticBox(panel_action_special, -1, group);
+					wxStaticBoxSizer* sizer_triggers = new wxStaticBoxSizer(frame_triggers, wxVERTICAL);
+					sizer->Add(sizer_triggers, 0, wxEXPAND|wxTOP, 4);
 
-			// Check if there are any triggers defined
-			if (triggers.size() > 0)
-			{
-				// Add frame
-				wxStaticBox* frame_triggers = new wxStaticBox(panel_action_special, -1, "Special Triggers");
-				wxStaticBoxSizer* sizer_triggers = new wxStaticBoxSizer(frame_triggers, wxVERTICAL);
-				sizer->Add(sizer_triggers, 0, wxEXPAND|wxTOP, 4);
+					frame_sizer = new wxFlexGridSizer(3);
+					frame_sizer->AddGrowableCol(0, 1);
+					frame_sizer->AddGrowableCol(1, 1);
+					frame_sizer->AddGrowableCol(2, 1);
+					sizer_triggers->Add(frame_sizer, 1, wxEXPAND|wxALL, 4);
 
-				// Add trigger checkboxes
-				wxGridBagSizer* gb_sizer = new wxGridBagSizer(4, 4);
-				sizer_triggers->Add(gb_sizer, 1, wxEXPAND|wxALL, 4);
-				int row = 0;
-				int col = 0;
-				int trigger_mid = triggers.size() / 3;
-				for (unsigned a = 0; a < triggers.size(); a++)
-				{
-					wxCheckBox* cb_trigger = new wxCheckBox(panel_action_special, -1, triggers[a], wxDefaultPosition, wxDefaultSize, wxCHK_3STATE);
-					gb_sizer->Add(cb_trigger, wxGBPosition(row++, col), wxDefaultSpan, wxEXPAND);
-					cb_triggers.push_back(cb_trigger);
-
-					if (row >= trigger_mid && col <= 1)
-					{
-						row = 0;
-						col++;
-					}
+					named_flexgrids.find(group)->second = frame_sizer;
 				}
 
-				gb_sizer->AddGrowableCol(0, 1);
-				gb_sizer->AddGrowableCol(1, 1);
-				gb_sizer->AddGrowableCol(2, 1);
+				wxCheckBox* cb_trigger = new wxCheckBox(panel_action_special, -1, property->getName(), wxDefaultPosition, wxDefaultSize, wxCHK_3STATE);
+				frame_sizer->Add(cb_trigger, 0, wxEXPAND);
+
+				triggers.push_back(property->getName());
+				triggers_udmf.push_back(property->getProperty());
+				cb_triggers.push_back(cb_trigger);
 			}
 		}
 

--- a/src/ActionSpecialDialog.cpp
+++ b/src/ActionSpecialDialog.cpp
@@ -587,7 +587,9 @@ protected:
 			slider_control->SetValue(value);
 			speed_label->SetLabel(S_FMT(
 				"%s (%.1f units per tic, %.1f units per sec)",
-				arg_t::speedLabel(value), value / 8.0, value / 8.0 * 35
+				arg_t::speedLabel(value), value / 8.0,
+				// A tic is 28ms, slightly less than 1/35 of a second
+				value / 8.0 * 1000.0 / 28.0
 			));
 		}
 	}

--- a/src/Args.h
+++ b/src/Args.h
@@ -10,6 +10,7 @@ enum
 	ARGT_ANGLE,
 	ARGT_CHOICE,
 	ARGT_FLAGS,
+	ARGT_SPEED,
 };
 
 struct arg_val_t
@@ -115,8 +116,61 @@ struct arg_t
 		else if (type == ARGT_ANGLE)
 			return S_FMT("%d Degrees", value);	// TODO: E/S/W/N/etc
 
+		// Speed
+		else if (type == ARGT_SPEED)
+		{
+			// Label with the Boom generalized speed names
+			string speed_label;
+			if (value == 0)
+				speed_label = "broken (don't use!)";
+			else if (value < 8)
+				speed_label = "< slow";
+			else if (value == 8)
+				speed_label = "slow";
+			else if (value < 16)
+				speed_label = "slow ~ normal";
+			else if (value == 16)
+				speed_label = "normal";
+			else if (value < 32)
+				speed_label = "normal ~ fast";
+			else if (value == 32)
+				speed_label = "fast";
+			else if (value < 64)
+				speed_label = "fast ~ turbo";
+			else if (value == 64)
+				speed_label = "turbo";
+			else
+				speed_label = "> turbo";
+			return S_FMT("%d (%s)", value, speed_label);
+		}
+
 		// Any other type
 		return S_FMT("%d", value);
+	}
+
+	static const string speedLabel(int value)
+	{
+		// Use the generalized Boom speeds as landmarks
+		if (value == 0)
+			return "none, probably bogus";
+		else if (value < 8)
+			return "< slow";
+		else if (value == 8)
+			return "slow";
+		else if (value < 16)
+			return "slow ~ normal";
+		else if (value == 16)
+			return "normal";
+		else if (value < 32)
+			return "normal ~ fast";
+		else if (value == 32)
+			return "fast";
+		else if (value < 64)
+			return "fast ~ turbo";
+		else if (value == 64)
+			return "turbo";
+		else
+			return "> turbo";
 	}
 };
 

--- a/src/GameConfiguration.cpp
+++ b/src/GameConfiguration.cpp
@@ -2785,6 +2785,7 @@ string GameConfiguration::spacTriggerString(MapLine* line, int map_format)
 		// Go through all line UDMF properties
 		string trigger = "";
 		vector<udmfp_t> props = allUDMFProperties(MOBJ_LINE);
+		sort(props.begin(), props.end());
 		for (unsigned a = 0; a < props.size(); a++)
 		{
 			// Check for trigger property

--- a/src/GameConfiguration.cpp
+++ b/src/GameConfiguration.cpp
@@ -677,7 +677,7 @@ void GameConfiguration::buildConfig(ArchiveEntry* entry, string& out, bool use_r
  * Reads action special definitions from a parsed tree [node], using
  * [group_defaults] for default values
  *******************************************************************/
-void GameConfiguration::readActionSpecials(ParseTreeNode* node, ActionSpecial* group_defaults)
+void GameConfiguration::readActionSpecials(ParseTreeNode* node, ActionSpecial* group_defaults, SpecialArgMap* shared_args)
 {
 	// Check if we're clearing all existing specials
 	if (node->getChild("clearexisting"))
@@ -701,9 +701,16 @@ void GameConfiguration::readActionSpecials(ParseTreeNode* node, ActionSpecial* g
 		groupname.RemoveLast();	// Remove last '/'
 
 	// --- Set up group default properties ---
+	bool own_shared_args = false;
+	if (!shared_args)
+	{
+		shared_args = new SpecialArgMap();
+		own_shared_args = true;
+	}
+
 	ActionSpecial* as_defaults = new ActionSpecial();
 	if (group_defaults) as_defaults->copy(group_defaults);
-	as_defaults->parse(node);
+	as_defaults->parse(node, shared_args);
 
 	// --- Go through all child nodes ---
 	for (unsigned a = 0; a < node->nChildren(); a++)
@@ -712,7 +719,12 @@ void GameConfiguration::readActionSpecials(ParseTreeNode* node, ActionSpecial* g
 
 		// Check for 'group'
 		if (S_CMPNOCASE(child->getType(), "group"))
-			readActionSpecials(child, as_defaults);
+			readActionSpecials(child, as_defaults, shared_args);
+
+		// Predeclared argument, for action specials that share the same
+		// complex argument
+		else if (S_CMPNOCASE(child->getType(), "arg"))
+			ActionSpecial::parseArg(child, shared_args, (*shared_args)[child->getName()]);
 
 		// Action special
 		else if (S_CMPNOCASE(child->getType(), "special"))
@@ -736,15 +748,13 @@ void GameConfiguration::readActionSpecials(ParseTreeNode* node, ActionSpecial* g
 			action_specials[special].special->copy(as_defaults);
 			action_specials[special].special->group = groupname;
 
-			// Check for simple definition
-			if (child->isLeaf())
-				action_specials[special].special->name = child->getStringValue();
-			else
-				action_specials[special].special->parse(child);	// Extended definition
+			action_specials[special].special->parse(child, shared_args);
 		}
 	}
 
 	delete as_defaults;
+	if (own_shared_args)
+		delete shared_args;
 }
 
 /* GameConfiguration::readThingTypes

--- a/src/GameConfiguration.h
+++ b/src/GameConfiguration.h
@@ -244,7 +244,7 @@ public:
 	void	buildConfig(ArchiveEntry* entry, string& out, bool use_res = true);
 
 	// Configuration reading
-	void	readActionSpecials(ParseTreeNode* node, ActionSpecial* group_defaults = NULL);
+	void	readActionSpecials(ParseTreeNode* node, ActionSpecial* group_defaults = NULL, SpecialArgMap* shared_args = NULL);
 	void	readThingTypes(ParseTreeNode* node, ThingType* group_defaults = NULL);
 	void	readUDMFProperties(ParseTreeNode* node, UDMFPropMap& plist);
 	void	readGameSection(ParseTreeNode* node_game, bool port_section = false);

--- a/src/ThingInfoOverlay.cpp
+++ b/src/ThingInfoOverlay.cpp
@@ -129,7 +129,12 @@ void ThingInfoOverlay::update(MapThing* thing)
 		args[2] = thing->intProperty("arg2");
 		args[3] = thing->intProperty("arg3");
 		args[4] = thing->intProperty("arg4");
-		string argstr = tt->getArgsString(args);
+		string argstr;
+		if (tt->getArgspec().count > 0)
+			argstr = tt->getArgsString(args);
+		else
+			argstr = theGameConfiguration->actionSpecial(as_id)->getArgsString(args);
+
 		if (!argstr.IsEmpty())
 			info_text += S_FMT("%s\n", argstr);
 		else


### PR DESCRIPTION
I added some config syntax for reusing arg definitions, since a number of them are shared between specials, and adding `custom_flags` blocks would've made for a whole lot of copy/paste.  It looks like this:

```
arg foo
{
    name = "Foo";
    type = bar;
}
special 123
{
    name = "Sector_DoThing";
    arg1 = $foo;
}
```

I also added "speed" as an arg type with a slider, and labeled it relative to the Boom generalized speeds — I always have to look them up and they are pretty good milestones.

Then I went on a wild arg-defining spree: speed of floors and doors, crush mode, means of death, and every other flag type I could find where the flags were defined in the arg description.

----

I also moved UDMF flags related to special activation onto the Special tab — I very frequently discover the hard way that I've forgotten to make some door repeatable, because the flag to do so is squirreled away on the General tab.  :)  This also makes them show up in the "trigger" line in the info overlay.

(Incidentally, is there any point to `monsteractivate` in UDMF?  It looks like it exists for the sake of Hexen, where triggers are a three-bit enum rather than a bitmask, so you can't pick more than one?)

----

And finally, when a thing has a special and its type doesn't take arguments, its special's arguments are correctly labeled in the overlay.