### PR TITLE
Actually finish slope support

### DIFF
--- a/src/MapCanvas.cpp
+++ b/src/MapCanvas.cpp
@@ -2622,7 +2622,7 @@ void MapCanvas::editObjectProperties(vector<MapObject*>& list)
 		type = "Thing";
 
 	// Begin recording undo level
-	editor->undoManager()->beginRecord(S_FMT("Property Edit (%s)", type));
+	editor->beginUndoRecord(S_FMT("Property Edit (%s)", type));
 	for (unsigned a = 0; a < list.size(); a++)
 		editor->recordPropertyChangeUndoStep(list[a]);
 
@@ -2630,7 +2630,7 @@ void MapCanvas::editObjectProperties(vector<MapObject*>& list)
 	if (list.size() == 1)
 		type += S_FMT(" #%d", list[0]->getIndex());
 	else if (list.size() > 1)
-		selsize = S_FMT("(%d selected)", list.size());
+		selsize = S_FMT("(%u selected)", list.size());
 
 	// Create dialog for properties panel
 	SDialog dlg(theMapEditor, S_FMT("%s Properties %s", type, selsize), S_FMT("mobjprops_%d", editor->editMode()), -1, -1);
@@ -2669,7 +2669,7 @@ void MapCanvas::editObjectProperties(vector<MapObject*>& list)
 	}
 
 	// End undo level
-	editor->undoManager()->endRecord(true);
+	editor->endUndoRecord(true);
 
 	// Clear property grid to avoid crash (wxPropertyGrid is at fault there)
 	//if (panel_props)

--- a/src/MapEditor.cpp
+++ b/src/MapEditor.cpp
@@ -5020,6 +5020,7 @@ void MapEditor::endUndoRecord(bool success)
 	}
 	updateThingLists();
 	us_create_delete = NULL;
