### PR TITLE
Fix strange crash when processing slopes in Windows

### DIFF
--- a/src/MapEditor/MapSpecials.h
+++ b/src/MapEditor/MapSpecials.h
@@ -23,6 +23,12 @@ class MapSpecials
 	vector<sector_colour_t> sector_fadecolours;
 
 	void	processZDoomSlopes(SLADEMap* map);
+	void	applyPlaneAlign(MapLine* line, MapSector* sector, MapSector* model_sector, bool floor);
+	void	applyLineSlopeThing(SLADEMap* map, MapThing* thing, bool floor);
+	void	applySectorTiltThing(SLADEMap* map, MapThing* thing, bool floor);
+	void	applyVavoomSlopeThing(SLADEMap* map, MapThing* thing, bool floor);
+	void	applyVertexHeightSlope(MapSector* target, vector<MapVertex*>& vertices, VertexHeightMap& heights, bool floor);
+#if 0
 	template<PlaneType>
 	void	applyPlaneAlign(MapLine* line, MapSector* sector, MapSector* model_sector);
 	template<PlaneType>
@@ -33,6 +39,7 @@ class MapSpecials
 	void	applyVavoomSlopeThing(SLADEMap* map, MapThing* thing);
 	template<PlaneType>
 	void	applyVertexHeightSlope(MapSector* target, vector<MapVertex*>& vertices, VertexHeightMap& heights);
+#endif
 
 public:
 	void	reset();

--- a/src/MapEditor/SLADEMap/MapSector.h
+++ b/src/MapEditor/SLADEMap/MapSector.h
@@ -139,6 +139,7 @@ public:
 	}
 };
 
+#if 0
 // Note: these MUST be inline, or the linker will complain
 template<> inline short MapSector::getPlaneHeight<FLOOR_PLANE>() { return getFloorHeight(); }
 template<> inline short MapSector::getPlaneHeight<CEILING_PLANE>() { return getCeilingHeight(); }
