### PR TITLE
Tweak calls to archive autodetect

### DIFF
--- a/src/Dialogs/Preferences/BaseResourceArchivesPanel.cpp
+++ b/src/Dialogs/Preferences/BaseResourceArchivesPanel.cpp
@@ -77,17 +77,18 @@ BaseResourceArchivesPanel::BaseResourceArchivesPanel(wxWindow* parent)
 	// Setup buttons
 	btn_add = new wxButton(this, -1, "Add Archive");
 	btn_remove = new wxButton(this, -1, "Remove Archive");
+	btn_detect = new wxButton(this, -1, "Detect Archives");
 
 	wxBoxSizer* vbox = new wxBoxSizer(wxVERTICAL);
 	vbox->Add(btn_add, 0, wxEXPAND|wxBOTTOM, 4);
 	vbox->Add(btn_remove, 0, wxEXPAND|wxBOTTOM, 4);
+	vbox->Add(btn_detect, 0, wxEXPAND|wxBOTTOM, 4);
 	hbox->Add(vbox, 0, wxEXPAND|wxALL, 4);
 
 	// Bind events
 	btn_add->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnAdd, this);
 	btn_remove->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnRemove, this);
-
-	autodetect();
+	btn_detect->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnDetect, this);
 
 	// Init layout
 	Layout();
@@ -154,6 +155,14 @@ void BaseResourceArchivesPanel::onBtnRemove(wxCommandEvent& e)
 
 	// Also remove it from the archive manager
 	theArchiveManager->removeBaseResourcePath(index);
+}
+
+/* BaseResourceArchivesPanel::onBtnDetect
+ * Called when the 'Detect Archives' button is clicked
+ *******************************************************************/
+void BaseResourceArchivesPanel::onBtnDetect(wxCommandEvent& e)
+{
+	autodetect();
 }
 
 #ifdef __WXMSW__

--- a/src/Dialogs/Preferences/BaseResourceArchivesPanel.h
+++ b/src/Dialogs/Preferences/BaseResourceArchivesPanel.h
@@ -8,6 +8,7 @@ private:
 	wxListBox*	list_base_archive_paths;
 	wxButton*	btn_add;
 	wxButton*	btn_remove;
+	wxButton*	btn_detect;
 
 public:
 	BaseResourceArchivesPanel(wxWindow* parent);
@@ -18,6 +19,7 @@ public:
 
 	void	onBtnAdd(wxCommandEvent& e);
 	void	onBtnRemove(wxCommandEvent& e);
+	void	onBtnDetect(wxCommandEvent& e);
 };
 
 #endif//__BASERESOURCEARCHIVESPANEL__

--- a/src/Dialogs/SetupWizard/BaseResourceWizardPage.cpp
+++ b/src/Dialogs/SetupWizard/BaseResourceWizardPage.cpp
@@ -48,6 +48,7 @@ BaseResourceWizardPage::BaseResourceWizardPage(wxWindow* parent) : WizardPageBas
 
 	// Add Base Resource Archive panel
 	bra_panel = new BaseResourceArchivesPanel(this);
+	bra_panel->autodetect();
 	sizer->Add(bra_panel, 1, wxEXPAND);
 }
 


### PR DESCRIPTION
Now there's a button to do it on the panel, instead of it being called
everytime the panel is created. It's also called by the setup wizard.