### PR TITLE
Exclude __FreeBSD__ systems from outputting stack traces OnFatalExcep…

### DIFF
--- a/src/MainApp.cpp
+++ b/src/MainApp.cpp
@@ -128,7 +128,7 @@ EXTERN_CVAR(Bool, map_show_selection_numbers)
  * getTraceString(). wxStackWalker is currently unimplemented on mac,
  * so unfortunately it has to be disabled there
  *******************************************************************/
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 class SLADEStackTrace : public wxStackWalker
 {
 private:
@@ -213,7 +213,7 @@ public:
 
 	~SLADECrashDialog() {}
 };
-#endif//__APPLE__
+#endif//!__APPLE__ && !__FreeBSD__
 
 /*******************************************************************
  * FUNCTIONS
@@ -876,7 +876,7 @@ int MainApp::OnExit()
 
 void MainApp::OnFatalException()
 {
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #ifndef _DEBUG
 	SLADEStackTrace st;
 	st.WalkFromException();


### PR DESCRIPTION
…tion

I don't know if this the preferred way to handle this, but this is the only roadblock to compilation and functionality on FreeBSD. It seems like a sticky situation, but other attempts to  get wxStackWalker stuff to compile+work on FreeBSD did not turn out so well.