### PR TITLE
Added basic level fog preview

### DIFF
--- a/src/MapRenderer3D.h
+++ b/src/MapRenderer3D.h
@@ -42,6 +42,7 @@ public:
 	{
 		gl_vertex_t	points[4];
 		rgba_t		colour;
+		rgba_t		fogcolour;
 		uint8_t		light;
 		GLTexture*	texture;
 		uint8_t		flags;
@@ -88,6 +89,7 @@ public:
 		uint8_t		flags;
 		uint8_t		light;
 		rgba_t		colour;
+		rgba_t		fogcolour;
 		GLTexture*	texture;
 		plane_t		plane;
 		float		alpha;
@@ -141,6 +143,7 @@ public:
 	// -- Rendering --
 	void	setupView(int width, int height);
 	void	setLight(rgba_t& colour, uint8_t light, float alpha = 1.0f);
+	void	setFog(rgba_t &fogcol);
 	void	renderMap();
 	void	renderSkySlice(float top, float bottom, float atop, float abottom, float size, float tx = 0.125f, float ty = 2.0f);
 	void	renderSky();
@@ -189,7 +192,6 @@ private:
 	bool		udmf_zdoom;
 	bool		fullbright;
 	bool		fog;
-	int			last_light;
 	GLTexture*	tex_last;
 	unsigned	n_quads;
 	unsigned	n_flats;

--- a/src/MapRenderer3D.h
+++ b/src/MapRenderer3D.h
@@ -143,7 +143,7 @@ public:
 	// -- Rendering --
 	void	setupView(int width, int height);
 	void	setLight(rgba_t& colour, uint8_t light, float alpha = 1.0f);
-	void	setFog(rgba_t &fogcol);
+	void	setFog(rgba_t &fogcol, uint8_t light);
 	void	renderMap();
 	void	renderSkySlice(float top, float bottom, float atop, float abottom, float size, float tx = 0.125f, float ty = 2.0f);
 	void	renderSky();

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -656,6 +656,31 @@ rgba_t MapSector::getColour(int where, bool fullbright)
 	}
 }
 
+/* MapSector::getColour
+ * Returns the fog colour of the sector
+ *******************************************************************/
+rgba_t MapSector::getFogColour()
+{
+	rgba_t color(0, 0, 0, 0);
+
+	// map specials/scripts
+	if (parent_map->mapSpecials()->tagFadeColoursSet())
+	{
+		if (parent_map->mapSpecials()->getTagFadeColour(tag, &color))
+			return color;
+	}
+
+	// udmf
+	if (parent_map->currentFormat() == MAP_UDMF && S_CMPNOCASE(parent_map->udmfNamespace(), "zdoom"))
+	{
+		int intcol = MapObject::intProperty("fadecolor");
+
+		wxColour wxcol(intcol);
+		color = rgba_t(wxcol.Blue(), wxcol.Green(), wxcol.Red(), 0);
+	}
+	return color;
+}
+
 /* MapSector::connectSide
  * Adds [side] to the list of 'connected sides' (sides that are part
  * of this sector)

--- a/src/MapSector.h
+++ b/src/MapSector.h
@@ -122,6 +122,7 @@ public:
 	uint8_t				getLight(int where = 0);
 	void				changeLight(int amount, int where = 0);
 	rgba_t				getColour(int where = 0, bool fullbright = false);
+	rgba_t				getFogColour();
 	long				geometryUpdatedTime() { return geometry_updated; }
 
 	void	connectSide(MapSide* side);

--- a/src/MapSpecials.h
+++ b/src/MapSpecials.h
@@ -20,6 +20,7 @@ class MapSpecials
 	};
 
 	vector<sector_colour_t> sector_colours;
+	vector<sector_colour_t> sector_fadecolours;
 
 	void	processZDoomSlopes(SLADEMap* map);
 	template<PlaneType>
@@ -40,7 +41,9 @@ public:
 	void	processLineSpecial(MapLine* line);
 
 	bool	getTagColour(int tag, rgba_t* colour);
+	bool	getTagFadeColour(int tag, rgba_t *colour);
 	bool	tagColoursSet();
+	bool	tagFadeColoursSet();
 	void	updateTaggedSectors(SLADEMap* map);
 
 	// ZDoom
@@ -48,6 +51,7 @@ public:
 	void	processZDoomLineSpecial(MapLine* line);
 	void	updateZDoomSector(MapSector* line);
 	void	processACSScripts(ArchiveEntry* entry);
+	void	setModified(SLADEMap *map, int tag);
 };
 
 #endif//__MAP_SPECIALS_H__

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -4045,7 +4045,6 @@ bool SLADEMap::modifiedSince(long since, int type)
  *******************************************************************/
 void SLADEMap::recomputeSpecials()
 {
-	map_specials.reset();
 	map_specials.processMapSpecials(this);
 }
 


### PR DESCRIPTION
What changed:
- Removed default global fog, added custom fog which can be configured from UDMF (fade color) or ACS scripts (Sector_SetFade).
- Fixed some sector/line update issues with color/fog in "checkVisibleFlats".
- Added new CVAR render_fog_distance (default: 1000)

![fog](https://cloud.githubusercontent.com/assets/3750982/10139272/61318a8e-6602-11e5-9747-8a39232af0f6.png)

Fog enabled:
![foge](https://cloud.githubusercontent.com/assets/3750982/10140115/595d2e36-6606-11e5-93fc-af2a99b29a92.png)
Fog disabled:
![fogd](https://cloud.githubusercontent.com/assets/3750982/10140119/5dcca4ce-6606-11e5-940c-e62389e7f759.png)

