### PR TITLE
Fixed memory leaks in polymorphic types

### DIFF
--- a/src/BrowserItem.h
+++ b/src/BrowserItem.h
@@ -20,7 +20,7 @@ protected:
 
 public:
 	BrowserItem(string name, unsigned index = 0, string type = "item");
-	~BrowserItem();
+	virtual ~BrowserItem();
 
 	string		getName() { return name; }
 	unsigned	getIndex() { return index; }

--- a/src/CTexture.h
+++ b/src/CTexture.h
@@ -21,7 +21,7 @@ public:
 	CTPatch();
 	CTPatch(string name, int16_t offset_x = 0, int16_t offset_y = 0);
 	CTPatch(CTPatch* copy);
-	~CTPatch();
+	virtual ~CTPatch();
 
 	string			getName() { return name; }
 	int16_t			xOffset() { return offset_x; }

--- a/src/MCAnimations.h
+++ b/src/MCAnimations.h
@@ -10,7 +10,7 @@ protected:
 
 public:
 	MCAnimation(long start, bool mode_3d = false) { starttime = start; this->mode_3d = mode_3d; }
-	~MCAnimation() {}
+	virtual ~MCAnimation() {}
 
 	bool	mode3d() { return mode_3d; }
 

--- a/src/MCOverlay.h
+++ b/src/MCOverlay.h
@@ -15,7 +15,7 @@ protected:
 
 public:
 	MCOverlay() { active = true; allow_3d_mlook = false; }
-	~MCOverlay() {}
+	virtual ~MCOverlay() {}
 
 	bool	isActive() { return active; }
 	bool	allow3dMlook() { return allow_3d_mlook; }

--- a/src/Translation.h
+++ b/src/Translation.h
@@ -24,6 +24,8 @@ public:
 		this->o_end = 0;
 	}
 
+	virtual ~TransRange() {}
+
 	uint8_t getType() { return type; }
 	uint8_t	oStart() { return o_start; }
 	uint8_t oEnd() { return o_end; }

--- a/src/zreaders/i_musicinterns.h
+++ b/src/zreaders/i_musicinterns.h
@@ -10,7 +10,7 @@ class MIDIStreamer
 {
 public:
 	MIDIStreamer();
-	~MIDIStreamer();
+	virtual ~MIDIStreamer();
 
 	int  GetSubsongs();
 	bool SetSubsong(int subsong);


### PR DESCRIPTION
Clang produced the following list of warnings:
```
src/CTexture.cpp:428:3: warning: delete called on 'CTPatch' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/CTexture.cpp:548:3: warning: delete called on 'CTPatch' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/CTexture.cpp:590:2: warning: delete called on 'CTPatch' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/CTexture.cpp:615:4: warning: delete called on 'CTPatch' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/CTexture.cpp:892:3: warning: delete called on 'CTPatch' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/CTexture.cpp:925:3: warning: delete called on 'CTPatch' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/BrowserWindow.cpp:73:3: warning: delete called on 'BrowserItem' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/MapCanvas.cpp:1982:4: warning: delete called on 'MCAnimation' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/MapCanvas.cpp:2452:25: warning: delete called on 'MCOverlay' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/MapCanvas.cpp:3181:27: warning: delete called on 'MCOverlay' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/MapCanvas.cpp:3355:25: warning: delete called on 'MCOverlay' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/MapCanvas.cpp:3650:25: warning: delete called on 'MCOverlay' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/Translation.cpp:59:3: warning: delete called on 'TransRange' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/Translation.cpp:286:3: warning: delete called on 'TransRange' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/Translation.cpp:359:2: warning: delete called on 'TransRange' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
src/zreaders/i_music.cpp:148:5: warning: delete called on 'MIDIStreamer' that is abstract but has non-virtual destructor [-Wdelete-non-virtual-dtor]
```