### PR TITLE
Fix Debuggable in release mode

### DIFF
--- a/src/Application/Main.h
+++ b/src/Application/Main.h
@@ -136,7 +136,7 @@ const string MAP_TYPE_NAMES[] = {
 };
 
 // Debug helper type
-#ifdef WXDEBUG
+#ifdef DEBUG
 #include <typeinfo>
 class Debuggable
 {
@@ -207,13 +207,14 @@ inline void LOG_DEBUG(
 }
 
 #define LOG_DEBUG_VAR(name) LOG_DEBUG(#name ": ", name)
-#else  // WXDEBUG
+#else  // DEBUG
 struct Debuggable {
-	string repr;
+	template<typename T>
+	Debuggable(T _unused) { }
 };
 #define LOG_DEBUG(...)
 #define LOG_DEBUG_VAR(name)
-#endif  // WXDEBUG
+#endif  // DEBUG
 
 
 


### PR DESCRIPTION
This fixes #497.

Relying on `WXDEBUG` meant that the non-debug code was only used when the wx library had been built in non-debug mode, regardless of how SLADE was built.

Also, the non-debug code didn't have a constructor that took any arguments, hence the compile errors.