+	map.recomputeSpecials();
 }
 
 /* MapEditor::recordPropertyChangeUndoStep
@@ -5056,7 +5057,7 @@ void MapEditor::doUndo()
 		last_undo_level = "";
 	}
 	updateThingLists();
-	map.expireSpecials();
+	map.recomputeSpecials();
 }
 
 /* MapEditor::doRedo
@@ -5084,7 +5085,7 @@ void MapEditor::doRedo()
 		last_undo_level = "";
 	}
 	updateThingLists();
-	map.expireSpecials();
+	map.recomputeSpecials();
 }
 
 #pragma endregion

--- a/src/MapLine.cpp
+++ b/src/MapLine.cpp
@@ -340,7 +340,6 @@ void MapLine::setIntProperty(string key, int value)
 	{
 		special = value;
 		setModified();
-		parent_map->expireSpecials();
 	}
 
 	// Line property

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -2335,14 +2335,16 @@ void MapRenderer3D::checkVisibleQuads()
 		{
 			// Check front side/sector modified
 			if (lines[a].updated_time < line->s1()->modifiedTime() ||
-			        lines[a].updated_time < line->frontSector()->modifiedTime())
+			        lines[a].updated_time < line->frontSector()->modifiedTime() ||
+			        lines[a].updated_time < line->frontSector()->geometryUpdatedTime())
 				update = true;
 		}
 		if (!update && line->s2())
 		{
 			// Check back side/sector modified
 			if (lines[a].updated_time < line->s2()->modifiedTime() ||
-			        lines[a].updated_time < line->backSector()->modifiedTime())
+			        lines[a].updated_time < line->backSector()->modifiedTime() ||
+			        lines[a].updated_time < line->backSector()->geometryUpdatedTime())
 				update = true;
 		}
 		if (update)
@@ -2405,7 +2407,8 @@ void MapRenderer3D::checkVisibleFlats()
 		}
 
 		// Update sector info if needed
-		if (floors[a].updated_time < sector->modifiedTime())
+		if (floors[a].updated_time < sector->modifiedTime() ||
+			floors[a].updated_time < sector->geometryUpdatedTime())
 			updateSector(a);
 
 		// Set distance fade alpha

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -2468,7 +2468,7 @@ selection_3d_t MapRenderer3D::determineHilight()
 			continue;
 
 		// Find quad intersect if any
-		height = cam_position.z + cam_dir3d.z*dist;
+		fpoint3_t intersection = cam_position + cam_dir3d * dist;
 		for (unsigned q = 0; q < lines[a].quads.size(); q++)
 		{
 			quad = &lines[a].quads[q];
@@ -2478,8 +2478,16 @@ selection_3d_t MapRenderer3D::determineHilight()
 				continue;
 
 			// Check intersection height
-			if ((height >= quad->points[1].z || height >= quad->points[2].z) &&
-				(height <= quad->points[0].z || height <= quad->points[3].z))
+			// Need to handle slopes by finding the floor and ceiling height of
+			// the quad at the intersection point
+			fpoint2_t seg_left = fpoint2_t(quad->points[1].x, quad->points[1].y);
+			fpoint2_t seg_right = fpoint2_t(quad->points[2].x, quad->points[2].y);
+			double dist_along_segment =
+				(intersection.get2d() - seg_left).magnitude() /
+				(seg_right - seg_left).magnitude();
+			double top = quad->points[0].z + (quad->points[3].z - quad->points[0].z) * dist_along_segment;
+			double bottom = quad->points[1].z + (quad->points[2].z - quad->points[1].z) * dist_along_segment;
+			if (bottom <= intersection.z && intersection.z <= top)
 			{
 				// Determine selected item from quad flags
 

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -236,7 +236,6 @@ void MapSector::setFloorHeight(short height)
 	f_height = height;
 	setFloorPlane(plane_t::flat(height));
 	setModified();
-	parent_map->expireSpecials();
 }
 
 void MapSector::setCeilingHeight(short height)
@@ -244,7 +243,6 @@ void MapSector::setCeilingHeight(short height)
 	c_height = height;
 	setCeilingPlane(plane_t::flat(height));
 	setModified();
-	parent_map->expireSpecials();
 }
 
 /* MapLine::getPoint

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -59,7 +59,7 @@ MapSector::MapSector(SLADEMap* parent) : MapObject(MOBJ_SECTOR, parent)
 	plane_floor.set(0, 0, 1, 0);
 	plane_ceiling.set(0, 0, 1, 0);
 	poly_needsupdate = true;
-	geometry_updated = theApp->runTimer();
+	setGeometryUpdated();
 }
 
 /* MapSector::MapSector
@@ -75,7 +75,7 @@ MapSector::MapSector(string f_tex, string c_tex, SLADEMap* parent) : MapObject(M
 	plane_floor.set(0, 0, 1, 0);
 	plane_ceiling.set(0, 0, 1, 0);
 	poly_needsupdate = true;
-	geometry_updated = theApp->runTimer();
+	setGeometryUpdated();
 }
 
 /* MapSector::~MapSector
@@ -124,11 +124,25 @@ void MapSector::copy(MapObject* s)
 	MapObject::copy(s);
 }
 
+/* MapSector::setGeometryUpdated
+ * Update the last time the sector geometry changed
+ *******************************************************************/
+void MapSector::setGeometryUpdated()
+{
+	geometry_updated = theApp->runTimer();
+}
+
+/* MapSector::floorHeightAt
+ * Returns the height of the floor at the given point
+ *******************************************************************/
 double MapSector::floorHeightAt(double x, double y)
 {
 	return plane_floor.height_at(x, y);
 }
 
+/* MapSector::ceilingHeightAt
+ * Returns the height of the ceiling at the given point
+ *******************************************************************/
 double MapSector::ceilingHeightAt(double x, double y)
 {
 	return plane_ceiling.height_at(x, y);
@@ -283,7 +297,7 @@ void MapSector::updateBBox()
 	}
 
 	text_point.set(0, 0);
