### PR TITLE
Allow multiple instances if the new ones are started without arguments (Fixes issues created by #333)

### DIFF
--- a/src/Application/MainApp.cpp
+++ b/src/Application/MainApp.cpp
@@ -772,11 +772,16 @@ void MainApp::initActions()
 /* MainApp::singleInstanceCheck
  * Checks if another instance of SLADE is already running, and if so,
  * sends the args to the file listener of the existing SLADE
- * process. Returns false if another instance was found
+ * process. Returns false if another instance was found and the new
+ * SLADE was started with arguments
  *******************************************************************/
 bool MainApp::singleInstanceCheck()
 {
 	single_instance_checker = new wxSingleInstanceChecker;
+
+	if (argc == 1)
+		return true;
+
 	if (single_instance_checker->IsAnotherRunning())
 	{
 		delete single_instance_checker;


### PR DESCRIPTION
This resolves the problem I've mentioned as a comment in #333.

If SLADE is running and a new instance is started without arguments it stays open otherwise it sends the arguments to the first instance and closes the second. This mimics the behavior of VLC.

Disclaimer: I've only tested the changes with the 3.1.1.1 release because master currently doesn't compile on my end.