### PR TITLE
Fixed compilation on OS X

### DIFF
--- a/src/UI/TextEditor/SCallTip.cpp
+++ b/src/UI/TextEditor/SCallTip.cpp
@@ -60,7 +60,10 @@ SCallTip::SCallTip(wxWindow* parent)
 	font = GetFont();
 
 	Show(false);
+
+#ifndef __WXOSX__
 	SetDoubleBuffered(true);
+#endif // !__WXOSX__
 
 	// Bind events
 	Bind(wxEVT_PAINT, &SCallTip::onPaint, this);


### PR DESCRIPTION
wxWindow::SetDoubleBuffered() isn't available on OS X