### PR TITLE
EntryOperations fix

### DIFF
--- a/src/EntryOperations.cpp
+++ b/src/EntryOperations.cpp
@@ -1231,17 +1231,36 @@ bool EntryOperations::compileACS(ArchiveEntry* entry, bool hexen, ArchiveEntry* 
 	// Execute acc
 	string command = path_acc + " " + opt + " \"" + srcfile + "\" \"" + ofile + "\"";
 	wxArrayString output;
+	wxArrayString errout;
 	theApp->SetTopWindow(parent);
-	wxExecute(command, output, wxEXEC_SYNC);
+	wxExecute(command, output, errout, wxEXEC_SYNC);
 	theApp->SetTopWindow(theMainWindow);
 
 	// Log output
-	theConsole->logMessage("ACC.exe Output:");
+	theConsole->logMessage("ACS compiler output:");
 	string output_log;
-	for (unsigned a = 0; a < output.size(); a++)
+	if (!output.IsEmpty())
 	{
-		theConsole->logMessage(output[a]);
-		output_log += output[a];
+		const char *title1 = "=== Log: ===\n";
+		theConsole->logMessage(title1);
+		output_log += title1;
+		for (unsigned a = 0; a < output.size(); a++)
+		{
+			theConsole->logMessage(output[a]);
+			output_log += output[a];
+		}
+	}
+
+	if (!errout.IsEmpty())
+	{
+		const char *title2 = "\n=== Error log: ===\n";
+		theConsole->logMessage(title2);
+		output_log += title2;
+		for (unsigned a = 0; a < errout.size(); a++)
+		{
+			theConsole->logMessage(errout[a]);
+			output_log += errout[a];
+		}
 	}
 
 	// Delete source file


### PR DESCRIPTION
Print all messages from compiler stderr (and stdout) if acc.err doesn't exists. (prints both to the console by default)

https://github.com/sirjuddington/SLADE/issues/335