### PR TITLE
Use the point types more heavily

### DIFF
--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -372,40 +372,6 @@ void Drawing::drawLineTabbed(fpoint2_t start, fpoint2_t end, double tab, double 
 	glEnd();
 }
 
-/* Drawing::drawLineTabbed
- * Draws a line from [x1,y1] to [x2,y2]
- *******************************************************************/
-void Drawing::drawLineTabbed(double x1, double y1, double x2, double y2, double tab, double tab_max)
-{
-	// Draw line
-	glBegin(GL_LINES);
-	glVertex2d(x1, y1);
-	glVertex2d(x2, y2);
-	glEnd();
-
-	// Calculate midpoint
-	fpoint2_t mid;
-	mid.x = x1 + ((x2 - x1) * 0.5);
-	mid.y = y1 + ((y1 - y1) * 0.5);
-
-	// Calculate tab length
-	fpoint2_t p1(x1, y1);
-	fpoint2_t p2(x2, y2);
-	double tablen = MathStuff::distance(p1, p2) * tab;
-	if (tablen > tab_max) tablen = tab_max;
-	if (tablen < 2) tablen = 2;
-
-	// Calculate tab endpoint
-	fpoint2_t invdir(-(y2 - y1), x2 - x1);
-	invdir.normalize();
-
-	// Draw tab
-	glBegin(GL_LINES);
-	glVertex2d(mid.x, mid.y);
-	glVertex2d(mid.x - invdir.x*tablen, mid.y - invdir.y*tablen);
-	glEnd();
-}
-
 /* Drawing::drawArrow
  * Draws a line from [p1] to [p2] with an arrowhead at the [p1] end.
  * If [twoway] is true, an arrowhead is also drawn at the [p2] end

--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -357,7 +357,7 @@ void Drawing::drawLineTabbed(fpoint2_t start, fpoint2_t end, double tab, double 
 	mid.y = start.y + ((end.y - start.y) * 0.5);
 
 	// Calculate tab length
-	double tablen = MathStuff::distance(start.x, start.y, end.x, end.y) * tab;
+	double tablen = MathStuff::distance(start, end) * tab;
 	if (tablen > tab_max) tablen = tab_max;
 	if (tablen < 2) tablen = 2;
 
@@ -389,7 +389,9 @@ void Drawing::drawLineTabbed(double x1, double y1, double x2, double y2, double 
 	mid.y = y1 + ((y1 - y1) * 0.5);
 
 	// Calculate tab length
-	double tablen = MathStuff::distance(x1, y1, x2, y2) * tab;
+	fpoint2_t p1(x1, y1);
+	fpoint2_t p2(x2, y2);
+	double tablen = MathStuff::distance(p1, p2) * tab;
 	if (tablen > tab_max) tablen = tab_max;
 	if (tablen < 2) tablen = 2;
 

--- a/src/Drawing.h
+++ b/src/Drawing.h
@@ -8,6 +8,8 @@
 
 #include <wx/colour.h>
 
+#include "Structs.h"
+
 class GLTexture;
 class FontManager;
 
@@ -36,7 +38,6 @@ namespace Drawing
 	void drawLine(fpoint2_t start, fpoint2_t end);
 	void drawLine(double x1, double y1, double x2, double y2);
 	void drawLineTabbed(fpoint2_t start, fpoint2_t end, double tab = 0.1, double tab_max = 16);
-	void drawLineTabbed(double x1, double y1, double x2, double y2, double tab = 0.1, double tab_max = 16);
 	void drawArrow(fpoint2_t p1, fpoint2_t p2, rgba_t color = COL_WHITE, bool twoway = false, double arrowhead_angle = 0.7854f, double arrowhead_length = 25.f);
 	void drawRect(fpoint2_t tl, fpoint2_t br);
 	void drawRect(double x1, double y1, double x2, double y2);

--- a/src/InfoOverlay3d.cpp
+++ b/src/InfoOverlay3d.cpp
@@ -442,7 +442,7 @@ void InfoOverlay3D::update(int item_index, int item_type, SLADEMap* map)
 		}
 
 		// Sector
-		int sector = map->sectorAt(thing->xPos(), thing->yPos());
+		int sector = map->sectorAt(thing->point());
 		if (sector >= 0)
 			info2.push_back(S_FMT("In Sector #%d", sector));
 		else

--- a/src/Main.h
+++ b/src/Main.h
@@ -133,4 +133,82 @@ const string MAP_TYPE_NAMES[] = {
 	"Unknown",
 };
 
+// Debug helper type
+#ifdef WXDEBUG
+#include <typeinfo>
+class Debuggable
+{
+	string repr;
+
+public:
+	Debuggable(string v) { repr = v; }
+	Debuggable(const char* v) { repr = v; }
+	Debuggable(int v) { repr = S_FMT("%d", v); }
+	Debuggable(unsigned int v) { repr = S_FMT("%u", v); }
+	Debuggable(long v) { repr = S_FMT("%ld", v); }
+	Debuggable(unsigned long v) { repr = S_FMT("%lu", v); }
+
+	Debuggable(fpoint2_t v) { repr = S_FMT("(%0.6f, %0.6f)", v.x, v.y); }
+	Debuggable(fpoint3_t v) { repr = S_FMT("(%0.6f, %0.6f, %0.6f)", v.x, v.y, v.z); }
+
+	template<typename T>
+	Debuggable(T* v) { repr = Debuggable(*v).repr; }
+
+	template<typename T>
+	Debuggable(vector<T> v) {
+		repr << "{";
+		for (unsigned int a = 0; a < v.size(); a++)
+		{
+			repr << Debuggable(v[a]).get();
+			if (a < v.size() - 1)
+				repr << ", ";
+		}
+		repr << "}";
+	}
+
+	string get() { return this->repr; }
+};
+
+inline void LOG_DEBUG(
+	Debuggable a1 = "",
+	Debuggable a2 = "",
+	Debuggable a3 = "",
+	Debuggable a4 = "",
+	Debuggable a5 = "",
+	Debuggable a6 = "",
+	Debuggable a7 = "",
+	Debuggable a8 = "",
+	Debuggable a9 = "",
+	Debuggable a10 = "",
+	Debuggable a11 = "",
+	Debuggable a12 = ""
+)
+{
+	string message;
+	message << a1.get();
+	message << a2.get();
+	message << a3.get();
+	message << a4.get();
+	message << a5.get();
+	message << a6.get();
+	message << a7.get();
+	message << a8.get();
+	message << a9.get();
+	message << a10.get();
+	message << a11.get();
+	message << a12.get();
+	wxLogMessage("%s", message);
+}
+
+#define LOG_DEBUG_VAR(name) LOG_DEBUG(#name ": ", name)
+#else  // WXDEBUG
+struct Debuggable {
+	string repr;
+};
+#define LOG_DEBUG(...)
+#define LOG_DEBUG_VAR(name)
+#endif  // WXDEBUG
+
+
+
 #endif // __MAIN_H__

--- a/src/MapCanvas.cpp
+++ b/src/MapCanvas.cpp
@@ -930,7 +930,7 @@ void MapCanvas::drawLineDrawLines()
 	if (modifiers_current & wxMOD_SHIFT)
 	{
 		// If shift is held down, snap to the nearest vertex (if any)
-		int vertex = editor->getMap().nearestVertex(end.x, end.y);
+		int vertex = editor->getMap().nearestVertex(end);
 		if (vertex >= 0)
 		{
 			end.x = editor->getMap().getVertex(vertex)->xPos();

--- a/src/MapCanvas.cpp
+++ b/src/MapCanvas.cpp
@@ -3852,7 +3852,7 @@ void MapCanvas::onKeyDown(wxKeyEvent& e)
 			if (line)
 			{
 				// Determine line side
-				double side = MathStuff::lineSide(mouse_pos_m.x, mouse_pos_m.y, line->x1(), line->y1(), line->x2(), line->y2());
+				double side = MathStuff::lineSide(mouse_pos_m, line->seg());
 				if (side >= 0)
 					sbuilder.traceSector(&(editor->getMap()), line, true);
 				else

--- a/src/MapCanvas.cpp
+++ b/src/MapCanvas.cpp
@@ -908,7 +908,7 @@ void MapCanvas::drawLineLength(fpoint2_t p1, fpoint2_t p2, rgba_t col)
 	fpoint2_t tp(mid.x + (vec.x * tdist), mid.y + (vec.y * tdist));
 
 	// Determine text half-height for vertical alignment
-	string length = S_FMT("%d", MathStuff::round(MathStuff::distance(p1.x, p1.y, p2.x, p2.y)));
+	string length = S_FMT("%d", MathStuff::round(MathStuff::distance(p1, p2)));
 	double hh = Drawing::textExtents(length).y * 0.5;
 
 	// Draw text
@@ -1131,7 +1131,7 @@ void MapCanvas::drawObjectEdit()
 	if (group->getNearestLine(mouse_pos_m, 128 / view_scale, nl_v1, nl_v2))
 	{
 		fpoint2_t mid(nl_v1.x + ((nl_v2.x - nl_v1.x) * 0.5), nl_v1.y + ((nl_v2.y - nl_v1.y) * 0.5));
-		int length = MathStuff::distance(nl_v1.x, nl_v1.y, nl_v2.x, nl_v2.y);
+		int length = MathStuff::distance(nl_v1, nl_v2);
 		int x = screenX(mid.x);
 		int y = screenY(mid.y) - 8;
 		setOverlayCoords(true);

--- a/src/MapCanvas.cpp
+++ b/src/MapCanvas.cpp
@@ -511,8 +511,8 @@ void MapCanvas::viewMatchSpot(double mx, double my, double sx, double sy)
 void MapCanvas::set3dCameraThing(MapThing* thing)
 {
 	// Determine position
-	fpoint3_t pos(thing->xPos(), thing->yPos(), 40);
-	int sector = editor->getMap().sectorAt(pos.x, pos.y);
+	fpoint3_t pos(thing->point(), 40);
+	int sector = editor->getMap().sectorAt(thing->point());
 	if (sector >= 0)
 		pos.z += editor->getMap().getSector(sector)->getFloorHeight();
 
@@ -3603,11 +3603,9 @@ bool MapCanvas::handleAction(string id)
 	// Move 3d mode camera
 	else if (id == "mapw_camera_set")
 	{
-		fpoint3_t pos;
-		pos.x = mouse_pos_m.x;
-		pos.y = mouse_pos_m.y;
+		fpoint3_t pos(mouse_pos_m);
 		SLADEMap& map = editor->getMap();
-		MapSector* sector = map.getSector(map.sectorAt(pos.x, pos.y));
+		MapSector* sector = map.getSector(map.sectorAt(mouse_pos_m));
 		if (sector)
 			pos.z = sector->getFloorHeight() + 40;
 		renderer_3d->cameraSetPosition(pos);
@@ -3847,7 +3845,7 @@ void MapCanvas::onKeyDown(wxKeyEvent& e)
 		if (e.GetKeyCode() == WXK_F7)
 		{
 			// Get nearest line
-			int nearest = editor->getMap().nearestLine(mouse_pos_m.x, mouse_pos_m.y, 999999);
+			int nearest = editor->getMap().nearestLine(mouse_pos_m, 999999);
 			MapLine* line = editor->getMap().getLine(nearest);
 			if (line)
 			{
@@ -3862,7 +3860,7 @@ void MapCanvas::onKeyDown(wxKeyEvent& e)
 		if (e.GetKeyCode() == WXK_F5)
 		{
 			// Get nearest line
-			int nearest = editor->getMap().nearestLine(mouse_pos_m.x, mouse_pos_m.y, 999999);
+			int nearest = editor->getMap().nearestLine(mouse_pos_m, 999999);
 			MapLine* line = editor->getMap().getLine(nearest);
 
 			// Get sectors

--- a/src/MapChecks.cpp
+++ b/src/MapChecks.cpp
@@ -1242,7 +1242,7 @@ public:
 			MapLine* line = lines[index];
 
 			// Get nearest line point to thing
-			fpoint2_t np = MathStuff::closestPointOnLine(thing->xPos(), thing->yPos(), line->x1(), line->y1(), line->x2(), line->y2());
+			fpoint2_t np = MathStuff::closestPointOnLine(thing->point(), line->seg());
 
 			// Get distance to move
 			double r = theGameConfiguration->thingType(thing->getType())->getRadius();

--- a/src/MapChecks.cpp
+++ b/src/MapChecks.cpp
@@ -1200,6 +1200,7 @@ public:
 				continue;
 
 			radius = tt->getRadius() - 1;
+			frect_t bbox(thing->xPos(), thing->yPos(), radius * 2, radius * 2, 1);
 
 			// Go through lines
 			for (unsigned b = 0; b < check_lines.size(); b++)
@@ -1207,9 +1208,7 @@ public:
 				line = check_lines[b];
 
 				// Check intersection
-				if (MathStuff::boxLineIntersect(thing->xPos() - radius, thing->yPos() - radius,
-					thing->xPos() + radius, thing->yPos() + radius,
-					line->x1(), line->y1(), line->x2(), line->y2()))
+				if (MathStuff::boxLineIntersect(bbox, line->seg()))
 				{
 					things.push_back(thing);
 					lines.push_back(line);

--- a/src/MapChecks.cpp
+++ b/src/MapChecks.cpp
@@ -1246,7 +1246,7 @@ public:
 
 			// Get distance to move
 			double r = theGameConfiguration->thingType(thing->getType())->getRadius();
-			double dist = MathStuff::distance(0, 0, r, r);
+			double dist = MathStuff::distance(fpoint2_t(), fpoint2_t(r, r));
 
 			editor->beginUndoRecord("Move Thing", true, false, false);
 

--- a/src/MapEditor.cpp
+++ b/src/MapEditor.cpp
@@ -721,7 +721,7 @@ bool MapEditor::updateHilight(fpoint2_t mouse_pos, double dist_scale)
 
 	// Update hilighted object depending on mode
 	if (edit_mode == MODE_VERTICES)
-		hilight_item = map.nearestVertex(mouse_pos.x, mouse_pos.y, 32/dist_scale);
+		hilight_item = map.nearestVertex(mouse_pos, 32/dist_scale);
 	else if (edit_mode == MODE_LINES)
 		hilight_item = map.nearestLine(mouse_pos.x, mouse_pos.y, 32/dist_scale);
 	else if (edit_mode == MODE_SECTORS)
@@ -2876,12 +2876,9 @@ bool MapEditor::addLineDrawPoint(fpoint2_t point, bool nearest)
 	// Snap to nearest vertex if necessary
 	if (nearest)
 	{
-		int vertex = map.nearestVertex(point.x, point.y);
+		int vertex = map.nearestVertex(point);
 		if (vertex >= 0)
-		{
-			point.x = map.getVertex(vertex)->xPos();
-			point.y = map.getVertex(vertex)->yPos();
-		}
+			point = map.getVertex(vertex)->point();
 	}
 
 	// Otherwise, snap to grid if necessary
@@ -2940,12 +2937,9 @@ void MapEditor::setShapeDrawOrigin(fpoint2_t point, bool nearest)
 	// Snap to nearest vertex if necessary
 	if (nearest)
 	{
-		int vertex = map.nearestVertex(point.x, point.y);
+		int vertex = map.nearestVertex(point);
 		if (vertex >= 0)
-		{
-			point.x = map.getVertex(vertex)->xPos();
-			point.y = map.getVertex(vertex)->yPos();
-		}
+			point = map.getVertex(vertex)->point();
 	}
 
 	// Otherwise, snap to grid if necessary

--- a/src/MapEditor.cpp
+++ b/src/MapEditor.cpp
@@ -736,7 +736,7 @@ bool MapEditor::updateHilight(fpoint2_t mouse_pos, double dist_scale)
 		{
 			MapThing* t = map.getThing(nearest[0]);
 			ThingType* type = theGameConfiguration->thingType(t->getType());
-			double dist = MathStuff::distance(mouse_pos.x, mouse_pos.y, t->xPos(), t->yPos());
+			double dist = MathStuff::distance(mouse_pos, t->point());
 			if (dist <= type->getRadius() + (32/dist_scale))
 				hilight_item = nearest[0];
 		}
@@ -746,7 +746,7 @@ bool MapEditor::updateHilight(fpoint2_t mouse_pos, double dist_scale)
 			{
 				MapThing* t = map.getThing(nearest[a]);
 				ThingType* type = theGameConfiguration->thingType(t->getType());
-				double dist = MathStuff::distance(mouse_pos.x, mouse_pos.y, t->xPos(), t->yPos());
+				double dist = MathStuff::distance(mouse_pos, t->point());
 				if (dist <= type->getRadius() + (32/dist_scale))
 					hilight_item = nearest[a];
 			}

--- a/src/MapEditor.cpp
+++ b/src/MapEditor.cpp
@@ -2615,6 +2615,8 @@ void MapEditor::createThing(double x, double y)
  *******************************************************************/
 void MapEditor::createSector(double x, double y)
 {
+	fpoint2_t point(x, y);
+
 	// Find nearest line
 	int nearest = map.nearestLine(x, y, 99999999);
 	MapLine* line = map.getLine(nearest);
@@ -2622,7 +2624,7 @@ void MapEditor::createSector(double x, double y)
 		return;
 
 	// Determine side
-	double side = MathStuff::lineSide(x, y, line->x1(), line->y1(), line->x2(), line->y2());
+	double side = MathStuff::lineSide(point, line->seg());
 
 	// Get sector to copy if we're in sectors mode
 	MapSector* sector_copy = NULL;

--- a/src/MapEditor.cpp
+++ b/src/MapEditor.cpp
@@ -1914,6 +1914,8 @@ void MapEditor::mergeLines(long move_time, vector<fpoint2_t>& merge_points)
  *******************************************************************/
 void MapEditor::splitLine(double x, double y, double min_dist)
 {
+	fpoint2_t point(x, y);
+
 	// Get the closest line
 	int lindex = map.nearestLine(x, y, min_dist);
 	MapLine* line = map.getLine(lindex);
@@ -1926,7 +1928,7 @@ void MapEditor::splitLine(double x, double y, double min_dist)
 	beginUndoRecord("Split Line", true, true, false);
 
 	// Get closest point on the line
-	fpoint2_t closest = MathStuff::closestPointOnLine(x, y, line->x1(), line->y1(), line->x2(), line->y2());
+	fpoint2_t closest = MathStuff::closestPointOnLine(point, line->seg());
 
 	// Create vertex there
 	MapVertex* vertex = map.createVertex(closest.x, closest.y);

--- a/src/MapEditor.cpp
+++ b/src/MapEditor.cpp
@@ -723,15 +723,15 @@ bool MapEditor::updateHilight(fpoint2_t mouse_pos, double dist_scale)
 	if (edit_mode == MODE_VERTICES)
 		hilight_item = map.nearestVertex(mouse_pos, 32/dist_scale);
 	else if (edit_mode == MODE_LINES)
-		hilight_item = map.nearestLine(mouse_pos.x, mouse_pos.y, 32/dist_scale);
+		hilight_item = map.nearestLine(mouse_pos, 32/dist_scale);
 	else if (edit_mode == MODE_SECTORS)
-		hilight_item = map.sectorAt(mouse_pos.x, mouse_pos.y);
+		hilight_item = map.sectorAt(mouse_pos);
 	else if (edit_mode == MODE_THINGS)
 	{
 		hilight_item = -1;
 
 		// Get (possibly multiple) nearest-thing(s)
-		vector<int> nearest = map.nearestThingMulti(mouse_pos.x, mouse_pos.y);
+		vector<int> nearest = map.nearestThingMulti(mouse_pos);
 		if (nearest.size() == 1)
 		{
 			MapThing* t = map.getThing(nearest[0]);
@@ -1917,7 +1917,7 @@ void MapEditor::splitLine(double x, double y, double min_dist)
 	fpoint2_t point(x, y);
 
 	// Get the closest line
-	int lindex = map.nearestLine(x, y, min_dist);
+	int lindex = map.nearestLine(point, min_dist);
 	MapLine* line = map.getLine(lindex);
 
 	// Do nothing if no line is close enough
@@ -2422,7 +2422,9 @@ int MapEditor::beginTagEdit()
  *******************************************************************/
 void MapEditor::tagSectorAt(double x, double y)
 {
-	int index = map.sectorAt(x, y);
+	fpoint2_t point(x, y);
+
+	int index = map.sectorAt(point);
 	if (index < 0)
 		return;
 
@@ -2620,7 +2622,7 @@ void MapEditor::createSector(double x, double y)
 	fpoint2_t point(x, y);
 
 	// Find nearest line
-	int nearest = map.nearestLine(x, y, 99999999);
+	int nearest = map.nearestLine(point, 99999999);
 	MapLine* line = map.getLine(nearest);
 	if (!line)
 		return;
@@ -5237,7 +5239,7 @@ CONSOLE_COMMAND(m_test_sector, 0, false)
 	sf::Clock clock;
 	SLADEMap& map = theMapEditor->mapEditor().getMap();
 	for (unsigned a = 0; a < map.nThings(); a++)
-		map.sectorAt(map.getThing(a)->xPos(), map.getThing(a)->yPos());
+		map.sectorAt(map.getThing(a)->point());
 	long ms = clock.getElapsedTime().asMilliseconds();
 	wxLogMessage("Took %ldms", ms);
 }

--- a/src/MapLine.cpp
+++ b/src/MapLine.cpp
@@ -435,6 +435,22 @@ fpoint2_t MapLine::getPoint(uint8_t point)
 		return fpoint2_t(x1() + ((x2() - x1()) * 0.5), y1() + ((y2() - y1()) * 0.5));
 }
 
+/* MapLine::point1
+ * Returns the point at the first vertex.
+ *******************************************************************/
+fpoint2_t MapLine::point1()
+{
+	return vertex1->getPoint(0);
+}
+
+/* MapLine::point2
+ * Returns the point at the first vertex.
+ *******************************************************************/
+fpoint2_t MapLine::point2()
+{
+	return vertex2->getPoint(0);
+}
+
 /* MapLine::getLength
  * Returns the length of the line
  *******************************************************************/

--- a/src/MapLine.cpp
+++ b/src/MapLine.cpp
@@ -432,7 +432,7 @@ void MapLine::setS2(MapSide* side)
 fpoint2_t MapLine::getPoint(uint8_t point)
 {
 	//if (point == MOBJ_POINT_MID || point == MOBJ_POINT_WITHIN)
-		return fpoint2_t(x1() + ((x2() - x1()) * 0.5), y1() + ((y2() - y1()) * 0.5));
+	return (point1() + point2()) * 0.5;
 }
 
 /* MapLine::point1
@@ -440,15 +440,23 @@ fpoint2_t MapLine::getPoint(uint8_t point)
  *******************************************************************/
 fpoint2_t MapLine::point1()
 {
-	return vertex1->getPoint(0);
+	return vertex1->point();
 }
 
 /* MapLine::point2
- * Returns the point at the first vertex.
+ * Returns the point at the second vertex.
  *******************************************************************/
 fpoint2_t MapLine::point2()
 {
-	return vertex2->getPoint(0);
+	return vertex2->point();
+}
+
+/* MapLine::seg
+ * Returns this line as a segment.
+ *******************************************************************/
+fseg2_t MapLine::seg()
+{
+	return fseg2_t(vertex1->point(), vertex2->point());
 }
 
 /* MapLine::getLength

--- a/src/MapLine.cpp
+++ b/src/MapLine.cpp
@@ -469,7 +469,7 @@ double MapLine::getLength()
 
 	if (length < 0)
 	{
-		length = MathStuff::distance(vertex1->xPos(), vertex1->yPos(), vertex2->xPos(), vertex2->yPos());
+		length = this->seg().length();
 		ca = (vertex2->xPos() - vertex1->xPos()) / length;
 		sa = (vertex2->yPos() - vertex1->yPos()) / length;
 	}
@@ -534,7 +534,7 @@ double MapLine::distanceTo(double x, double y)
 	// Update length data if needed
 	if (length < 0)
 	{
-		length = MathStuff::distance(vertex1->xPos(), vertex1->yPos(), vertex2->xPos(), vertex2->yPos());
+		length = this->seg().length();
 		if (length != 0)
 		{
 			ca = (vertex2->xPos() - vertex1->xPos()) / length;

--- a/src/MapLine.cpp
+++ b/src/MapLine.cpp
@@ -527,9 +527,9 @@ fpoint2_t MapLine::dirTabPoint(double tablen)
 }
 
 /* MapLine::distanceTo
- * Returns the minimum distance from [x, y] to the line
+ * Returns the minimum distance from the point to the line
  *******************************************************************/
-double MapLine::distanceTo(double x, double y)
+double MapLine::distanceTo(fpoint2_t point)
 {
 	// Update length data if needed
 	if (length < 0)
@@ -544,14 +544,14 @@ double MapLine::distanceTo(double x, double y)
 
 	// Calculate intersection point
 	double mx, ix, iy;
-	mx = (-vertex1->xPos()+x)*ca + (-vertex1->yPos()+y)*sa;
+	mx = (-vertex1->xPos()+point.x)*ca + (-vertex1->yPos()+point.y)*sa;
 	if (mx <= 0)		mx = 0.00001;				// Clip intersection to line (but not exactly on endpoints)
 	else if (mx >= length)	mx = length - 0.00001;	// ^^
 	ix = vertex1->xPos() + mx*ca;
 	iy = vertex1->yPos() + mx*sa;
 
 	// Calculate distance to line
-	return sqrt((ix-x)*(ix-x) + (iy-y)*(iy-y));
+	return sqrt((ix-point.x)*(ix-point.x) + (iy-point.y)*(iy-point.y));
 }
 
 // Minimum gap between planes for a texture to be considered missing

--- a/src/MapLine.h
+++ b/src/MapLine.h
@@ -125,6 +125,8 @@ public:
 	void	writeBackup(mobj_backup_t* backup);
 	void	readBackup(mobj_backup_t* backup);
 	void	copy(MapObject*);
+
+	operator Debuggable() const { return Debuggable(S_FMT("<line %u>", index)); }
 };
 
 #endif //__MAPLINE_H__

--- a/src/MapLine.h
+++ b/src/MapLine.h
@@ -109,6 +109,8 @@ public:
 	void	setS2(MapSide* side);
 
 	fpoint2_t	getPoint(uint8_t point);
+	fpoint2_t	point1();
+	fpoint2_t	point2();
 	double		getLength();
 	bool		doubleSector();
 	fpoint2_t	frontVector();

--- a/src/MapLine.h
+++ b/src/MapLine.h
@@ -116,7 +116,7 @@ public:
 	bool		doubleSector();
 	fpoint2_t	frontVector();
 	fpoint2_t	dirTabPoint(double length = 0);
-	double		distanceTo(double x, double y);
+	double		distanceTo(fpoint2_t point);
 	int			needsTexture();
 	void		clearUnneededTextures();
 

--- a/src/MapLine.h
+++ b/src/MapLine.h
@@ -111,6 +111,7 @@ public:
 	fpoint2_t	getPoint(uint8_t point);
 	fpoint2_t	point1();
 	fpoint2_t	point2();
+	fseg2_t		seg();
 	double		getLength();
 	bool		doubleSector();
 	fpoint2_t	frontVector();

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -1916,7 +1916,7 @@ void MapRenderer3D::renderThings()
 		}
 
 		// Check thing distance if needed
-		dist = MathStuff::distance(cam_position.x, cam_position.y, thing->xPos(), thing->yPos());
+		dist = MathStuff::distance(cam_position.get2d(), thing->point());
 		if (mdist > 0 && dist > mdist)
 			continue;
 

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -357,12 +357,12 @@ void MapRenderer3D::cameraUpdateVectors()
 	cam_direction.normalize();
 
 	// Calculate strafe vector
-	cam_strafe = fpoint3_t(cam_direction.x, cam_direction.y, 0).cross(fpoint3_t(0, 0, 1));
-	cam_strafe = cam_strafe.normalize();
+	cam_strafe = fpoint3_t(cam_direction, 0).cross(fpoint3_t(0, 0, 1));
+	cam_strafe.normalize();
 
 	// Calculate 3d direction vector
-	cam_dir3d = MathStuff::rotateVector3D(fpoint3_t(cam_direction.x, cam_direction.y, 0), cam_strafe, cam_pitch);
-	cam_dir3d = cam_dir3d.normalize();
+	cam_dir3d = MathStuff::rotateVector3D(fpoint3_t(cam_direction, 0), cam_strafe, cam_pitch);
+	cam_dir3d.normalize();
 }
 
 /* MapRenderer3D::cameraSet
@@ -442,7 +442,7 @@ void MapRenderer3D::setupView(int width, int height)
 	glLoadIdentity();
 
 	// Calculate up vector
-	fpoint3_t up = cam_strafe.cross(cam_dir3d).normalize();
+	fpoint3_t up = cam_strafe.cross(cam_dir3d).normalized();
 
 	// Setup camera view
 	gluLookAt(cam_position.x, cam_position.y, cam_position.z,

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -2294,10 +2294,9 @@ void MapRenderer3D::quickVisDiscard()
 		dist_sectors.resize(map->nSectors());
 
 	// Go through all sectors
-	double x = cam_position.x;
-	double y = cam_position.y;
+	fpoint2_t cam = cam_position.get2d();
 	double min_dist, dist;
-	fseg2_t strafe(cam_position.get2d(), (cam_position + cam_strafe).get2d());
+	fseg2_t strafe(cam, cam + cam_strafe.get2d());
 	for (unsigned a = 0; a < map->nSectors(); a++)
 	{
 		// Get sector bbox
@@ -2307,7 +2306,7 @@ void MapRenderer3D::quickVisDiscard()
 		dist_sectors[a] = 0.0f;
 
 		// Check if within bbox
-		if (bbox.point_within(x, y))
+		if (bbox.contains(cam))
 			continue;
 
 		// Check side of camera
@@ -2328,13 +2327,13 @@ void MapRenderer3D::quickVisDiscard()
 		if (render_max_dist > 0)
 		{
 			min_dist = 9999999;
-			dist = MathStuff::distanceToLine(x, y, bbox.min.x, bbox.min.y, bbox.min.x, bbox.max.y);
+			dist = MathStuff::distanceToLine(cam, bbox.left_side());
 			if (dist < min_dist) min_dist = dist;
-			dist = MathStuff::distanceToLine(x, y, bbox.min.x, bbox.max.y, bbox.max.x, bbox.max.y);
+			dist = MathStuff::distanceToLine(cam, bbox.top_side());
 			if (dist < min_dist) min_dist = dist;
-			dist = MathStuff::distanceToLine(x, y, bbox.max.x, bbox.max.y, bbox.max.x, bbox.min.y);
+			dist = MathStuff::distanceToLine(cam, bbox.right_side());
 			if (dist < min_dist) min_dist = dist;
-			dist = MathStuff::distanceToLine(x, y, bbox.max.x, bbox.min.y, bbox.min.x, bbox.min.y);
+			dist = MathStuff::distanceToLine(cam, bbox.bottom_side());
 			if (dist < min_dist) min_dist = dist;
 
 			dist_sectors[a] = dist;
@@ -2402,7 +2401,7 @@ void MapRenderer3D::checkVisibleQuads()
 
 		// Check for distance fade
 		if (render_max_dist > 0)
-			distfade = calcDistFade(MathStuff::distanceToLine(cam_position.x, cam_position.y, line->x1(), line->y1(), line->x2(), line->y2()), render_max_dist);
+			distfade = calcDistFade(MathStuff::distanceToLine(cam_position.get2d(), line->seg()), render_max_dist);
 		else
 			distfade = 1.0f;
 

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -399,8 +399,8 @@ void MapRenderer3D::cameraApplyGravity(double mult)
 
 	// Get target height
 	int view_height = (map->currentFormat() == MAP_DOOM64) ? 56 : 41;
-	int fheight = map->getSector(sector)->floorHeightAt(cam_position.x, cam_position.y) + view_height;
-	int cheight = map->getSector(sector)->ceilingHeightAt(cam_position.x, cam_position.y);
+	int fheight = map->getSector(sector)->getFloorPlane().height_at(cam_position.get2d()) + view_height;
+	int cheight = map->getSector(sector)->getCeilingPlane().height_at(cam_position.get2d());
 	if (fheight > cheight - 4)
 		fheight = cheight - 4;
 

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -1902,7 +1902,7 @@ void MapRenderer3D::renderThings()
 	uint8_t light;
 	float x1, y1, x2, y2;
 	unsigned update = 0;
-	fpoint2_t strafe(cam_position.x + cam_strafe.x, cam_position.y + cam_strafe.y);
+	fseg2_t strafe(cam_position.get2d(), (cam_position + cam_strafe).get2d());
 	for (unsigned a = 0; a < map->nThings(); a++)
 	{
 		MapThing* thing = map->getThing(a);
@@ -1911,7 +1911,7 @@ void MapRenderer3D::renderThings()
 		// Check side of camera
 		if (cam_pitch > -0.9 && cam_pitch < 0.9)
 		{
-			if (MathStuff::lineSide(thing->xPos(), thing->yPos(), cam_position.x, cam_position.y, strafe.x, strafe.y) > 0)
+			if (MathStuff::lineSide(thing->point(), strafe) > 0)
 				continue;
 		}
 
@@ -2297,7 +2297,7 @@ void MapRenderer3D::quickVisDiscard()
 	double x = cam_position.x;
 	double y = cam_position.y;
 	double min_dist, dist;
-	fpoint2_t strafe(x + cam_strafe.x, y + cam_strafe.y);
+	fseg2_t strafe(cam_position.get2d(), (cam_position + cam_strafe).get2d());
 	for (unsigned a = 0; a < map->nSectors(); a++)
 	{
 		// Get sector bbox
@@ -2313,10 +2313,10 @@ void MapRenderer3D::quickVisDiscard()
 		// Check side of camera
 		if (cam_pitch > -0.9 && cam_pitch < 0.9)
 		{
-			if (MathStuff::lineSide(bbox.min.x, bbox.min.y, x, y, strafe.x, strafe.y) > 0 &&
-			        MathStuff::lineSide(bbox.max.x, bbox.min.y, x, y, strafe.x, strafe.y) > 0 &&
-			        MathStuff::lineSide(bbox.max.x, bbox.max.y, x, y, strafe.x, strafe.y) > 0 &&
-			        MathStuff::lineSide(bbox.min.x, bbox.max.y, x, y, strafe.x, strafe.y) > 0)
+			if (MathStuff::lineSide(bbox.min, strafe) > 0 &&
+			        MathStuff::lineSide(fpoint2_t(bbox.max.x, bbox.min.y), strafe) > 0 &&
+			        MathStuff::lineSide(bbox.max, strafe) > 0 &&
+			        MathStuff::lineSide(fpoint2_t(bbox.min.x, bbox.max.y), strafe) > 0)
 			{
 				// Behind camera, invisible
 				dist_sectors[a] = -1.0f;
@@ -2383,7 +2383,7 @@ void MapRenderer3D::checkVisibleQuads()
 	n_quads = 0;
 	unsigned updates = 0;
 	bool update = false;
-	fpoint2_t strafe(cam_position.x+cam_strafe.x, cam_position.y+cam_strafe.y);
+	fseg2_t strafe(cam_position.get2d(), (cam_position + cam_strafe).get2d());
 	for (unsigned a = 0; a < lines.size(); a++)
 	{
 		line = map->getLine(a);
@@ -2395,8 +2395,8 @@ void MapRenderer3D::checkVisibleQuads()
 		// Check side of camera
 		if (cam_pitch > -0.9 && cam_pitch < 0.9)
 		{
-			if (MathStuff::lineSide(line->x1(), line->y1(), cam_position.x, cam_position.y, strafe.x, strafe.y) > 0 &&
-			        MathStuff::lineSide(line->x2(), line->y2(), cam_position.x, cam_position.y, strafe.x, strafe.y) > 0)
+			if (MathStuff::lineSide(line->point1(), strafe) > 0 &&
+			        MathStuff::lineSide(line->point2(), strafe) > 0)
 				continue;
 		}
 
@@ -2442,7 +2442,7 @@ void MapRenderer3D::checkVisibleQuads()
 		{
 			// Check we're on the right side of the quad
 			quad = &(lines[a].quads[q]);
-			if (MathStuff::lineSide(cam_position.x, cam_position.y, quad->points[0].x, quad->points[0].y, quad->points[2].x, quad->points[2].y) < 0)
+			if (MathStuff::lineSide(cam_position.get2d(), fseg2_t(quad->points[0].x, quad->points[0].y, quad->points[2].x, quad->points[2].y)) < 0)
 				continue;
 
 			quads[n_quads] = quad;
@@ -2528,7 +2528,7 @@ selection_3d_t MapRenderer3D::determineHilight()
 	// Init
 	double min_dist = 9999999;
 	selection_3d_t current;
-	fpoint2_t strafe(cam_position.x+cam_strafe.x, cam_position.y+cam_strafe.y);
+	fseg2_t strafe(cam_position.get2d(), (cam_position + cam_strafe).get2d());
 
 	// Check for required map structures
 	if (!map || lines.size() != map->nLines() ||
@@ -2563,7 +2563,7 @@ selection_3d_t MapRenderer3D::determineHilight()
 			quad = &lines[a].quads[q];
 
 			// Check side of camera
-			if (MathStuff::lineSide(cam_position.x, cam_position.y, quad->points[0].x, quad->points[0].y, quad->points[2].x, quad->points[2].y) < 0)
+			if (MathStuff::lineSide(cam_position.get2d(), fseg2_t(quad->points[0].x, quad->points[0].y, quad->points[2].x, quad->points[2].y)) < 0)
 				continue;
 
 			// Check intersection height
@@ -2659,7 +2659,7 @@ selection_3d_t MapRenderer3D::determineHilight()
 
 		// Ignore if not visible
 		MapThing* thing = map->getThing(a);
-		if (MathStuff::lineSide(thing->xPos(), thing->yPos(), cam_position.x, cam_position.y, strafe.x, strafe.y) > 0)
+		if (MathStuff::lineSide(thing->point(), strafe) > 0)
 			continue;
 
 		// Ignore if not shown

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -2548,9 +2548,9 @@ selection_3d_t MapRenderer3D::determineHilight()
 		MapLine* line = map->getLine(a);
 
 		// Find (2d) distance to line
-		dist = MathStuff::distanceRayLine(fpoint2_t(cam_position.x, cam_position.y),
-		                                  fpoint2_t(cam_position.x+cam_dir3d.x, cam_position.y+cam_dir3d.y),
-		                                  line->x1(), line->y1(), line->x2(), line->y2());
+		dist = MathStuff::distanceRayLine(
+			cam_position.get2d(), (cam_position + cam_dir3d).get2d(),
+			line->point1(), line->point2());
 
 		// Ignore if no intersection or something was closer
 		if (dist < 0 || dist >= min_dist)
@@ -2670,10 +2670,9 @@ selection_3d_t MapRenderer3D::determineHilight()
 		halfwidth = things[a].sprite->getWidth() * 0.5;
 		if (things[a].flags & ICON)
 			halfwidth = render_thing_icon_size*0.5;
-		dist = MathStuff::distanceRayLine(fpoint2_t(cam_position.x, cam_position.y),
-		                                  fpoint2_t(cam_position.x+cam_dir3d.x, cam_position.y+cam_dir3d.y),
-		                                  thing->xPos() - cam_strafe.x * halfwidth, thing->yPos() - cam_strafe.y * halfwidth,
-		                                  thing->xPos() + cam_strafe.x * halfwidth, thing->yPos() + cam_strafe.y * halfwidth);
+		dist = MathStuff::distanceRayLine(
+			cam_position.get2d(), (cam_position + cam_dir3d).get2d(),
+			thing->point() - cam_strafe.get2d() * halfwidth, thing->point() + cam_strafe.get2d() * halfwidth);
 
 		// Ignore if no intersection or something was closer
 		if (dist < 0 || dist >= min_dist)

--- a/src/MapRenderer3D.cpp
+++ b/src/MapRenderer3D.cpp
@@ -393,7 +393,7 @@ void MapRenderer3D::cameraSetPosition(fpoint3_t position)
 void MapRenderer3D::cameraApplyGravity(double mult)
 {
 	// Get current sector
-	int sector = map->sectorAt(cam_position.x, cam_position.y);
+	int sector = map->sectorAt(cam_position.get2d());
 	if (sector < 0)
 		return;
 
@@ -1828,7 +1828,7 @@ void MapRenderer3D::updateThing(unsigned index, MapThing* thing)
 
 	// Setup thing info
 	things[index].type = theGameConfiguration->thingType(thing->getType());
-	things[index].sector = map->getSector(map->sectorAt(thing->xPos(), thing->yPos()));
+	things[index].sector = map->getSector(map->sectorAt(thing->point()));
 
 	// Get sprite texture
 	uint32_t theight = render_thing_icon_size;
@@ -2464,6 +2464,7 @@ void MapRenderer3D::checkVisibleFlats()
 	MapSector* sector;
 	n_flats = 0;
 	float alpha;
+	fpoint2_t cam = cam_position.get2d();
 	for (unsigned a = 0; a < map->nSectors(); a++)
 	{
 		sector = map->getSector(a);
@@ -2478,8 +2479,8 @@ void MapRenderer3D::checkVisibleFlats()
 			if (dist_sectors[a] > render_max_dist)
 				continue;
 			// Double-check distance
-			dist_sectors[a] = sector->distanceTo(cam_position.x, cam_position.y, render_max_dist);
-			if (dist_sectors[a] > render_max_dist && !sector->boundingBox().point_within(cam_position.x, cam_position.y))
+			dist_sectors[a] = sector->distanceTo(cam, render_max_dist);
+			if (dist_sectors[a] > render_max_dist && !sector->boundingBox().contains(cam))
 			{
 				dist_sectors[a] = -1;
 				continue;
@@ -2613,7 +2614,7 @@ selection_3d_t MapRenderer3D::determineHilight()
 			if (cam_position.z > floors[a].plane.height_at(cam_position.x, cam_position.y))
 			{
 				// Check if intersection is within sector
-				if (map->getSector(a)->isWithin(cam_position.x + cam_dir3d.x*dist, cam_position.y + cam_dir3d.y*dist))
+				if (map->getSector(a)->isWithin((cam_position + cam_dir3d * dist).get2d()))
 				{
 					current.index = a;
 					current.type = MapEditor::SEL_FLOOR;
@@ -2630,7 +2631,7 @@ selection_3d_t MapRenderer3D::determineHilight()
 			if (cam_position.z < ceilings[a].plane.height_at(cam_position.x, cam_position.y))
 			{
 				// Check if intersection is within sector
-				if (map->getSector(a)->isWithin(cam_position.x + cam_dir3d.x*dist, cam_position.y + cam_dir3d.y*dist))
+				if (map->getSector(a)->isWithin((cam_position + cam_dir3d * dist).get2d()))
 				{
 					current.index = a;
 					current.type = MapEditor::SEL_CEILING;

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -365,6 +365,8 @@ bool MapSector::isWithin(double x, double y)
  *******************************************************************/
 double MapSector::distanceTo(double x, double y, double maxdist)
 {
+	fpoint2_t point(x, y);
+
 	// Init
 	if (maxdist < 0)
 		maxdist = 9999999;
@@ -373,13 +375,13 @@ double MapSector::distanceTo(double x, double y, double maxdist)
 	if (!bbox.is_valid())
 		updateBBox();
 	double min_dist = 9999999;
-	double dist = MathStuff::distanceToLine(x, y, bbox.min.x, bbox.min.y, bbox.min.x, bbox.max.y);
+	double dist = MathStuff::distanceToLine(point, bbox.left_side());
 	if (dist < min_dist) min_dist = dist;
-	dist = MathStuff::distanceToLine(x, y, bbox.min.x, bbox.max.y, bbox.max.x, bbox.max.y);
+	dist = MathStuff::distanceToLine(point, bbox.top_side());
 	if (dist < min_dist) min_dist = dist;
-	dist = MathStuff::distanceToLine(x, y, bbox.max.x, bbox.max.y, bbox.max.x, bbox.min.y);
+	dist = MathStuff::distanceToLine(point, bbox.right_side());
 	if (dist < min_dist) min_dist = dist;
-	dist = MathStuff::distanceToLine(x, y, bbox.max.x, bbox.min.y, bbox.min.x, bbox.min.y);
+	dist = MathStuff::distanceToLine(point, bbox.bottom_side());
 	if (dist < min_dist) min_dist = dist;
 
 	if (min_dist > maxdist && !bbox.point_within(x, y))

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -315,6 +315,8 @@ Polygon2D* MapSector::getPolygon()
  *******************************************************************/
 bool MapSector::isWithin(double x, double y)
 {
+	fpoint2_t point(x, y);
+
 	// Check with bbox first
 	if (!boundingBox().point_within(x, y))
 		return false;
@@ -348,7 +350,7 @@ bool MapSector::isWithin(double x, double y)
 		return false;
 
 	// Check the side of the nearest line
-	double side = MathStuff::lineSide(x, y, nline->x1(), nline->y1(), nline->x2(), nline->y2());
+	double side = MathStuff::lineSide(point, nline->seg());
 	if (side >= 0 && nline->frontSector() == this)
 		return true;
 	else if (side < 0 && nline->backSector() == this)

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -311,14 +311,12 @@ Polygon2D* MapSector::getPolygon()
 }
 
 /* MapSector::isWithin
- * Returns true if the point [x, y] is inside the sector
+ * Returns true if the point is inside the sector
  *******************************************************************/
-bool MapSector::isWithin(double x, double y)
+bool MapSector::isWithin(fpoint2_t point)
 {
-	fpoint2_t point(x, y);
-
 	// Check with bbox first
-	if (!boundingBox().point_within(x, y))
+	if (!boundingBox().contains(point))
 		return false;
 
 	// Find nearest line in the sector
@@ -335,7 +333,7 @@ bool MapSector::isWithin(double x, double y)
 		//	LOG_MESSAGE(3, "Warning: connected side #%i has a NULL pointer parent line!", connected_sides[a]->getIndex());
 		//	continue;
 		//}
-		dist = connected_sides[a]->getParentLine()->distanceTo(x, y);
+		dist = connected_sides[a]->getParentLine()->distanceTo(point);
 
 		// Check distance
 		if (dist < min_dist)
@@ -360,13 +358,11 @@ bool MapSector::isWithin(double x, double y)
 }
 
 /* MapSector::distanceTo
- * Returns the minimum distance from [x, y] to the closest line in
+ * Returns the minimum distance from the point to the closest line in
  * the sector
  *******************************************************************/
-double MapSector::distanceTo(double x, double y, double maxdist)
+double MapSector::distanceTo(fpoint2_t point, double maxdist)
 {
-	fpoint2_t point(x, y);
-
 	// Init
 	if (maxdist < 0)
 		maxdist = 9999999;
@@ -384,7 +380,7 @@ double MapSector::distanceTo(double x, double y, double maxdist)
 	dist = MathStuff::distanceToLine(point, bbox.bottom_side());
 	if (dist < min_dist) min_dist = dist;
 
-	if (min_dist > maxdist && !bbox.point_within(x, y))
+	if (min_dist > maxdist && !bbox.contains(point))
 		return -1;
 
 	// Go through connected sides
@@ -395,7 +391,7 @@ double MapSector::distanceTo(double x, double y, double maxdist)
 		if (!line) continue;
 
 		// Check distance
-		dist = line->distanceTo(x, y);
+		dist = line->distanceTo(point);
 		if (dist < min_dist)
 			min_dist = dist;
 	}

--- a/src/MapSector.cpp
+++ b/src/MapSector.cpp
@@ -132,22 +132,6 @@ void MapSector::setGeometryUpdated()
 	geometry_updated = theApp->runTimer();
 }
 