-	geometry_updated = theApp->runTimer();
+	setGeometryUpdated();
 }
 
 /* MapSector::boundingBox
@@ -652,7 +666,7 @@ void MapSector::connectSide(MapSide* side)
 	poly_needsupdate = true;
 	bbox.reset();
 	setModified();
-	geometry_updated = theApp->runTimer();
+	setGeometryUpdated();
 }
 
 /* MapSector::disconnectSide
@@ -672,7 +686,7 @@ void MapSector::disconnectSide(MapSide* side)
 	setModified();
 	poly_needsupdate = true;
 	bbox.reset();
-	geometry_updated = theApp->runTimer();
+	setGeometryUpdated();
 }
 
 /* MapSector::writeBackup
@@ -713,5 +727,5 @@ void MapSector::readBackup(mobj_backup_t* backup)
 	// Update geometry info
 	poly_needsupdate = true;
 	bbox.reset();
-	geometry_updated = theApp->runTimer();
+	setGeometryUpdated();
 }

--- a/src/MapSector.h
+++ b/src/MapSector.h
@@ -91,16 +91,8 @@ public:
 	void	setIntProperty(string key, int value);
 	void	setFloorHeight(short height);
 	void	setCeilingHeight(short height);
-	void	setFloorPlane(plane_t p) {
-		if (p != plane_floor)
-			setModified();
-		plane_floor = p;
-	}
-	void	setCeilingPlane(plane_t p) {
-		if (p != plane_ceiling)
-			setModified();
-		plane_ceiling = p;
-	}
+	void	setFloorPlane(plane_t p) { plane_floor = p; }
+	void	setCeilingPlane(plane_t p) { plane_ceiling = p; }
 
 	template<PlaneType p> short getPlaneHeight();
 

--- a/src/MapSector.h
+++ b/src/MapSector.h
@@ -62,8 +62,7 @@ private:
 	plane_t				plane_floor;
 	plane_t				plane_ceiling;
 
-	template<PlaneType p>
-	plane_t		computeZDoomPlane();
+	void		setGeometryUpdated();
 
 public:
 	MapSector(SLADEMap* parent = NULL);
@@ -91,8 +90,16 @@ public:
 	void	setIntProperty(string key, int value);
 	void	setFloorHeight(short height);
 	void	setCeilingHeight(short height);
-	void	setFloorPlane(plane_t p) { plane_floor = p; }
-	void	setCeilingPlane(plane_t p) { plane_ceiling = p; }
+	void	setFloorPlane(plane_t p) {
+		if (plane_floor != p)
+			setGeometryUpdated();
+		plane_floor = p;
+	}
+	void	setCeilingPlane(plane_t p) {
+		if (plane_ceiling != p)
+			setGeometryUpdated();
+		plane_ceiling = p;
+	}
 
 	template<PlaneType p> short getPlaneHeight();
 

--- a/src/MapSpecials.cpp
+++ b/src/MapSpecials.cpp
@@ -415,16 +415,47 @@ void MapSpecials::processZDoomSlopes(SLADEMap* map)
 	}
 
 	// Plane_Copy
+	vector<MapSector*> sectors;
 	for (unsigned a = 0; a < map->nLines(); a++)
 	{
 		MapLine* line = map->getLine(a);
 		if (line->getSpecial() != 118)
 			continue;
 
-		// The fifth "share" argument copies from one side of the line to the
-		// other, and takes priority
+		int tag;
 		MapSector* front = line->frontSector();
 		MapSector* back = line->backSector();
+		if ((tag = line->intProperty("arg0")))
+		{
+			sectors.clear();
+			map->getSectorsByTag(tag, sectors);
+			if (sectors.size())
+				front->setFloorPlane(sectors[0]->getFloorPlane());
+		}
+		if ((tag = line->intProperty("arg1")))
+		{
+			sectors.clear();
+			map->getSectorsByTag(tag, sectors);
+			if (sectors.size())
+				front->setCeilingPlane(sectors[0]->getCeilingPlane());
+		}
+		if ((tag = line->intProperty("arg2")))
+		{
+			sectors.clear();
+			map->getSectorsByTag(tag, sectors);
+			if (sectors.size())
+				back->setFloorPlane(sectors[0]->getFloorPlane());
+		}
+		if ((tag = line->intProperty("arg3")))
+		{
+			sectors.clear();
+			map->getSectorsByTag(tag, sectors);
+			if (sectors.size())
+				back->setCeilingPlane(sectors[0]->getCeilingPlane());
+		}
+
+		// The fifth "share" argument copies from one side of the line to the
+		// other
 		if (front && back)
 		{
 			int share = line->intProperty("arg4");
@@ -439,8 +470,6 @@ void MapSpecials::processZDoomSlopes(SLADEMap* map)
 			else if ((share & 12) == 8)
 				front->setCeilingPlane(back->getCeilingPlane());
 		}
-
-		// TODO other args...
 	}
 }
 

--- a/src/MapSpecials.h
+++ b/src/MapSpecials.h
@@ -23,6 +23,8 @@ class MapSpecials
 	template<PlaneType>
 	void	applySectorTiltThing(SLADEMap* map, MapThing* thing);
 	template<PlaneType>
+	void	applyVavoomSlopeThing(SLADEMap* map, MapThing* thing);
+	template<PlaneType>
 	void	applyVertexHeightSlope(MapSector* target, vector<MapVertex*>& vertices);
 
 public:

--- a/src/MapSpecials.h
+++ b/src/MapSpecials.h
@@ -1,9 +1,15 @@
+#include <wx/hashmap.h>
+#include "MapLine.h"
+#include "MapSector.h"
+#include "MapThing.h"
 
 #ifndef __MAP_SPECIALS_H__
 #define __MAP_SPECIALS_H__
 
 class SLADEMap;
 class ArchiveEntry;
+
+WX_DECLARE_HASH_MAP(MapVertex*, double, wxPointerHash, wxPointerEqual, VertexHeightMap);
 
 class MapSpecials
 {
@@ -25,7 +31,7 @@ class MapSpecials
 	template<PlaneType>
 	void	applyVavoomSlopeThing(SLADEMap* map, MapThing* thing);
 	template<PlaneType>
-	void	applyVertexHeightSlope(MapSector* target, vector<MapVertex*>& vertices);
+	void	applyVertexHeightSlope(MapSector* target, vector<MapVertex*>& vertices, VertexHeightMap& heights);
 
 public:
 	void	reset();

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -378,6 +378,7 @@ bool SLADEMap::readMap(Archive::mapdesc_t map)
 	opened_time = theApp->runTimer() + 10;
 
 	initSectorPolygons();
+	recomputeSpecials();
 
 	return ok;
 }
@@ -3978,48 +3979,16 @@ bool SLADEMap::modifiedSince(long since, int type)
 	return false;
 }
 
-/* SLADEMap::beginBulkOperation
- * Indicate that a lot of changes to the map are about to be performed all at
- * once (i.e., without redrawing the UI or returning control to the user).
- * This suspends some operations, such as re-evaluating map specials, until
- * endBulkOperation is called.
+/* SLADEMap::recomputeSpecials
+ * Re-applies all the currently calculated special map properties (currently
+ * this just means ZDoom slopes).
+ * Since this needs to be done anytime the map changes, it's called whenever a
+ * map is read, an undo record ends, or an undo/redo is performed.
  *******************************************************************/
