### PR TITLE
(UNIX) Create install targets, expand search space for slade.pk3

### DIFF
--- a/src/ArchiveManager.cpp
+++ b/src/ArchiveManager.cpp
@@ -138,7 +138,9 @@ bool ArchiveManager::init()
 	}
 
 	// Find slade3.pk3 directory
-	string dir_slade_pk3 = appPath("slade.pk3", DIR_DATA);
+	string dir_slade_pk3 = appPath("slade.pk3", DIR_RES);
+	if (!wxFileExists(dir_slade_pk3))
+		dir_slade_pk3 = appPath("slade.pk3", DIR_DATA);
 	if (!wxFileExists(dir_slade_pk3))
 		dir_slade_pk3 = appPath("slade.pk3", DIR_APP);
 	if (!wxFileExists(dir_slade_pk3))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,10 @@ if (NO_FLUIDSYNTH)
 ADD_DEFINITIONS(-DNO_FLUIDSYNTH)
 endif(NO_FLUIDSYNTH)
 
+if (CMAKE_INSTALL_PREFIX)
+ADD_DEFINITIONS(-DINSTALL_PREFIX="\\"${CMAKE_INSTALL_PREFIX}\\"")
+endif(CMAKE_INSTALL_PREFIX)
+
 find_package (PkgConfig REQUIRED)
 if (APPLE)
 	# There is no need to have GTK2 installed on OS X
@@ -115,10 +119,20 @@ endif()
 
 set_target_properties(slade PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${SLADE_OUTPUT_DIR})
 
+	# TODO: Installation targets for APPLE
 if(APPLE)
 	set_target_properties(slade PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${OSX_PLIST})
 
 	add_custom_command(TARGET slade POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${SLADE_OUTPUT_DIR}/slade.pk3" "$<TARGET_FILE_DIR:slade>/slade.pk3"
 	)
+else(APPLE)
+	install(TARGETS slade
+		RUNTIME DESTINATION bin
+		)
+
+	install(FILES "${SLADE_OUTPUT_DIR}/slade.pk3"
+		DESTINATION share/slade3
+		)
 endif(APPLE)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,12 +127,14 @@ if(APPLE)
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${SLADE_OUTPUT_DIR}/slade.pk3" "$<TARGET_FILE_DIR:slade>/slade.pk3"
 	)
 else(APPLE)
-	install(TARGETS slade
-		RUNTIME DESTINATION bin
-		)
+	if(UNIX)
+		install(TARGETS slade
+			RUNTIME DESTINATION bin
+			)
 
-	install(FILES "${SLADE_OUTPUT_DIR}/slade.pk3"
-		DESTINATION share/slade3
-		)
+		install(FILES "${SLADE_OUTPUT_DIR}/slade.pk3"
+			DESTINATION share/slade3
+			)
+	endif(UNIX)
 endif(APPLE)
 

--- a/src/Main.h
+++ b/src/Main.h
@@ -106,7 +106,7 @@ namespace Global
 
 
 // Path related stuff
-enum Directory { DIR_USER, DIR_DATA, DIR_APP, DIR_TEMP };
+enum Directory { DIR_USER, DIR_DATA, DIR_APP, DIR_RES, DIR_TEMP };
 string appPath(string filename, int dir);
 
 

--- a/src/MainApp.cpp
+++ b/src/MainApp.cpp
@@ -105,6 +105,7 @@ namespace Global
 string	dir_data = "";
 string	dir_user = "";
 string	dir_app = "";
+string	dir_res = "";
 bool	exiting = false;
 string	current_action = "";
 bool	update_check_message_box = false;
@@ -348,6 +349,8 @@ string appPath(string filename, int dir)
 		return dir_user + sep + filename;
 	else if (dir == DIR_APP)
 		return dir_app + sep + filename;
+	else if (dir == DIR_RES)
+		return dir_res + sep + filename;
 	else if (dir == DIR_TEMP)
 	{
 		// Get temp path
@@ -445,6 +448,11 @@ bool MainApp::initDirectories()
 	string sep = "/";
 #endif
 
+	// If we're passed in a INSTALL_PREFIX (from CMAKE_INSTALL_PREFIX), use this for the installation prefix
+#ifdef INSTALL_PREFIX
+	wxStandardPaths::Get().SetInstallPrefix(INSTALL_PREFIX);
+#endif
+	
 	// Setup app dir
 	dir_app = wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath();
 
@@ -453,6 +461,7 @@ bool MainApp::initDirectories()
 	{
 		// Setup portable user/data dirs
 		dir_data = dir_app;
+		dir_res = dir_app;
 		dir_user = dir_app + sep + "config";
 	}
 	else
@@ -460,6 +469,7 @@ bool MainApp::initDirectories()
 		// Setup standard user/data dirs
 		dir_user = wxStandardPaths::Get().GetUserDataDir();
 		dir_data = wxStandardPaths::Get().GetDataDir();
+		dir_res = wxStandardPaths::Get().GetResourcesDir();
 	}
 
 	// Create user dir if necessary
@@ -475,6 +485,10 @@ bool MainApp::initDirectories()
 	// Check data dir
 	if (!wxDirExists(dir_data))
 		dir_data = dir_app;	// Use app dir if data dir doesn't exist
+
+	// Check res dir
+	if(!wxDirExists(dir_res))
+		dir_res = dir_app;	// Use app dir if res dir doesn't exist
 
 	return true;
 }

--- a/src/MainApp.cpp
+++ b/src/MainApp.cpp
@@ -449,9 +449,9 @@ bool MainApp::initDirectories()
 #endif
 
 	// If we're passed in a INSTALL_PREFIX (from CMAKE_INSTALL_PREFIX), use this for the installation prefix
-#ifdef INSTALL_PREFIX
+#if defined(__UNIX__) && defined(INSTALL_PREFIX)
 	wxStandardPaths::Get().SetInstallPrefix(INSTALL_PREFIX);
-#endif
+#endif//defined(__UNIX__) && defined(INSTALL_PREFIX)
 	
 	// Setup app dir
 	dir_app = wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath();


### PR DESCRIPTION
I've created install targets for non-OSX builds that moves the `slade` binary into `$PREFIX/bin` and `slade.pk3` into `$PREFIX/share/slade3` (to be consistent with `wxStandardPaths::GetResourcesDir()`). I've intentionally ignored OSX and WIN32 because of the former's different way of doing things that I'm not familiar with, and the latter will generally be using a more full-fledged installer anyways.

I've also expanded the search for `slade.pk3` to look in the resources directory (`wxStandardPaths::GetResourcesDir()`) before moving on. If INSTALL_PREFIX (provisioned from CMAKE_INSTALL_PREFIX) is defined, then we'll need to pass that into `wxStandardPaths::SetInstallPrefix()` so that the resources directory is adjusted accordingly. This should be pretty standard and useful across Linux/BSD flavors alike.