-/* MapSector::floorHeightAt
- * Returns the height of the floor at the given point
- *******************************************************************/
-double MapSector::floorHeightAt(double x, double y)
-{
-	return plane_floor.height_at(x, y);
-}
-
-/* MapSector::ceilingHeightAt
- * Returns the height of the ceiling at the given point
- *******************************************************************/
-double MapSector::ceilingHeightAt(double x, double y)
-{
-	return plane_ceiling.height_at(x, y);
-}
-
 /* MapSector::stringProperty
  * Returns the value of the string property matching [key]
  *******************************************************************/

--- a/src/MapSector.h
+++ b/src/MapSector.h
@@ -112,8 +112,8 @@ public:
 	vector<MapSide*>&	connectedSides() { return connected_sides; }
 	void				resetPolygon() { poly_needsupdate = true; }
 	Polygon2D*			getPolygon();
-	bool				isWithin(double x, double y);
-	double				distanceTo(double x, double y, double maxdist = -1);
+	bool				isWithin(fpoint2_t point);
+	double				distanceTo(fpoint2_t point, double maxdist = -1);
 	bool				getLines(vector<MapLine*>& list);
 	bool				getVertices(vector<MapVertex*>& list);
 	bool				getVertices(vector<MapObject*>& list);

--- a/src/MapSector.h
+++ b/src/MapSector.h
@@ -130,6 +130,8 @@ public:
 
 	void	writeBackup(mobj_backup_t* backup);
 	void	readBackup(mobj_backup_t* backup);
