### PR TITLE
Select sectors by distance.

### DIFF
--- a/src/MapEditor/SLADEMap/SLADEMap.cpp
+++ b/src/MapEditor/SLADEMap/SLADEMap.cpp
@@ -2951,16 +2951,38 @@ vector<int> SLADEMap::nearestThingMulti(fpoint2_t point)
  *******************************************************************/
 int SLADEMap::sectorAt(fpoint2_t point)
 {
+	int closest_sector = -1;
+	float closest_sector_distance = -1;
+
+	float sector_distance;
+	float vertex_distance;
+
+	vector<MapVertex*> sector_vertices;
+
 	// Go through sectors
 	for (unsigned a = 0; a < sectors.size(); a++)
 	{
 		// Check if point is within sector
-		if (sectors[a]->isWithin(point))
-			return a;
+		if (!sectors[a]->isWithin(point))
+			continue;
+
+		sector_distance = -1;
+		sectors[a]->getVertices(sector_vertices);
+		for (unsigned i = 0; i < sector_vertices.size(); i++)
+		{
+			vertex_distance = sector_vertices[i]->point().distance_to(point);
+			if (sector_distance < 0 || vertex_distance < sector_distance)
+				sector_distance = vertex_distance;
+		}
+
+		if (closest_sector < 0 || sector_distance < closest_sector_distance)
+		{
+			closest_sector = a;
+			closest_sector_distance = sector_distance;
+		}
 	}
 
-	// Not within a sector
-	return -1;
+	return closest_sector;
 }
 
 /* SLADEMap::getMapBBox


### PR DESCRIPTION
When selecting sectors by poin, select sector containing point and closest to
given point, instead of just selecting first one containing it. Allows working
with sectors inside sectors, needed when working with 3d floors or similar.
Use custom distance code, as MapSector::distanceTo seems to be very slow
(noticeable lag on hover highlights if using it).

SIDE NOTE:
Considering some performance implication of this, and the need of this to work 3d stuff (not entirely sure it is strictly needed, as I'm new to mapping, and maybe there are some other methods, but in any case such precise selection seems like a correct way to function), highlight feature might be problematic (though with this distance code it was not bad on my smallish map, while distanceTo was very slow).