### PR TITLE
Fixed crash when opening lump in text editor

### DIFF
--- a/src/UI/TextEditor/TextEditor.cpp
+++ b/src/UI/TextEditor/TextEditor.cpp
@@ -357,7 +357,7 @@ wxThread::ExitCode JumpToCalculator::Entry()
 					name = tz.getToken();
 
 				for (unsigned i = 0; i < ignore.size(); ++i)
-					if (S_CMPNOCASE(name, ignore[a]))
+					if (S_CMPNOCASE(name, ignore[i]))
 						name = tz.getToken();
 
 				// Numbered block, add block name


### PR DESCRIPTION
Opening ZDoom Texture Definitions lump no longer leads to a crash