-void SLADEMap::beginBulkOperation()
-{
-	bulk_op_in_progress = true;
-}
-
-/* SLADEMap::endBulkOperation
- * Counterpart to beginBulkOperation.
- *******************************************************************/
-void SLADEMap::endBulkOperation()
-{
-	bulk_op_in_progress = false;
-
-	if (specials_expired)
-	{
-		map_specials.processMapSpecials(this);
-		specials_expired = false;
-	}
-}
-
-/* SLADEMap::expireSpecials
- * Expires all the currently calculated special map properties (currently this
- * just means ZDoom slopes).  They're guaranteed to be recomputed by the next
- * time the user can see or edit the map.
- *******************************************************************/
-void SLADEMap::expireSpecials()
+void SLADEMap::recomputeSpecials()
 {
 	map_specials.reset();
-
-	if (bulk_op_in_progress)
-	{
-		specials_expired = true;
-		return;
-	}
-
 	map_specials.processMapSpecials(this);
-	specials_expired = false;
 }
 
 /* SLADEMap::createVertex

--- a/src/SLADEMap.h
+++ b/src/SLADEMap.h
@@ -55,6 +55,8 @@ private:
 	int					current_format;
 	long				opened_time;
 	MapSpecials			map_specials;
+	bool				bulk_op_in_progress;
+	bool				specials_expired;
 
 	vector<mobj_holder_t>	all_objects;
 	vector<unsigned>		deleted_objects;
@@ -174,7 +176,11 @@ public:
 	void	refreshIndices();
 	bool	readMap(Archive::mapdesc_t map);
 	void	clearMap();
+
 	MapSpecials*	mapSpecials() { return &map_specials; }
+	void			expireSpecials();
+	void			beginBulkOperation();
+	void			endBulkOperation();
 
 	// Map loading
 	bool	readDoomMap(Archive::mapdesc_t map);
@@ -239,7 +245,6 @@ public:
 	bool				isModified();
 	void				setOpenedTime();
 	bool				modifiedSince(long since, int type = -1);
-	void				expireSpecials();
 
 	// Creation
 	MapVertex*	createVertex(double x, double y, double split_dist = -1);

--- a/src/SLADEMap.h
+++ b/src/SLADEMap.h
@@ -55,7 +55,7 @@ private:
 	int					current_format;
 	long				opened_time;
 	MapSpecials			map_specials;
-	bool				bulk_op_in_progress;
+	int					bulk_op_level;
 	bool				specials_expired;
 
 	vector<mobj_holder_t>	all_objects;
@@ -178,9 +178,7 @@ public:
 	void	clearMap();
 
 	MapSpecials*	mapSpecials() { return &map_specials; }
-	void			expireSpecials();
-	void			beginBulkOperation();
-	void			endBulkOperation();
+	void			recomputeSpecials();
 
 	// Map loading
 	bool	readDoomMap(Archive::mapdesc_t map);


### PR DESCRIPTION
I realized there's already a mechanism that marks the end of an edit and the return of control to the user — the undo manager.  So now we just recompute slopes in bulk on map read, on undo/redo, and in `endUndoRecord`.

I timed this on Sunder's MAP14 and it adds about a quarter of a second to every edit on my machine.  Could be improved (indexed blockmap of object positions, perhaps?), but many simple geometry edits on that map take _multiple_ seconds, so.

tl;dr:

- Vavoom slope things, vertex height things, and `Plane_Copy` now work.
- Pasting no longer crashes.
- Opening a map and switching to 3D mode no longer sets it as modified.
- 3D mode should now always highlight the correct wall; previously the cursor could mistakenly think it was pointing at some oddly-shaped sloped walls.

Lingering issues:

- There's no way to discern a missing vertex height from an explicit vertex height of 0.  Not sure how to fix this.
- Slopes in Doom-format maps aren't supported.
- Slope calculation is a little inconsistent about what it considers an error, and will spew them after every edit, but maybe that's okay.
- 3D mode doesn't correctly handle quads whose top and bottom slopes _intersect_, and my clumsy OpenGL flailing has failed to fix this.