### PR TITLE
OS X fixes for stable branch

### DIFF
--- a/src/Application/MainApp.cpp
+++ b/src/Application/MainApp.cpp
@@ -454,7 +454,7 @@ bool MainApp::initDirectories()
 #endif
 
 	// If we're passed in a INSTALL_PREFIX (from CMAKE_INSTALL_PREFIX), use this for the installation prefix
-#if defined(__UNIX__) && defined(INSTALL_PREFIX)
+#if defined(__WXGTK__) && defined(INSTALL_PREFIX)
 	wxStandardPaths::Get().SetInstallPrefix(INSTALL_PREFIX);
 #endif//defined(__UNIX__) && defined(INSTALL_PREFIX)
 	

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 set_target_properties(slade PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${SLADE_OUTPUT_DIR})
 
 set_target_properties(slade PROPERTIES XCODE_ATTRIBUTE_GCC_PRECOMPILE_PREFIX_HEADER YES)
-set_target_properties(slade PROPERTIES XCODE_ATTRIBUTE_GCC_PREFIX_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/Main.h)
+set_target_properties(slade PROPERTIES XCODE_ATTRIBUTE_GCC_PREFIX_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/Application/Main.h)
 
 	# TODO: Installation targets for APPLE
 if(APPLE)


### PR DESCRIPTION
Adjusted path to Xcode prefix header
Set install prefix only for wxGTK targets
Generic way to get executable path from bundle