+
+	operator Debuggable() const { return Debuggable(S_FMT("<sector %u>", index)); }
 };
 
 // Note: these MUST be inline, or the linker will complain

--- a/src/MapSector.h
+++ b/src/MapSector.h
@@ -80,8 +80,6 @@ public:
 	short		getTag() { return tag; }
 	plane_t		getFloorPlane() { return plane_floor; }
 	plane_t		getCeilingPlane() { return plane_ceiling; }
-	double		floorHeightAt(double x, double y);
-	double		ceilingHeightAt(double x, double y);
 
 	string	stringProperty(string key);
 	int		intProperty(string key);

--- a/src/MapSpecials.cpp
+++ b/src/MapSpecials.cpp
@@ -722,16 +722,16 @@ void MapSpecials::applyVavoomSlopeThing(SLADEMap* map, MapThing* thing)
 		// Vavoom things use the plane defined by the thing and its two
 		// endpoints, based on the sector's original (flat) plane and treating
 		// the thing's height as absolute
-		short height = target->getPlaneHeight<p>();
-		fpoint3_t p1(thing->point(), thing->floatProperty("height"));
-		fpoint3_t p2(lines[a]->point1(), height);
-		fpoint3_t p3(lines[a]->point2(), height);
-
-		if (MathStuff::distanceToLineFast(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y) == 0)
+		if (MathStuff::distanceToLineFast(thing->point(), lines[a]->seg()) == 0)
 		{
 			LOG_MESSAGE(1, "Vavoom thing %d lies directly on its target line %d", thing->getIndex(), a);
 			return;
 		}
