### PR TITLE
OS X fixes for wxWidgets 3.1

### DIFF
--- a/src/Application/MainApp.cpp
+++ b/src/Application/MainApp.cpp
@@ -454,7 +454,7 @@ bool MainApp::initDirectories()
 #endif
 
 	// If we're passed in a INSTALL_PREFIX (from CMAKE_INSTALL_PREFIX), use this for the installation prefix
-#if defined(__UNIX__) && defined(INSTALL_PREFIX)
+#if defined(__WXGTK__) && defined(INSTALL_PREFIX)
 	wxStandardPaths::Get().SetInstallPrefix(INSTALL_PREFIX);
 #endif//defined(__UNIX__) && defined(INSTALL_PREFIX)
 	

--- a/src/MainEditor/MainWindow.cpp
+++ b/src/MainEditor/MainWindow.cpp
@@ -997,12 +997,11 @@ void MainWindow::onHTMLLinkClicked(wxEvent& e)
 	else if (href.StartsWith("recent://"))
 	{
 		// Recent file
-		string rs = href.Right(1);
+		string rs = href.Mid(9);
 		unsigned long index = 0;
 		rs.ToULong(&index);
-		index++;
-
-		panel_archivemanager->handleAction(S_FMT("aman_recent%lu", index));
+		theApp->doAction("aman_recent", index);
+		createStartPage();
 	}
 	else if (href.StartsWith("action://"))
 	{


### PR DESCRIPTION
Set install prefix only for wxGTK targets (there is no need in this on OS X)
Generic way to get executable path from bundle (works in 3.0 and 3.1)
Fixed opening of recent items from non-WebView start page (not really OS X specific)