### PR TITLE
Fix a bunch of sizing stuff with the action special panels

### DIFF
--- a/src/DirArchive.cpp
+++ b/src/DirArchive.cpp
@@ -233,7 +233,7 @@ bool DirArchive::save(string filename)
 	wxDir dir(this->filename);
 	dir.Traverse(traverser, "", wxDIR_FILES|wxDIR_DIRS);
 	//wxDir::GetAllFiles(this->filename, &files, wxEmptyString, wxDIR_FILES|wxDIR_DIRS);
-	LOG_MESSAGE(2, "GetAllFiles took %dms", theApp->runTimer() - time);
+	LOG_MESSAGE(2, "GetAllFiles took %lums", theApp->runTimer() - time);
 
 	// Check for any files to remove
 	time = theApp->runTimer();

--- a/src/STabCtrl.cpp
+++ b/src/STabCtrl.cpp
@@ -23,3 +23,20 @@ STabCtrl::STabCtrl(wxWindow* parent, bool close_buttons, bool window_list, int h
 STabCtrl::~STabCtrl()
 {
 }
+
+// wxAuiNotebook doesn't automatically set its own minimum size to the minimum
+// size of its contents, so we have to do that for it.  See
+// http://trac.wxwidgets.org/ticket/4698
+wxSize STabCtrl::DoGetBestClientSize() const
+{
+	wxSize ret;
+	for (int i = 0; i < GetPageCount(); i++)
+	{
+		wxWindow* page = GetPage(i);
+		ret.IncTo(page->GetBestSize());
+	}
+
+	ret.IncBy(0, GetTabCtrlHeight());
+
+	return ret;
+}

--- a/src/STabCtrl.h
+++ b/src/STabCtrl.h
@@ -11,6 +11,9 @@ private:
 public:
 	STabCtrl(wxWindow* parent, bool close_buttons = false, bool window_list = false, int height = 24, bool main_tabs = false);
 	~STabCtrl();
+
+protected:
+	wxSize	DoGetBestClientSize() const;
 };
 
 #endif//__S_TAB_CTRL_H__


### PR DESCRIPTION
This fixes #231.  Also, I hate wxWidgets.

Curiously, this same change applied to master results in an archive manager panel that refuses to go any narrower than half the width of my screen _and_ puts the two lists next to each other rather than stacked.  I'm guessing bf6d8e0a is why, but the different orientation baffles me.

From commit, for your convenience:

----

I only barely understand what is going on in most of this but this makes sizing work more better.

- `wxDataViewTreeCtrl`, used to show the list of action specials, doesn't really report a minimum size very well.  I had to manually compute the size of each of the specials' names to get the minimum width correct.

- Sometimes parts of the fancy arg controls (flag names and the like) got cut off.  Needed to explicitly recompute the top-level window's minimum size and resize it.

- `wxAuiNotebook` doesn't report a minimum size at all, which imo is not really very advanced of it.  I added a quick implementation to `STabCtrl` that's just based on the minimum sizes of the panels.

- Several panels in the action special dialog used `SetSizer()` but never set themselves a minimum size; using `SetSizerAndFit()` instead fixes this.  Probably?