### PR TITLE
Allow editing of SOC lumps in the text editor.

### DIFF
--- a/dist/res/config/entry_types/types_text.txt
+++ b/dist/res/config/entry_types/types_text.txt
@@ -396,8 +396,14 @@ entry_types
 		match_name = "lua_*";
 		text_language = "srb2lua";
 	}
-
-	// ZDaemon text lumps
+        
+        soc : text
+	{
+		name = "Sonic Object Configuration";
+		match_name = "soc_*";
+	}
+	
+        // ZDaemon text lumps
 	patchinf : text
 	{
 		name = "Patchinfo";


### PR DESCRIPTION
This one commit just adds soc to the list of text types, so it gets
recognized as a SOC and not (Unknown) in SLADE.