### PR TITLE
Property: Fix error case for invalid types in the constructor

### DIFF
--- a/src/Utility/PropertyList/Property.cpp
+++ b/src/Utility/PropertyList/Property.cpp
@@ -63,7 +63,7 @@ Property::Property(uint8_t type)
 	else
 	{
 		// Invalid type given, default to boolean
-		type = PROP_BOOL;
+		this->type = PROP_BOOL;
 		value.Boolean = true;
 	}
 }


### PR DESCRIPTION
Previously this was just reassigning the parameter.