### PR TITLE
iwads.cfg: Fix erroneous colon for the GOG strife WAD path

### DIFF
--- a/dist/res/config/iwads.cfg
+++ b/dist/res/config/iwads.cfg
@@ -60,7 +60,7 @@ gog
 	strife
 	{
 		id = "\\Games\\1432899949";
-		path = "/strife1.wad":
+		path = "/strife1.wad";
 	}
 }
 


### PR DESCRIPTION
This would cause SLADE to crash on Windows (and likely Linux/OSX, however I didn't test on those).