### PR TITLE
Make SLADE's map editor recognize full path textures.

### DIFF
--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -272,33 +272,32 @@ void ResourceManager::addEntry(ArchiveEntry* entry)
 			return;
 
 		// Check for patch entry
-		if (type->extraProps().propertyExists("patch") || entry->isInNamespace("patches")) {
+		if (type->extraProps().propertyExists("patch") || entry->isInNamespace("patches"))
+		{
 			patches[name].add(entry);
 			/*
 			if (name.Length() > 8) patches[name.Left(8)].add(entry);
-			if (!entry->getParent()->isTreeless()) {
+			if (!entry->getParent()->isTreeless())
 				patches[path].add(entry);
-			}
 			*/
 		}
 
 		// Check for flat entry
-		if (type->getId() == "gfx_flat" || entry->isInNamespace("flats")) {
+		if (type->getId() == "gfx_flat" || entry->isInNamespace("flats"))
+		{
 			flats[name].add(entry);
-			if (name.Length() > 8) flats[name.Left(8)].add(entry);
-			if (!entry->getParent()->isTreeless()) {
+			// if (name.Length() > 8) flats[name.Left(8)].add(entry);
+			if (!entry->getParent()->isTreeless())
 				flats[path].add(entry);
-			}
 		}
 
 		// Check for stand-alone texture entry
 		if (entry->isInNamespace("textures") || entry->isInNamespace("hires"))
 		{
 			satextures[name].add(entry);
-			if (name.Length() > 8) satextures[name.Left(8)].add(entry);
-			if (!entry->getParent()->isTreeless()) {
+			// if (name.Length() > 8) satextures[name.Left(8)].add(entry);
+			if (!entry->getParent()->isTreeless())
 				satextures[path].add(entry);
-			}
 
 			// Add name to hash table
 			ResourceManager::Doom64HashTable[getTextureHash(name)] = name;

--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -650,12 +650,6 @@ ArchiveEntry* ResourceManager::getFlatEntry(string flat, Archive* priority)
 	ArchiveEntry* entry = res.entries[0];
 	for (unsigned a = 0; a < res.entries.size(); a++)
 	{
-		// Talon1024 - If texture is a full path to the texture file in the archive,
-		// get the texture entry.
-		if (flat.IsSameAs(res.entries[a]->getPath(true).Mid(1), false)) {
-			return res.entries[a];
-		}
-
 		// If it's in the 'priority' archive, return it
 		if (priority && (res.entries[a]->getParent() == priority ||
 		                 // PK3 and Doom64 maps are contained in an embedded .wad,
@@ -694,13 +688,6 @@ ArchiveEntry* ResourceManager::getTextureEntry(string texture, string nspace, Ar
 		// namespace ought to be either "textures" or "hires"
 		if (nspace.IsEmpty() || res.entries[a]->isInNamespace(nspace))
 		{
-			// Talon1024 - If texture is a full path to the texture file in the archive,
-			// get the texture entry.
-			string entryPath = res.entries[a]->getPath(true).Mid(1);
-			if (texture.IsSameAs(res.entries[a]->getPath(true).Mid(1), false)) {
-				return res.entries[a];
-			}
-
 			// If it's in the 'priority' archive, return it
 			if (priority && (res.entries[a]->getParent() == priority ||
 			                 // PK3 and Doom64 maps are contained in an embedded .wad,

--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -674,7 +674,6 @@ ArchiveEntry* ResourceManager::getFlatEntry(string flat, Archive* priority)
  *******************************************************************/
 ArchiveEntry* ResourceManager::getTextureEntry(string texture, string nspace, Archive* priority)
 {
-	//wxLogMessage("getTextureEntry called - texture: %s, nspace: %s, priority: %s", texture, nspace, priority->getFilename());
 	// Check resource with matching name exists
 	EntryResource& res = satextures[texture.Upper()];
 	if (res.entries.size() == 0)

--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -278,14 +278,18 @@ void ResourceManager::addEntry(ArchiveEntry* entry)
 		// Check for flat entry
 		if (type->getId() == "gfx_flat" || entry->isInNamespace("flats")) {
 			flats[name].add(entry);
-			flats[path].add(entry);
+			if (!entry->getParent()->isTreeless()) {
+				flats[path].add(entry);
+			}
 		}
 
 		// Check for stand-alone texture entry
 		if (entry->isInNamespace("textures") || entry->isInNamespace("hires"))
 		{
 			satextures[name].add(entry);
-			satextures[path].add(entry);
+			if (!entry->getParent()->isTreeless()) {
+				satextures[path].add(entry);
+			}
 
 			// Add name to hash table
 			ResourceManager::Doom64HashTable[getTextureHash(name)] = name;

--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -272,12 +272,20 @@ void ResourceManager::addEntry(ArchiveEntry* entry)
 			return;
 
 		// Check for patch entry
-		if (type->extraProps().propertyExists("patch") || entry->isInNamespace("patches"))
+		if (type->extraProps().propertyExists("patch") || entry->isInNamespace("patches")) {
 			patches[name].add(entry);
+			/*
+			if (name.Length() > 8) patches[name.Left(8)].add(entry);
+			if (!entry->getParent()->isTreeless()) {
+				patches[path].add(entry);
+			}
+			*/
+		}
 
 		// Check for flat entry
 		if (type->getId() == "gfx_flat" || entry->isInNamespace("flats")) {
 			flats[name].add(entry);
+			if (name.Length() > 8) flats[name.Left(8)].add(entry);
 			if (!entry->getParent()->isTreeless()) {
 				flats[path].add(entry);
 			}
@@ -287,6 +295,7 @@ void ResourceManager::addEntry(ArchiveEntry* entry)
 		if (entry->isInNamespace("textures") || entry->isInNamespace("hires"))
 		{
 			satextures[name].add(entry);
+			if (name.Length() > 8) satextures[name.Left(8)].add(entry);
 			if (!entry->getParent()->isTreeless()) {
 				satextures[path].add(entry);
 			}


### PR DESCRIPTION
I've modified the resource manager code so that walls and flats in a UDMF-format map that use the full path name of an image file from a ZIP/PK3 archive as a texture name (you'll find countless examples in WolfenDoom: Blade of Agony) will be recognized and loaded by SLADE's map editor.