@@ -146,7 +147,7 @@ template<> inline plane_t MapSector::getPlane<FLOOR_PLANE>() { return getFloorPl
 template<> inline plane_t MapSector::getPlane<CEILING_PLANE>() { return getCeilingPlane(); }
 template<> inline void MapSector::setPlane<FLOOR_PLANE>(plane_t plane) { setFloorPlane(plane); }
 template<> inline void MapSector::setPlane<CEILING_PLANE>(plane_t plane) { setCeilingPlane(plane); }
-
+#endif
 
 
 #endif //__MAPSECTOR_H__


### PR DESCRIPTION
For whatever reason the release build doesn't like the template stuff in MapSpecials/MapSector. Removing the templates and using boolean 'floor' flags in the functions works fine.

I'm putting this in a pull request for now in case I figure out what is going on.

The stack trace, for what it's worth, opening Paranoid.pk3 MAP03:

    Version: 3.1.1
    No current action
    
    Operating System: Windows NT 10.0 (build 10586), 64-bit edition
    Graphics Vendor: NVIDIA Corporation
    Graphics Hardware: GeForce GTX 970/PCIe/SSE2
    OpenGL Version: 4.5.0 NVIDIA 362.00
    
    Stack Trace:
    0: (c:\dev\slade3\src\mapeditor\mapspecials.cpp:602) MapSpecials::applyPlaneAlign<1>
    1: (c:\dev\slade3\src\mapeditor\mapspecials.cpp:406) MapSpecials::processZDoomSlopes
    2: (c:\dev\slade3\src\mapeditor\mapspecials.cpp:177) MapSpecials::processZDoomMapSpecials
    3: (c:\dev\slade3\src\mapeditor\mapspecials.cpp:67) MapSpecials::processMapSpecials
    4: (c:\dev\slade3\src\mapeditor\slademap\slademap.cpp:386) SLADEMap::readMap
    5: (c:\dev\slade3\src\mapeditor\mapeditor.cpp:613) MapEditor::openMap
    6: (c:\dev\slade3\src\mapeditor\mapeditorwindow.cpp:553) MapEditorWindow::openMap
    7: (c:\dev\slade3\src\maineditor\mainwindow.cpp:714) MainWindow::openMapEditor
    8: (c:\dev\slade3\src\maineditor\ui\archivepanel.cpp:3001) ArchivePanel::handleAction
    9: (c:\dev\slade3\src\application\mainapp.cpp:1302) MainApp::doAction
    10: (c:\dev\slade3\src\ui\stoolbar\stoolbarbutton.cpp:342) SToolBarButton::onMouseEvent
    11: (f:\programming\libs\wxwidgets\src\common\appbase.cpp:612) wxAppConsoleBase::HandleEvent
    12: (f:\programming\libs\wxwidgets\src\common\appbase.cpp:623) wxAppConsoleBase::CallEventHandler
    13: (f:\programming\libs\wxwidgets\src\common\event.cpp:1751) wxEvtHandler::SearchDynamicEventTable
    14: (f:\programming\libs\wxwidgets\src\common\event.cpp:1585) wxEvtHandler::TryHereOnly
    15: (f:\programming\libs\wxwidgets\src\common\event.cpp:1495) wxEvtHandler::ProcessEvent
    16: (f:\programming\libs\wxwidgets\src\common\event.cpp:1647) wxEvtHandler::SafelyProcessEvent
    17: (f:\programming\libs\wxwidgets\src\msw\window.cpp:5538) wxWindow::HandleMouseEvent
    18: (f:\programming\libs\wxwidgets\src\msw\window.cpp:3006) wxWindow::MSWHandleMessage
    19: (f:\programming\libs\wxwidgets\src\msw\window.cpp:3645) wxWindow::MSWWindowProc
    20: (f:\programming\libs\wxwidgets\src\msw\window.cpp:2711) wxWndProc
    21: [unknown location] SetManipulationInputTarget
    22: [unknown location] CallWindowProcW
    23: [unknown location] DispatchMessageW
    24: [unknown location] IsDialogMessageW
    25: (f:\programming\libs\wxwidgets\src\msw\window.cpp:2612) wxWindow::MSWSafeIsDialogMessage
    26: (f:\programming\libs\wxwidgets\src\msw\window.cpp:2494) wxWindow::MSWProcessMessage
    27: (f:\programming\libs\wxwidgets\src\msw\evtloop.cpp:148) wxGUIEventLoop::PreProcessMessage
    28: (f:\programming\libs\wxwidgets\src\msw\evtloop.cpp:166) wxGUIEventLoop::ProcessMessage
    29: (f:\programming\libs\wxwidgets\src\msw\evtloop.cpp:232) wxGUIEventLoop::Dispatch
    30: (f:\programming\libs\wxwidgets\src\common\evtloopcmn.cpp:206) wxEventLoopManual::DoRun
    31: (f:\programming\libs\wxwidgets\src\common\evtloopcmn.cpp:78) wxEventLoopBase::Run
    32: (f:\programming\libs\wxwidgets\src\common\appbase.cpp:334) wxAppConsoleBase::MainLoop
    33: (f:\programming\libs\wxwidgets\src\common\init.cpp:495) wxEntryReal
    34: (f:\programming\libs\wxwidgets\src\msw\main.cpp:188) wxEntry
    35: (f:\programming\libs\wxwidgets\src\msw\main.cpp:415) wxEntry
    36: (c:\dev\slade3\src\application\mainapp.cpp:421) WinMain
    37: (f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl:264) __scrt_common_main_seh
    38: [unknown location] BaseThreadInitThunk
    39: [unknown location] RtlUnicodeStringToInteger
    40: [unknown location] RtlUnicodeStringToInteger
    
    Last Log Messages:
    00:45:04: Initialising OpenGL...
    00:45:04: OpenGL Version: 4.5
    00:45:04: Max Texture Size: 16384x16384
    00:45:04: Checking extensions...
    00:45:04: Vertex Buffer Objects supported
    00:45:04: Point Sprites supported
    00:45:04: Framebuffer Objects supported
    00:45:06: Read game configuration "doom2" + "zdoom"
    00:45:06: Opening map MAP03
    00:45:06: Reading Hexen format map
    00:45:06: Removed 0 detached vertices, 0 detached sides, 0 invalid sides and 0 detached sectors

Makes no sense, and doesn't happen in Debug, only Release.