+
+		short height = target->getPlaneHeight<p>();
+		fpoint3_t p1(thing->point(), thing->floatProperty("height"));
+		fpoint3_t p2(lines[a]->point1(), height);
+		fpoint3_t p3(lines[a]->point2(), height);
 
 		target->setPlane<p>(MathStuff::planeFromTriangle(p1, p2, p3));
 		return;

--- a/src/MapSpecials.cpp
+++ b/src/MapSpecials.cpp
@@ -624,9 +624,7 @@ void MapSpecials::applyLineSlopeThing(SLADEMap* map, MapThing* thing)
 
 		// Line slope things only affect the sector on the side of the line
 		// that faces the thing
-		double side = MathStuff::lineSide(
-			thing->xPos(), thing->yPos(),
-			line->x1(), line->y1(), line->x2(), line->y2());
+		double side = MathStuff::lineSide(thing->point(), line->seg());
 		MapSector* target = NULL;
 		if (side < 0)
 			target = line->backSector();

--- a/src/MapSpecials.cpp
+++ b/src/MapSpecials.cpp
@@ -596,9 +596,9 @@ void MapSpecials::applyPlaneAlign(MapLine* line, MapSector* target, MapSector* m
 	// sector's height).
 	double modelz = model->getPlaneHeight<p>();
 	double targetz = target->getPlaneHeight<p>();
-	fpoint3_t p1(line->x1(), line->y1(), modelz);
-	fpoint3_t p2(line->x2(), line->y2(), modelz);
-	fpoint3_t p3(furthest_vertex->xPos(), furthest_vertex->yPos(), targetz);
+	fpoint3_t p1(line->point1(), modelz);
+	fpoint3_t p2(line->point2(), modelz);
+	fpoint3_t p3(furthest_vertex->point(), targetz);
 	target->setPlane<p>(MathStuff::planeFromTriangle(p1, p2, p3));
 }
 
@@ -644,20 +644,16 @@ void MapSpecials::applyLineSlopeThing(SLADEMap* map, MapThing* thing)
 				return;
 			containing_sector = map->getSector(containing_sector_idx);
 			thingz = (
-				containing_sector->getPlane<p>().height_at(thing->xPos(), thing->yPos())
+				containing_sector->getPlane<p>().height_at(thing->point())
 				+ thing->floatProperty("height")
 			);
 		}
 
 		// Three points: endpoints of the line, and the thing itself
 		plane_t target_plane = target->getPlane<p>();
-		fpoint3_t p1(
-			lines[b]->x1(), lines[b]->y1(),
-			target_plane.height_at(lines[b]->x1(), lines[b]->y1()));
-		fpoint3_t p2(
-			lines[b]->x2(), lines[b]->y2(),
-			target_plane.height_at(lines[b]->x2(), lines[b]->y2()));
-		fpoint3_t p3(thing->xPos(), thing->yPos(), thingz);
+		fpoint3_t p1(lines[b]->point1(), target_plane.height_at(lines[b]->point1()));
+		fpoint3_t p2(lines[b]->point2(), target_plane.height_at(lines[b]->point2()));
+		fpoint3_t p3(thing->point(), thingz);
 		target->setPlane<p>(MathStuff::planeFromTriangle(p1, p2, p3));
 	}
 }
