### PR TITLE
Added prefix header for generated Xcode project

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,6 +119,9 @@ endif()
 
 set_target_properties(slade PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${SLADE_OUTPUT_DIR})
 
+set_target_properties(slade PROPERTIES XCODE_ATTRIBUTE_GCC_PRECOMPILE_PREFIX_HEADER YES)
+set_target_properties(slade PROPERTIES XCODE_ATTRIBUTE_GCC_PREFIX_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/Main.h)
+
 	# TODO: Installation targets for APPLE
 if(APPLE)
 	set_target_properties(slade PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${OSX_PLIST})

--- a/src/Main.h
+++ b/src/Main.h
@@ -1,4 +1,6 @@
 
+#ifdef __cplusplus
+
 #ifdef _MSC_VER
 // Avoid many '#pragma once in main file' warnings from GCC or Clang
 // when this file is used as the prefix header
@@ -134,3 +136,5 @@ const string MAP_TYPE_NAMES[] = {
 };
 
 #endif // __MAIN_H__
+
+#endif /* __cplusplus */


### PR DESCRIPTION
Xcode attributes are ignored by other CMake generators

I don't have any other setup for building SLADE except OS X.
So I cannot add precompiled header support for other platforms.