@@ -683,7 +679,7 @@ void MapSpecials::applySectorTiltThing(SLADEMap* map, MapThing* thing)
 	double tilt = (raw_angle - 90) / 360.0 * TAU;
 	// Resulting plane goes through the position of the thing
 	double z = target->getPlaneHeight<p>() + thing->floatProperty("height");
-	fpoint3_t point(thing->xPos(), thing->yPos(), z);
+	fpoint3_t point(thing->point(), z);
 
 	double cos_angle = cos(angle);
 	double sin_angle = sin(angle);
@@ -729,9 +725,9 @@ void MapSpecials::applyVavoomSlopeThing(SLADEMap* map, MapThing* thing)
 		// endpoints, based on the sector's original (flat) plane and treating
 		// the thing's height as absolute
 		short height = target->getPlaneHeight<p>();
-		fpoint3_t p1(thing->xPos(), thing->yPos(), thing->floatProperty("height"));
-		fpoint3_t p2(lines[a]->x1(), lines[a]->y1(), height);
-		fpoint3_t p3(lines[a]->x2(), lines[a]->y2(), height);
+		fpoint3_t p1(thing->point(), thing->floatProperty("height"));
+		fpoint3_t p2(lines[a]->point1(), height);
+		fpoint3_t p3(lines[a]->point2(), height);
 
 		if (MathStuff::distanceToLineFast(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y) == 0)
 		{
@@ -762,9 +758,9 @@ void MapSpecials::applyVertexHeightSlope(MapSector* target, vector<MapVertex*>& 
 	// interesting slope, after all.
 	if (z1 || z2 || z3)
 	{
-		fpoint3_t p1(vertices[0]->xPos(), vertices[0]->yPos(), z1);
-		fpoint3_t p2(vertices[1]->xPos(), vertices[1]->yPos(), z2);
-		fpoint3_t p3(vertices[2]->xPos(), vertices[2]->yPos(), z3);
+		fpoint3_t p1(vertices[0]->point(), z1);
+		fpoint3_t p2(vertices[1]->point(), z2);
+		fpoint3_t p3(vertices[2]->point(), z3);
 		target->setPlane<p>(MathStuff::planeFromTriangle(p1, p2, p3));
 	}
 }

--- a/src/MapSpecials.cpp
+++ b/src/MapSpecials.cpp
@@ -435,7 +435,7 @@ void MapSpecials::processZDoomSlopes(SLADEMap* map)
 
 		if (thing->getType() == 9510 || thing->getType() == 9511)
 		{
-			int target_idx = map->sectorAt(thing->xPos(), thing->yPos());
+			int target_idx = map->sectorAt(thing->point());
 			if (target_idx < 0)
 				continue;
 			MapSector* target = map->getSector(target_idx);
@@ -577,7 +577,7 @@ void MapSpecials::applyPlaneAlign(MapLine* line, MapSector* target, MapSector* m
 	for (unsigned a = 0; a < vertices.size(); a++)
 	{
 		this_vertex = vertices[a];
-		this_dist = line->distanceTo(this_vertex->xPos(), this_vertex->yPos());
+		this_dist = line->distanceTo(this_vertex->point());
 		if (this_dist > furthest_dist)
 		{
 			furthest_dist = this_dist;
@@ -636,8 +636,7 @@ void MapSpecials::applyLineSlopeThing(SLADEMap* map, MapThing* thing)
 		// Need to know the containing sector's height to find the thing's true height
 		if (!containing_sector)
 		{
-			int containing_sector_idx = map->sectorAt(
-				thing->xPos(), thing->yPos());
+			int containing_sector_idx = map->sectorAt(thing->point());
 			if (containing_sector_idx < 0)
 				return;
 			containing_sector = map->getSector(containing_sector_idx);
@@ -661,7 +660,7 @@ void MapSpecials::applySectorTiltThing(SLADEMap* map, MapThing* thing)
 {
 	// TODO should this apply to /all/ sectors at this point, in the case of an
 	// intersection?
-	int target_idx = map->sectorAt(thing->xPos(), thing->yPos());
+	int target_idx = map->sectorAt(thing->point());
 	if (target_idx < 0)
 		return;
 	MapSector* target = map->getSector(target_idx);
@@ -703,7 +702,7 @@ void MapSpecials::applySectorTiltThing(SLADEMap* map, MapThing* thing)
 template<PlaneType p>
 void MapSpecials::applyVavoomSlopeThing(SLADEMap* map, MapThing* thing)
 {
-	int target_idx = map->sectorAt(thing->xPos(), thing->yPos());
+	int target_idx = map->sectorAt(thing->point());
 	if (target_idx < 0)
 		return;
 	MapSector* target = map->getSector(target_idx);

--- a/src/MapThing.cpp
+++ b/src/MapThing.cpp
@@ -76,6 +76,15 @@ fpoint2_t MapThing::getPoint(uint8_t point)
 	return fpoint2_t(x, y);
 }
 
+/* MapThing::point
+ * Returns the position of the thing, more explicitly than the
+ * generic method getPoint
+ *******************************************************************/
+fpoint2_t MapThing::point()
+{
+	return fpoint2_t(x, y);
+}
+
 /* MapThing::intProperty
  * Returns the value of the integer property matching [key]
  *******************************************************************/

--- a/src/MapThing.h
+++ b/src/MapThing.h
@@ -73,6 +73,8 @@ public:
 
 	void	writeBackup(mobj_backup_t* backup);
 	void	readBackup(mobj_backup_t* backup);
+
+	operator Debuggable() const { return Debuggable(S_FMT("<thing %u>", index)); }
 };
 
 #endif //__MAPTHING_H__

--- a/src/MapThing.h
+++ b/src/MapThing.h
@@ -57,6 +57,7 @@ public:
 	void		setPos(double x, double y) { this->x = x; this->y = y; }
 
 	fpoint2_t	getPoint(uint8_t point);
+	fpoint2_t	point();
 
 	short	getType() { return type; }
 	short	getAngle() { return angle; }

--- a/src/MapVertex.cpp
+++ b/src/MapVertex.cpp
@@ -70,6 +70,15 @@ MapVertex::~MapVertex()
  *******************************************************************/
 fpoint2_t MapVertex::getPoint(uint8_t point)
 {
+	return this->point();
+}
+
+/* MapVertex::point
+ * Returns the vertex position, more explicitly than the overridden
+ * getPoint
+ *******************************************************************/
+fpoint2_t MapVertex::point()
+{
 	return fpoint2_t(x, y);
 }
 

--- a/src/MapVertex.h
+++ b/src/MapVertex.h
@@ -52,6 +52,8 @@ public:
 
 	void	writeBackup(mobj_backup_t* backup);
 	void	readBackup(mobj_backup_t* backup);
+
+	operator Debuggable() const { return Debuggable(S_FMT("<vertex %u>", index)); }
 };
 
 #endif //__MAPVERTEX_H__

--- a/src/MapVertex.h
+++ b/src/MapVertex.h
@@ -39,6 +39,7 @@ public:
 	double		yPos() { return y; }
 
 	fpoint2_t	getPoint(uint8_t point);
+	fpoint2_t	point();
 
 	int		intProperty(string key);
 	double	floatProperty(string key);

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -100,9 +100,9 @@ double MathStuff::distance(double x1, double y1, double x2, double y2)
 /* MathStuff::distance3d
  * Returns the distance between [x1,y1,z1] and [x2,y2,z2]
  *******************************************************************/
-double MathStuff::distance3d(double x1, double y1, double z1, double x2, double y2, double z2)
+double MathStuff::distance3d(fpoint3_t p1, fpoint3_t p2)
 {
-	return sqrt((x2-x1)*(x2-x1) + (y2-y1)*(y2-y1) + (z2-z1)*(z2-z1));
+	return sqrt((p2.x-p1.x)*(p2.x-p1.x) + (p2.y-p1.y)*(p2.y-p1.y) + (p2.z-p1.z)*(p2.z-p1.z));
 }
 
 /* MathStuff::lineSide

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -407,37 +407,36 @@ double MathStuff::distanceRayPlane(fpoint3_t r_o, fpoint3_t r_v, plane_t plane)
  * [line_x2,line_y2]. Box values must be from min to max.
  * Taken from http://stackoverflow.com/a/100165
  *******************************************************************/
-bool MathStuff::boxLineIntersect(double box_x1, double box_y1, double box_x2, double box_y2,
-						double line_x1, double line_y1, double line_x2, double line_y2)
+bool MathStuff::boxLineIntersect(frect_t box, fseg2_t line)
 {
 	// Find min and max X for the segment
-	double minX = line_x1;
-	double maxX = line_x2;
-	if (line_x1 > line_x2)
+	double minX = line.x1();
+	double maxX = line.x2();
+	if (line.x1() > line.x2())
 	{
-		minX = line_x2;
-		maxX = line_x1;
+		minX = line.x2();
+		maxX = line.x1();
 	}
 
 	// Find the intersection of the segment's and rectangle's x-projections
-	if (maxX > box_x2)
-		maxX = box_x2;
-	if (minX < box_x1)
-		minX = box_x1;
+	if (maxX > box.x2())
+		maxX = box.x2();
+	if (minX < box.x1())
+		minX = box.x1();
 
 	// If their projections do not intersect return false
 	if (minX > maxX)
 		return false;
 
 	// Find corresponding min and max Y for min and max X we found before
-	double minY = line_y1;
-	double maxY = line_y2;
-	double dx = line_x2 - line_x1;
+	double minY = line.y1();
+	double maxY = line.y2();
+	double dx = line.x2() - line.x1();
 
 	if (fabs(dx) > 0.0000001)
 	{
-		double a = (line_y2 - line_y1) / dx;
-		double b = line_y1 - a * line_x1;
+		double a = (line.y2() - line.y1()) / dx;
+		double b = line.y1() - a * line.x1();
 		minY = a * minX + b;
 		maxY = a * maxX + b;
 	}
@@ -449,10 +448,10 @@ bool MathStuff::boxLineIntersect(double box_x1, double box_y1, double box_x2, do
 	}
 
 	// Find the intersection of the segment's and rectangle's y-projections
-	if (maxY > box_y2)
-		maxY = box_y2;
-	if (minY < box_y1)
-		minY = box_y1;
+	if (maxY > box.y2())
+		maxY = box.y2();
+	if (minY < box.y1())
+		minY = box.y1();
 
 	// If Y-projections do not intersect return false
 	if (minY > maxY)

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -110,9 +110,9 @@ double MathStuff::distance3d(fpoint3_t p1, fpoint3_t p2)
  * point at [x,y] lies on. Positive is front, negative is back, zero
  * is on the line
  *******************************************************************/
-double MathStuff::lineSide(double x, double y, double x1, double y1, double x2, double y2)
+double MathStuff::lineSide(fpoint2_t point, fseg2_t line)
 {
-	return -((y-y1)*(x2-x1) - (x-x1)*(y2-y1));
+	return (point.x - line.x1()) * line.height() - (point.y - line.y1()) * line.width();
 }
 
 /* MathStuff::closestPointOnLine

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -465,10 +465,10 @@ plane_t MathStuff::planeFromTriangle(fpoint3_t p1, fpoint3_t p2, fpoint3_t p3)
 {
 	fpoint3_t v1 = p3 - p1;
 	fpoint3_t v2 = p2 - p1;
-	v1 = v1.normalize();
-	v2 = v2.normalize();
+	v1.normalize();
+	v2.normalize();
 	fpoint3_t normal = v1.cross(v2);
-	normal.set(normal.normalize());
+	normal.normalize();
 
 	plane_t plane;
 	plane.a = normal.x;

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -106,9 +106,8 @@ double MathStuff::distance3d(fpoint3_t p1, fpoint3_t p2)
 }
 
 /* MathStuff::lineSide
- * Returns the side of the line from [x1,y1] to [x2,y2] that the
- * point at [x,y] lies on. Positive is front, negative is back, zero
- * is on the line
+ * Returns the side of the line that the point lies on.  Positive is
+ * front, negative is back, zero is on the line
  *******************************************************************/
 double MathStuff::lineSide(fpoint2_t point, fseg2_t line)
 {
@@ -116,19 +115,19 @@ double MathStuff::lineSide(fpoint2_t point, fseg2_t line)
 }
 
 /* MathStuff::closestPointOnLine
- * Returns the closest point to [x,y] along the line from [x1,y1] to
- * [x2,y2]
+ * Returns the point on the given line that's closest to the given
+ * point
  *******************************************************************/
-fpoint2_t MathStuff::closestPointOnLine(double x, double y, double x1, double y1, double x2, double y2)
+fpoint2_t MathStuff::closestPointOnLine(fpoint2_t point, fseg2_t line)
 {
 	// Get line length
-	double len = sqrt((x2-x1)*(x2-x1) + (y2-y1)*(y2-y1));
+	double len = line.length();
 
 	// Calculate intersection distance
 	double u = 0;
 	if (len > 0)
 	{
-		u = ((x-x1)*(x2-x1) + (y-y1)*(y2-y1)) / (len*len);
+		u = MathStuff::lineSide(point, line) / (len * len);
 
 		// Limit intersection distance to the line
 		double lbound = 1 / len;
@@ -137,37 +136,36 @@ fpoint2_t MathStuff::closestPointOnLine(double x, double y, double x1, double y1
 	}
 
 	// Return intersection point
-	return fpoint2_t(x1 + u*(x2 - x1), y1 + u*(y2 - y1));
+	return fpoint2_t(line.x1() + u*line.width(), line.y1() + u*line.height());
 }
 
 /* MathStuff::distanceToLine
  * Returns the shortest distance between the point at [x,y] and the
  * line from [x1,y1] to [x2,y2]
  *******************************************************************/
-double MathStuff::distanceToLine(double x, double y, double x1, double y1, double x2, double y2)
+double MathStuff::distanceToLine(fpoint2_t point, fseg2_t line)
 {
 	// Calculate intersection point
-	fpoint2_t i = closestPointOnLine(x, y, x1, y1, x2, y2);
+	fpoint2_t i = closestPointOnLine(point, line);
 
 	// Return distance between intersection and point
 	// which is the shortest distance to the line
-	return sqrt((i.x-x)*(i.x-x) + (i.y-y)*(i.y-y));
+	return MathStuff::distance(i, point);
 }
 
 /* MathStuff::distanceToLineFast
- * Returns the shortest 'distance' between the point at [x,y] and the
- * line from [x1,y1] to [x2,y2]. The distance returned isn't the
- * real distance, but can be used to find the 'closest' line to the
- * point
+ * Returns the shortest 'distance' between the given point and line.
+ * The distance returned isn't the real distance, but can be used to
+ * find the 'closest' line to the point
  *******************************************************************/
-double MathStuff::distanceToLineFast(double x, double y, double x1, double y1, double x2, double y2)
+double MathStuff::distanceToLineFast(fpoint2_t point, fseg2_t line)
 {
 	// Calculate intersection point
-	fpoint2_t i = closestPointOnLine(x, y, x1, y1, x2, y2);
+	fpoint2_t i = closestPointOnLine(point, line);
 
 	// Return fast distance between intersection and point
 	// which is the shortest distance to the line
-	return (i.x-x)*(i.x-x) + (i.y-y)*(i.y-y);
+	return (i.x-point.x)*(i.x-point.x) + (i.y-point.y)*(i.y-point.y);
 }
 
 /* MathStuff::linesIntersect

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -90,15 +90,15 @@ int MathStuff::round(double val)
 }
 
 /* MathStuff::distance
- * Returns the distance between [x1,y1] and [x2,y2]
+ * Returns the distance between p1 and p2
  *******************************************************************/
-double MathStuff::distance(double x1, double y1, double x2, double y2)
+double MathStuff::distance(fpoint2_t p1, fpoint2_t p2)
 {
-	return sqrt((x2-x1)*(x2-x1) + (y2-y1)*(y2-y1));
+	return sqrt((p2.x-p1.x)*(p2.x-p1.x) + (p2.y-p1.y)*(p2.y-p1.y));
 }
 
 /* MathStuff::distance3d
- * Returns the distance between [x1,y1,z1] and [x2,y2,z2]
+ * Returns the distance between p1 and p2
  *******************************************************************/
 double MathStuff::distance3d(fpoint3_t p1, fpoint3_t p2)
 {

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -171,55 +171,52 @@ double MathStuff::distanceToLineFast(double x, double y, double x1, double y1, d
 }
 
 /* MathStuff::linesIntersect
- * Checks for an intersection between two lines [l1x1,l1y1]-[l1x2,l1y2]
- * and [l2x1,l2y1]-[l2x2,l2y2]. Returns true if they intersect and
- * sets [x,y] to the intersection point
+ * Checks for an intersection between two lines l1 and l2.  Returns
+ * true if they intersect and sets out to the intersection point
  *******************************************************************/
-bool MathStuff::linesIntersect(double l1x1, double l1y1, double l1x2, double l1y2,
-							   double l2x1, double l2y1, double l2x2, double l2y2,
-							   double& x, double& y)
+bool MathStuff::linesIntersect(fseg2_t l1, fseg2_t l2, fpoint2_t& out)
 {
 	// First, simple check for two parallel horizontal or vertical lines
-	if ((l1x1 == l1x2 && l2x1 == l2x2) || (l1y1 == l1y2 && l2y1 == l2y2))
+	if ((l1.x1() == l1.x2() && l2.x1() == l2.x2()) || (l1.y1() == l1.y2() && l2.y1() == l2.y2()))
 		return false;
 
 	// Second, check if the lines share any endpoints
-	if ((l1x1 == l2x1 && l1y1 == l2y1) ||
-			(l1x2 == l2x2 && l1y2 == l2y2) ||
-			(l1x1 == l2x2 && l1y1 == l2y2) ||
-			(l1x2 == l2x1 && l1y2 == l2y1))
+	if ((l1.x1() == l2.x1() && l1.y1() == l2.y1()) ||
+			(l1.x2() == l2.x2() && l1.y2() == l2.y2()) ||
+			(l1.x1() == l2.x2() && l1.y1() == l2.y2()) ||
+			(l1.x2() == l2.x1() && l1.y2() == l2.y1()))
 		return false;
 
 	// Third, check bounding boxes
-	if (max(l1x1, l1x2) < min(l2x1, l2x2) ||
-			max(l2x1, l2x2) < min(l1x1, l1x2) ||
-			max(l1y1, l1y2) < min(l2y1, l2y2) ||
-			max(l2y1, l2y2) < min(l1y1, l1y2))
+	if (max(l1.x1(), l1.x2()) < min(l2.x1(), l2.x2()) ||
+			max(l2.x1(), l2.x2()) < min(l1.x1(), l1.x2()) ||
+			max(l1.y1(), l1.y2()) < min(l2.y1(), l2.y2()) ||
+			max(l2.y1(), l2.y2()) < min(l1.y1(), l1.y2()))
 		return false;
 
 	// Fourth, check for two perpendicular horizontal or vertical lines
-	if (l1x1 == l1x2 && l2y1 == l2y2)
+	if (l1.x1() == l1.x2() && l2.y1() == l2.y2())
 	{
-		x = l1x1;
-		y = l2y1;
+		out.x = l1.x1();
+		out.y = l2.y1();
 		return true;
 	}
-	if (l1y1 == l1y2 && l2x1 == l2x2)
+	if (l1.y1() == l1.y2() && l2.x1() == l2.x2())
 	{
-		x = l2x1;
-		y = l1y1;
+		out.x = l2.x1();
+		out.y = l1.y1();
 		return true;
 	}
 
 	// Not a simple case, do full intersection calculation
 
 	// Calculate some values
-	double a1 = l1y2 - l1y1;
-	double a2 = l2y2 - l2y1;
-	double b1 = l1x1 - l1x2;
-	double b2 = l2x1 - l2x2;
-	double c1 = (a1 * l1x1) + (b1 * l1y1);
-	double c2 = (a2 * l2x1) + (b2 * l2y1);
+	double a1 = l1.y2() - l1.y1();
+	double a2 = l2.y2() - l2.y1();
+	double b1 = l1.x1() - l1.x2();
+	double b2 = l2.x1() - l2.x2();
+	double c1 = (a1 * l1.x1()) + (b1 * l1.y1());
+	double c2 = (a2 * l2.x1()) + (b2 * l2.y1());
 	double det = a1*b2 - a2*b1;
 
 	// Check for no intersection
@@ -227,18 +224,18 @@ bool MathStuff::linesIntersect(double l1x1, double l1y1, double l1x2, double l1y
 		return false;
 
 	// Calculate intersection point
-	x = (b2*c1 - b1*c2) / det;
-	y = (a1*c2 - a2*c1) / det;
+	out.x = (b2*c1 - b1*c2) / det;
+	out.y = (a1*c2 - a2*c1) / det;
 
 	// Round to nearest 3 decimal places
-	x = std::floor(x * 1000.0 + 0.5) / 1000.0;
-	y = std::floor(y * 1000.0 + 0.5) / 1000.0;
+	out.x = std::floor(out.x * 1000.0 + 0.5) / 1000.0;
+	out.y = std::floor(out.y * 1000.0 + 0.5) / 1000.0;
 
 	// Check that the intersection point is on both lines
-	if (min(l1x1, l1x2) <= x && x <= max(l1x1, l1x2) &&
-			min(l1y1, l1y2) <= y && y <= max(l1y1, l1y2) &&
-			min(l2x1, l2x2) <= x && x <= max(l2x1, l2x2) &&
-			min(l2y1, l2y2) <= y && y <= max(l2y1, l2y2))
+	if (min(l1.x1(), l1.x2()) <= out.x && out.x <= max(l1.x1(), l1.x2()) &&
+		min(l1.y1(), l1.y2()) <= out.y && out.y <= max(l1.y1(), l1.y2()) &&
+		min(l2.x1(), l2.x2()) <= out.x && out.x <= max(l2.x1(), l2.x2()) &&
+		min(l2.y1(), l2.y2()) <= out.y && out.y <= max(l2.y1(), l2.y2()))
 		return true;
 
 	// Intersection point does not lie on both lines

--- a/src/MathStuff.cpp
+++ b/src/MathStuff.cpp
@@ -247,17 +247,17 @@ bool MathStuff::linesIntersect(double l1x1, double l1y1, double l1x2, double l1y
 
 /* MathStuff::distanceRayLine
  * Returns the distance between the ray [r1 -> r2] and the line
- * segment [x1,y1]-[x2,y2]
+ * segment [seg1 -> seg2]
  *******************************************************************/
-double MathStuff::distanceRayLine(fpoint2_t r1, fpoint2_t r2, double x1, double y1, double x2, double y2)
+double MathStuff::distanceRayLine(fpoint2_t r1, fpoint2_t r2, fpoint2_t s1, fpoint2_t s2)
 {
 	// Calculate the intersection distance from the ray
-	double u_ray = ((x2 - x1) * (r1.y - y1) - (y2 - y1) * (r1.x - x1)) /
-				   ((y2 - y1) * (r2.x - r1.x) - (x2 - x1) * (r2.y - r1.y));
+	double u_ray = ((s2.x - s1.x) * (r1.y - s1.y) - (s2.y - s1.y) * (r1.x - s1.x)) /
+				   ((s2.y - s1.y) * (r2.x - r1.x) - (s2.x - s1.x) * (r2.y - r1.y));
 
 	// Calculate the intersection distance from the line
-	double u_line = ((r2.x - r1.x) * (r1.y - y1) - (r2.y - r1.y) * (r1.x - x1)) /
-					((y2 - y1) * (r2.x - r1.x) - (x2 - x1) * (r2.y - r1.y));
+	double u_line = ((r2.x - r1.x) * (r1.y - s1.y) - (r2.y - r1.y) * (r1.x - s1.x)) /
+					((s2.y - s1.y) * (r2.x - r1.x) - (s2.x - s1.x) * (r2.y - r1.y));
 
 	// Return the distance on the ray if intersecting, or return -1
 	if((u_ray >= 0)/* && (u_ray <= 1024) */&& (u_line >= 0) && (u_line <= 1)) return u_ray; else return -1;

--- a/src/MathStuff.h
+++ b/src/MathStuff.h
@@ -14,7 +14,7 @@ namespace MathStuff
 	int			round(double val);
 	double		distance(double x1, double y1, double x2, double y2);
 	double		distance3d(fpoint3_t p1, fpoint3_t p2);
-	double		lineSide(double x, double y, double x1, double y1, double x2, double y2);
+	double		lineSide(fpoint2_t point, fseg2_t line);
 	fpoint2_t	closestPointOnLine(double x, double y, double x1, double y1, double x2, double y2);
 	double		distanceToLine(double x, double y, double x1, double y1, double x2, double y2);
 	double		distanceToLineFast(double x, double y, double x1, double y1, double x2, double y2);

--- a/src/MathStuff.h
+++ b/src/MathStuff.h
@@ -13,7 +13,7 @@ namespace MathStuff
 	int			ceil(double val);
 	int			round(double val);
 	double		distance(double x1, double y1, double x2, double y2);
-	double		distance3d(double x1, double y1, double z1, double x2, double y2, double z2);
+	double		distance3d(fpoint3_t p1, fpoint3_t p2);
 	double		lineSide(double x, double y, double x1, double y1, double x2, double y2);
 	fpoint2_t	closestPointOnLine(double x, double y, double x1, double y1, double x2, double y2);
 	double		distanceToLine(double x, double y, double x1, double y1, double x2, double y2);

--- a/src/MathStuff.h
+++ b/src/MathStuff.h
@@ -15,9 +15,9 @@ namespace MathStuff
 	double		distance(fpoint2_t p1, fpoint2_t p2);
 	double		distance3d(fpoint3_t p1, fpoint3_t p2);
 	double		lineSide(fpoint2_t point, fseg2_t line);
-	fpoint2_t	closestPointOnLine(double x, double y, double x1, double y1, double x2, double y2);
-	double		distanceToLine(double x, double y, double x1, double y1, double x2, double y2);
-	double		distanceToLineFast(double x, double y, double x1, double y1, double x2, double y2);
+	fpoint2_t	closestPointOnLine(fpoint2_t point, fseg2_t line);
+	double		distanceToLine(fpoint2_t point, fseg2_t line);
+	double		distanceToLineFast(fpoint2_t point, fseg2_t line);
 	bool		linesIntersect(fseg2_t line1, fseg2_t line2, fpoint2_t& out);
 	double		distanceRayLine(fpoint2_t ray_origin, fpoint2_t ray_dir, fpoint2_t seg1, fpoint2_t seg2);
 	double		angle2DRad(fpoint2_t p1, fpoint2_t p2, fpoint2_t p3);

--- a/src/MathStuff.h
+++ b/src/MathStuff.h
@@ -27,8 +27,7 @@ namespace MathStuff
 	double		radToDeg(double angle);
 	fpoint2_t	vectorAngle(double angle_rad);
 	double		distanceRayPlane(fpoint3_t ray_origin, fpoint3_t ray_dir, plane_t plane);
-	bool		boxLineIntersect(double box_x1, double box_y1, double box_x2, double box_y2,
-									double line_x1, double line_y1, double line_x2, double line_y2);
+	bool		boxLineIntersect(frect_t box, fseg2_t line);
 	plane_t		planeFromTriangle(fpoint3_t p1, fpoint3_t p2, fpoint3_t p3);
 }
 

--- a/src/MathStuff.h
+++ b/src/MathStuff.h
@@ -18,9 +18,7 @@ namespace MathStuff
 	fpoint2_t	closestPointOnLine(double x, double y, double x1, double y1, double x2, double y2);
 	double		distanceToLine(double x, double y, double x1, double y1, double x2, double y2);
 	double		distanceToLineFast(double x, double y, double x1, double y1, double x2, double y2);
-	bool		linesIntersect(double l1x1, double l1y1, double l1x2, double l1y2,
-	                           double l2x1, double l2y1, double l2x2, double l2y2,
-	                           double& x, double& y);
+	bool		linesIntersect(fseg2_t line1, fseg2_t line2, fpoint2_t& out);
 	double		distanceRayLine(fpoint2_t ray_origin, fpoint2_t ray_dir, fpoint2_t seg1, fpoint2_t seg2);
 	double		angle2DRad(fpoint2_t p1, fpoint2_t p2, fpoint2_t p3);
 	fpoint2_t	rotatePoint(fpoint2_t origin, fpoint2_t point, double angle);

--- a/src/MathStuff.h
+++ b/src/MathStuff.h
@@ -12,7 +12,7 @@ namespace MathStuff
 	int			floor(double val);
 	int			ceil(double val);
 	int			round(double val);
-	double		distance(double x1, double y1, double x2, double y2);
+	double		distance(fpoint2_t p1, fpoint2_t p2);
 	double		distance3d(fpoint3_t p1, fpoint3_t p2);
 	double		lineSide(fpoint2_t point, fseg2_t line);
 	fpoint2_t	closestPointOnLine(double x, double y, double x1, double y1, double x2, double y2);

--- a/src/MathStuff.h
+++ b/src/MathStuff.h
@@ -2,6 +2,8 @@
 #ifndef __MATHSTUFF_H__
 #define __MATHSTUFF_H__
 
+#include "Structs.h"
+
 #define PI	3.1415926535897932384
 
 namespace MathStuff
@@ -19,7 +21,7 @@ namespace MathStuff
 	bool		linesIntersect(double l1x1, double l1y1, double l1x2, double l1y2,
 	                           double l2x1, double l2y1, double l2x2, double l2y2,
 	                           double& x, double& y);
-	double		distanceRayLine(fpoint2_t ray_origin, fpoint2_t ray_dir, double x1, double y1, double x2, double y2);
+	double		distanceRayLine(fpoint2_t ray_origin, fpoint2_t ray_dir, fpoint2_t seg1, fpoint2_t seg2);
 	double		angle2DRad(fpoint2_t p1, fpoint2_t p2, fpoint2_t p3);
 	fpoint2_t	rotatePoint(fpoint2_t origin, fpoint2_t point, double angle);
 	fpoint3_t	rotateVector3D(fpoint3_t vector, fpoint3_t axis, double angle);

--- a/src/ObjectEdit.cpp
+++ b/src/ObjectEdit.cpp
@@ -242,9 +242,8 @@ bool ObjectEditGroup::getNearestLine(fpoint2_t pos, double min, fpoint2_t& v1, f
 	double min_dist = min;
 	for (unsigned a = 0; a < lines.size(); a++)
 	{
-		double d = MathStuff::distanceToLineFast(pos.x, pos.y,
-			lines[a].v1->position.x, lines[a].v1->position.y,
-			lines[a].v2->position.x, lines[a].v2->position.y);
+		double d = MathStuff::distanceToLineFast(
+			pos, fseg2_t(lines[a].v1->position, lines[a].v2->position));
 
 		if (d < min_dist)
 		{

--- a/src/ObjectEdit.h
+++ b/src/ObjectEdit.h
@@ -2,6 +2,8 @@
 #ifndef __OBJECT_EDIT_H__
 #define __OBJECT_EDIT_H__
 
+#include "Structs.h"
+
 class MapVertex;
 class MapLine;
 class MapThing;

--- a/src/Polygon2D.cpp
+++ b/src/Polygon2D.cpp
@@ -698,7 +698,7 @@ bool PolygonSplitter::splitFromEdge(int splitter_edge)
 	{
 		if (MathStuff::lineSide(vertices[a], fseg2_t(vertices[v1], vertices[v2])) > 0 && vertices[a].ok)
 		{
-			vertices[a].distance = MathStuff::distance(vertices[v2].x, vertices[v2].y, vertices[a].x, vertices[a].y);
+			vertices[a].distance = MathStuff::distance(vertices[v2], vertices[a]);
 			if (vertices[a].distance < min_dist)
 			{
 				min_dist = vertices[a].distance;

--- a/src/Polygon2D.cpp
+++ b/src/Polygon2D.cpp
@@ -696,7 +696,7 @@ bool PolygonSplitter::splitFromEdge(int splitter_edge)
 	int closest = -1;
 	for (unsigned a = 0; a < vertices.size(); a++)
 	{
-		if (MathStuff::lineSide(vertices[a].x, vertices[a].y, vertices[v1].x, vertices[v1].y, vertices[v2].x, vertices[v2].y) > 0 && vertices[a].ok)
+		if (MathStuff::lineSide(vertices[a], fseg2_t(vertices[v1], vertices[v2])) > 0 && vertices[a].ok)
 		{
 			vertices[a].distance = MathStuff::distance(vertices[v2].x, vertices[v2].y, vertices[a].x, vertices[a].y);
 			if (vertices[a].distance < min_dist)

--- a/src/Polygon2D.cpp
+++ b/src/Polygon2D.cpp
@@ -716,7 +716,7 @@ bool PolygonSplitter::splitFromEdge(int splitter_edge)
 	// See if we can split to here without crossing anything
 	// (this will be the case most of the time)
 	bool intersect = false;
-	double xi, yi;
+	fpoint2_t pointi;
 	for (unsigned a = 0; a < edges.size(); a++)
 	{
 		// Ignore edge if adjacent to the vertices we are looking at
@@ -724,7 +724,7 @@ bool PolygonSplitter::splitFromEdge(int splitter_edge)
 			continue;
 
 		// Intersection test
-		if (MathStuff::linesIntersect(vertices[v2].x, vertices[v2].y, vertices[closest].x, vertices[closest].y, vertices[edges[a].v1].x, vertices[edges[a].v1].y, vertices[edges[a].v2].x, vertices[edges[a].v2].y, xi, yi))
+		if (MathStuff::linesIntersect(fseg2_t(vertices[v2], vertices[closest]), fseg2_t(vertices[edges[a].v1], vertices[edges[a].v2]), pointi))
 		{
 			intersect = true;
 			break;
@@ -768,7 +768,7 @@ bool PolygonSplitter::splitFromEdge(int splitter_edge)
 				continue;
 
 			// Intersection test
-			if (MathStuff::linesIntersect(vertices[v2].x, vertices[v2].y, vert.x, vert.y, vertices[edges[a].v1].x, vertices[edges[a].v1].y, vertices[edges[a].v2].x, vertices[edges[a].v2].y, xi, yi))
+			if (MathStuff::linesIntersect(fseg2_t(vertices[v2], vert), fseg2_t(vertices[edges[a].v1], vertices[edges[a].v2]), pointi))
 			{
 				intersect = true;
 				break;

--- a/src/Polygon2D.h
+++ b/src/Polygon2D.h
@@ -100,6 +100,8 @@ private:
 		bool			ok;
 		double			distance;
 		vertex_t(double x=0, double y=0) { this->x = x; this->y = y; ok = true; }
+
+		operator fpoint2_t() const { return fpoint2_t(x, y); }
 	};
 	struct poly_outline_t
 	{

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -2832,7 +2832,8 @@ int SLADEMap::nearestVertex(double x, double y, double min)
 	if (index >= 0)
 	{
 		v = vertices[index];
-		double rdist = MathStuff::distance(v->x, v->y, x, y);
+		fpoint2_t point(x, y);
+		double rdist = MathStuff::distance(v->point(), point);
 		if (rdist > min)
 			return -1;
 	}
@@ -2908,7 +2909,8 @@ int SLADEMap::nearestThing(double x, double y, double min)
 	if (index >= 0)
 	{
 		t = things[index];
-		double rdist = MathStuff::distance(t->x, t->y, x, y);
+		fpoint2_t point(x, y);
+		double rdist = MathStuff::distance(t->point(), point);
 		if (rdist > min)
 			return -1;
 	}
@@ -3120,7 +3122,8 @@ MapVertex* SLADEMap::lineCrossVertex(double x1, double y1, double x2, double y2)
 		if (MathStuff::distanceToLineFast(vertex->x, vertex->y, x1, y1, x2, y2) == 0)
 		{
 			// Check distance between line start and vertex
-			double dist = MathStuff::distance(x1, y1, vertex->x, vertex->y);
+			fpoint2_t point1(x1, y1);
+			double dist = MathStuff::distance(point1, vertex->point());
 			if (dist < min_dist)
 			{
 				cv = vertex;

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -3836,7 +3836,7 @@ MapSector* SLADEMap::getLineSideSector(MapLine* line, bool front)
 
 		// Check side of line
 		MapSector* sector = NULL;
-		if (MathStuff::lineSide(mid.x, mid.y, l->x1(), l->y1(), l->x2(), l->y2()) >= 0)
+		if (MathStuff::lineSide(mid, l->seg()) >= 0)
 			sector = l->frontSector();
 		else
 			sector = l->backSector();

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -2799,10 +2799,10 @@ bool SLADEMap::removeThing(unsigned index)
 }
 
 /* SLADEMap::nearestVertex
- * Returns the index of the vertex closest to [x,y], or -1 if none
+ * Returns the index of the vertex closest to the point, or -1 if none
  * found. Igonres any vertices further away than [min]
  *******************************************************************/
-int SLADEMap::nearestVertex(double x, double y, double min)
+int SLADEMap::nearestVertex(fpoint2_t point, double min)
 {
 	// Go through vertices
 	double min_dist = 999999999;
@@ -2814,10 +2814,10 @@ int SLADEMap::nearestVertex(double x, double y, double min)
 		v = vertices[a];
 
 		// Get 'quick' distance (no need to get real distance)
-		if (v->x < x)	dist = x - v->x;
-		else			dist = v->x - x;
-		if (v->y < y)	dist += y - v->y;
-		else			dist += v->y - y;
+		if (v->x < point.x)	dist = point.x - v->x;
+		else				dist = v->x - point.x;
+		if (v->y < point.y)	dist += point.y - v->y;
+		else				dist += v->y - point.y;
 
 		// Check if it's nearer than the previous nearest
 		if (dist < min_dist)
@@ -2832,7 +2832,6 @@ int SLADEMap::nearestVertex(double x, double y, double min)
 	if (index >= 0)
 	{
 		v = vertices[index];
-		fpoint2_t point(x, y);
 		double rdist = MathStuff::distance(v->point(), point);
 		if (rdist > min)
 			return -1;

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -3226,7 +3226,7 @@ void SLADEMap::findSectorTextPoint(MapSector* sector)
 			continue;
 
 		MapLine* line = sector->connected_sides[a]->parent;
-		double dist = MathStuff::distanceRayLine(r_o, r_o + r_d, line->x1(), line->y1(), line->x2(), line->y2());
+		double dist = MathStuff::distanceRayLine(r_o, r_o + r_d, line->point1(), line->point2());
 
 		if (dist > 0 && dist < min_dist)
 			min_dist = dist;
@@ -3277,7 +3277,7 @@ MapLine* SLADEMap::lineVectorIntersect(MapLine* line, bool front, double& hit_x,
 		if (lines[a] == line)
 			continue;
 
-		double dist = MathStuff::distanceRayLine(mid, mid + vec, lines[a]->x1(), lines[a]->y1(), lines[a]->x2(), lines[a]->y2());
+		double dist = MathStuff::distanceRayLine(mid, mid + vec, lines[a]->point1(), lines[a]->point2());
 
 		if (dist < min_dist && dist > 0)
 		{
@@ -3816,7 +3816,7 @@ MapSector* SLADEMap::getLineSideSector(MapLine* line, bool front)
 		if (lines[a] == line)
 			continue;
 
-		dist = MathStuff::distanceRayLine(mid, dir, lines[a]->x1(), lines[a]->y1(), lines[a]->x2(), lines[a]->y2());
+		dist = MathStuff::distanceRayLine(mid, dir, lines[a]->point1(), lines[a]->point2());
 		if (dist < min_dist && dist > 0)
 		{
 			min_dist = dist;

--- a/src/SLADEMap.cpp
+++ b/src/SLADEMap.cpp
@@ -3096,10 +3096,7 @@ vector<fpoint2_t> SLADEMap::cutLines(double x1, double y1, double x2, double y2)
  *******************************************************************/
 MapVertex* SLADEMap::lineCrossVertex(double x1, double y1, double x2, double y2)
 {
-	// Create bbox for line
-	bbox_t bbox;
-	bbox.extend(x1, y1);
-	bbox.extend(x2, y2);
+	fseg2_t seg(x1, y1, x2, y2);
 
 	// Go through vertices
 	MapVertex* cv = NULL;
@@ -3107,23 +3104,21 @@ MapVertex* SLADEMap::lineCrossVertex(double x1, double y1, double x2, double y2)
 	for (unsigned a = 0; a < vertices.size(); a++)
 	{
 		MapVertex* vertex = vertices[a];
+		fpoint2_t point = vertex->point();
 
 		// Skip if outside line bbox
-		if (!bbox.point_within(vertex->x, vertex->y))
+		if (!seg.contains(point))
 			continue;
 
 		// Skip if it's at an end of the line
-		if (vertex->x == x1 && vertex->y == y1)
-			continue;
-		if (vertex->x == x2 && vertex->y == y2)
+		if (point == seg.p1() || point == seg.p2())
 			continue;
 
 		// Check if on line
-		if (MathStuff::distanceToLineFast(vertex->x, vertex->y, x1, y1, x2, y2) == 0)
+		if (MathStuff::distanceToLineFast(point, seg) == 0)
 		{
 			// Check distance between line start and vertex
-			fpoint2_t point1(x1, y1);
-			double dist = MathStuff::distance(point1, vertex->point());
+			double dist = MathStuff::distance(seg.p1(), point);
 			if (dist < min_dist)
 			{
 				cv = vertex;
@@ -3209,7 +3204,7 @@ void SLADEMap::findSectorTextPoint(MapSector* sector)
 	for (unsigned a = 0; a < sector->connected_sides.size(); a++)
 	{
 		MapLine* l = sector->connected_sides[a]->parent;
-		double dist = MathStuff::distanceToLineFast(sector->text_point.x, sector->text_point.y, l->x1(), l->y1(), l->x2(), l->y2());
+		double dist = MathStuff::distanceToLineFast(sector->text_point, l->seg());
 
 		if (dist < min_dist)
 		{

--- a/src/SLADEMap.h
+++ b/src/SLADEMap.h
@@ -210,7 +210,7 @@ public:
 	bool	removeThing(unsigned index);
 
 	// Geometry
-	int					nearestVertex(double x, double y, double min = 64);
+	int					nearestVertex(fpoint2_t point, double min = 64);
 	int					nearestLine(double x, double y, double min = 64);
 	int					nearestThing(double x, double y, double min = 64);
 	vector<int>			nearestThingMulti(double x, double y);

--- a/src/SLADEMap.h
+++ b/src/SLADEMap.h
@@ -211,10 +211,10 @@ public:
 
 	// Geometry
 	int					nearestVertex(fpoint2_t point, double min = 64);
-	int					nearestLine(double x, double y, double min = 64);
-	int					nearestThing(double x, double y, double min = 64);
-	vector<int>			nearestThingMulti(double x, double y);
-	int					sectorAt(double x, double y);
+	int					nearestLine(fpoint2_t point, double min = 64);
+	int					nearestThing(fpoint2_t point, double min = 64);
+	vector<int>			nearestThingMulti(fpoint2_t point);
+	int					sectorAt(fpoint2_t point);
 	bbox_t				getMapBBox();
 	MapVertex*			vertexAt(double x, double y);
 	vector<fpoint2_t>	cutLines(double x1, double y1, double x2, double y2);

--- a/src/SectorBuilder.cpp
+++ b/src/SectorBuilder.cpp
@@ -242,6 +242,8 @@ bool SectorBuilder::traceOutline(MapLine* line, bool front)
  *******************************************************************/
 int SectorBuilder::nearestEdge(double x, double y)
 {
+	fpoint2_t point(x, y);
+
 	// Init variables
 	double min_dist = 99999999;
 	int nearest = -1;
@@ -251,9 +253,7 @@ int SectorBuilder::nearestEdge(double x, double y)
 	for (unsigned a = 0; a < o_edges.size(); a++)
 	{
 		// Get distance to edge
-		dist = MathStuff::distanceToLineFast(x, y,
-		                                     o_edges[a].line->x1(), o_edges[a].line->y1(),
-		                                     o_edges[a].line->x2(), o_edges[a].line->y2());
+		dist = MathStuff::distanceToLineFast(point, o_edges[a].line->seg());
 
 		// Check if minimum
 		if (dist < min_dist)

--- a/src/SectorBuilder.cpp
+++ b/src/SectorBuilder.cpp
@@ -272,6 +272,8 @@ int SectorBuilder::nearestEdge(double x, double y)
  *******************************************************************/
 bool SectorBuilder::pointWithinOutline(double x, double y)
 {
+	fpoint2_t point(x, y);
+
 	// Check with bounding box
 	if (!o_bbox.point_within(x, y))
 	{
@@ -291,9 +293,7 @@ bool SectorBuilder::pointWithinOutline(double x, double y)
 	if (nearest >= 0)
 	{
 		// Check what side of the edge the point is on
-		double side = MathStuff::lineSide(x, y,
-		                                  o_edges[nearest].line->x1(), o_edges[nearest].line->y1(),
-		                                  o_edges[nearest].line->x2(), o_edges[nearest].line->y2());
+		double side = MathStuff::lineSide(point, o_edges[nearest].line->seg());
 
 		// Return true if it is on the correct side
 		if (side >= 0 && o_edges[nearest].front)
@@ -380,7 +380,7 @@ SectorBuilder::edge_t SectorBuilder::findOuterEdge()
 	//wxLogMessage("Found next outer line %d", nearest->getIndex());
 
 	// Determine the edge side
-	double side = MathStuff::lineSide(vr_x, vr_y, nearest->x1(), nearest->y1(), nearest->x2(), nearest->y2());
+	double side = MathStuff::lineSide(vertex_right->point(), nearest->seg());
 	if (side >= 0)
 		return edge_t(nearest, true);
 	else

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -98,6 +98,19 @@ struct fpoint2_t
 		return sqrt((dist_x * dist_x) + (dist_y * dist_y));
 	}
 
+	// aka "Manhattan" distance -- just the sum of the vertical and horizontal
+	// distance, and an upper bound on the true distance
+	double taxicab_distance_to(fpoint2_t point)
+	{
+		double dist;
+		if (point.x < x)	dist = x - point.x;
+		else				dist = point.x - x;
+		if (point.y < y)	dist += y - point.y;
+		else				dist += point.y - y;
+
+		return dist;
+	}
+
 	double dot(fpoint2_t vec)
 	{
 		return x*vec.x + y*vec.y;

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -127,6 +127,10 @@ struct fpoint2_t
 	{
 		return (x == rhs.x && y == rhs.y);
 	}
+	bool operator!=(fpoint2_t rhs)
+	{
+		return (x != rhs.x || y != rhs.y);
+	}
 };
 
 
@@ -566,6 +570,8 @@ struct frect_t
 	double y1() { return tl.y; }
 	double x2() { return br.x; }
 	double y2() { return br.y; }
+	fpoint2_t p1() { return tl; }
+	fpoint2_t p2() { return br; }
 
 	double left()	{ return min(tl.x, br.x); }
 	double top()	{ return min(tl.y, br.y); }
@@ -621,6 +627,9 @@ struct frect_t
 			return false;
 	}
 };
+// Rectangle is not really any different from a 2D segment, but using it to
+// mean that can be confusing, so here's an alias.
+typedef frect_t fseg2_t;
 
 
 // plane_t: A 3d plane

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -816,12 +816,12 @@ struct bbox_t
 		return fseg2_t(max.x, min.y, max.x, max.y);
 	}
 
-	fseg2_t top_side()
+	fseg2_t bottom_side()
 	{
 		return fseg2_t(min.x, max.y, max.x, max.y);
 	}
 
-	fseg2_t bottom_side()
+	fseg2_t top_side()
 	{
 		return fseg2_t(min.x, min.y, max.x, min.y);
 	}

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -90,6 +90,14 @@ struct fpoint2_t
 		}
 	}
 
+	double distance_to(fpoint2_t point)
+	{
+		double dist_x = point.x - x;
+		double dist_y = point.y - y;
+
+		return sqrt((dist_x * dist_x) + (dist_y * dist_y));
+	}
+
 	double dot(fpoint2_t vec)
 	{
 		return x*vec.x + y*vec.y;

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -671,7 +671,7 @@ struct plane_t
 		d = d / mag;
 	}
 
-	double height_at(fpoint2_t& point)
+	double height_at(fpoint2_t point)
 	{
 		return height_at(point.x, point.y);
 	}

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -141,7 +141,7 @@ struct fpoint3_t
 
 	fpoint3_t() { x = y = z = 0; }
 	fpoint3_t(double X, double Y, double Z) { x = X; y = Y; z = Z; }
-	fpoint3_t(fpoint2_t p) { x = p.x; y = p.y; z = 0; }
+	fpoint3_t(fpoint2_t p, double Z = 0) { x = p.x; y = p.y; z = Z; }
 
 	void set(double X, double Y, double Z) { x = X; y = Y; z = Z; }
 	void set(fpoint3_t p) { x = p.x; y = p.y; z = p.z; }

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -476,12 +476,10 @@ struct rect_t
 		return sqrt(dist_x * dist_x + dist_y * dist_y);
 	}
 
-	bool within(int x, int y)
+	bool contains(point2_t point)
 	{
-		if (x >= left() && x <= right() && y >= top() && y <= bottom())
-			return true;
-		else
-			return false;
+		return (point.x >= left() && point.x <= right() &&
+				point.y >= top() && point.y <= bottom());
 	}
 };
 
@@ -619,12 +617,10 @@ struct frect_t
 		return sqrt(dist_x * dist_x + dist_y * dist_y);
 	}
 
-	bool within(double x, double y)
+	bool contains(fpoint2_t point)
 	{
-		if (x >= left() && x <= right() && y >= top() && y <= bottom())
-			return true;
-		else
-			return false;
+		return (point.x >= left() && point.x <= right() &&
+				point.y >= top() && point.y <= bottom());
 	}
 };
 // Rectangle is not really any different from a 2D segment, but using it to
@@ -730,6 +726,10 @@ struct bbox_t
 	{
 		return (x >= min.x && x <= max.x && y >= min.y && y <= max.y);
 	}
+	bool contains(fpoint2_t point)
+	{
+		return point_within(point.x, point.y);
+	}
 
 	bool is_within(fpoint2_t bmin, fpoint2_t bmax)
 	{
@@ -769,6 +769,26 @@ struct bbox_t
 	double mid_y()
 	{
 		return min.y + ((max.y - min.y) * 0.5);
+	}
+
+	fseg2_t left_side()
+	{
+		return fseg2_t(min.x, min.y, min.x, max.y);
+	}
+
+	fseg2_t right_side()
+	{
+		return fseg2_t(max.x, min.y, max.x, max.y);
+	}
+
+	fseg2_t top_side()
+	{
+		return fseg2_t(min.x, max.y, max.x, max.y);
+	}
+
+	fseg2_t bottom_side()
+	{
+		return fseg2_t(min.x, min.y, max.x, min.y);
 	}
 };
 

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -156,13 +156,26 @@ struct fpoint3_t
 		return x*vec.x + y*vec.y + z*vec.z;
 	}
 
-	fpoint3_t normalize()
+	fpoint3_t normalized()
 	{
 		double mag = magnitude();
 		if (mag == 0)
 			return fpoint3_t(0, 0, 0);
 		else
 			return fpoint3_t(x / mag, y / mag, z / mag);
+	}
+
+	void normalize()
+	{
+		double mag = magnitude();
+		if (mag == 0)
+			set(0, 0, 0);
+		else
+		{
+			x /= mag;
+			y /= mag;
+			z /= mag;
+		}
 	}
 
 	double distance_to(fpoint3_t point)
@@ -663,7 +676,8 @@ struct plane_t
 	fpoint3_t normal()
 	{
 		fpoint3_t norm(a, b, c);
-		return norm.normalize();
+		norm.normalize();
+		return norm;
 	}
 
 	void normalize()

--- a/src/ThingPropsPanel.cpp
+++ b/src/ThingPropsPanel.cpp
@@ -315,13 +315,14 @@ void ThingDirCanvas::onMouseEvent(wxMouseEvent& e)
 			// Get cursor position in canvas coordinates
 			double x = -1.2 + ((double)e.GetX() / (double)GetSize().x) * 2.4;
 			double y = -1.2 + ((double)e.GetY() / (double)GetSize().y) * 2.4;
+			fpoint2_t cursor_pos(x, y);
 
 			// Find closest dir point to cursor
 			point_hl = -1;
 			double min_dist = 0.3;
 			for (unsigned a = 0; a < dir_points.size(); a++)
 			{
-				double dist = MathStuff::distance(x, y, dir_points[a].x, dir_points[a].y);
+				double dist = MathStuff::distance(cursor_pos, dir_points[a]);
 				if (dist < min_dist)
 				{
 					point_hl = a;


### PR DESCRIPTION
A humble proposal.  We've already got `fpoint2_t` and friends, but there's a lot of code that still handles and passes points around as distinct `x` and `y` coordinates, which strikes me as tedious and error-prone.  So I changed some of it to work with points instead, and added a couple helper methods to map objects.

I also threw in a `LOG_DEBUG`, because trying to get C++ to do useful print-debugging has been driving me up the wall.  You can tell any type how to cast itself to `Debuggable` and it'll print out to the console that way when you feed it to `LOG_DEBUG`, no format strings or other nonsense required.  And it all compiles out in production builds.  I changed the logging in `SLADEMap::cutLines` to use it as an example, since it's especially un-useful to end users.

I know this is a lot of churn when you're in beta, so I won't be too heartbroken if you defer or reject this.  :)