### PR TITLE
Fix MSVC always recompiling

### DIFF
--- a/build/msvc/SLADE.vcxproj
+++ b/build/msvc/SLADE.vcxproj
@@ -1461,9 +1461,9 @@
     <ClInclude Include="..\..\src\General\SAction.h" />
     <ClInclude Include="..\..\src\General\UndoRedo.h" />
     <ClInclude Include="..\..\src\General\VersionCheck.h" />
-    <ClInclude Include="..\..\src\glew\glew.h" />
-    <ClInclude Include="..\..\src\glew\glxew.h" />
-    <ClInclude Include="..\..\src\glew\wglew.h" />
+    <ClInclude Include="..\..\src\External\glew\glew.h" />
+    <ClInclude Include="..\..\src\External\glew\glxew.h" />
+    <ClInclude Include="..\..\src\External\glew\wglew.h" />
     <ClInclude Include="..\..\src\Graphics\CTexture\CTexture.h" />
     <ClInclude Include="..\..\src\Graphics\CTexture\PatchTable.h" />
     <ClInclude Include="..\..\src\Graphics\CTexture\TextureXList.h" />
@@ -1620,7 +1620,7 @@
     <ClInclude Include="..\..\src\MapEditor\UI\PropsPanel\ThingPropsPanel.h" />
     <ClInclude Include="..\..\src\MapEditor\UI\ScriptEditorPanel.h" />
     <ClInclude Include="..\..\src\MapEditor\UI\ShapeDrawPanel.h" />
-    <ClInclude Include="..\..\src\mus2mid\mus2mid.h" />
+    <ClInclude Include="..\..\src\External\mus2mid\mus2mid.h" />
     <ClInclude Include="..\..\src\OpenGL\Drawing.h" />
     <ClInclude Include="..\..\src\OpenGL\GLTexture.h" />
     <ClInclude Include="..\..\src\OpenGL\OpenGL.h" />

--- a/build/msvc/SLADE.vcxproj.filters
+++ b/build/msvc/SLADE.vcxproj.filters
@@ -1707,15 +1707,6 @@
     <ClInclude Include="..\..\src\Dialogs\TranslationEditorDialog.h">
       <Filter>Dialogs</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\glew\glew.h">
-      <Filter>External\GLEW</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\glew\glxew.h">
-      <Filter>External\GLEW</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\mus2mid\mus2mid.h">
-      <Filter>External\Mus2Mid</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\External\dumb\internal\dumb.h">
       <Filter>External\DUMB\internal</Filter>
     </ClInclude>
@@ -1802,9 +1793,6 @@
     </ClInclude>
     <ClInclude Include="..\..\src\Utility\MemChunk.h">
       <Filter>Utility</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\glew\wglew.h">
-      <Filter>External\GLEW</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\General\Clipboard.h">
       <Filter>General</Filter>
@@ -2378,6 +2366,18 @@
     </ClInclude>
     <ClInclude Include="..\..\src\common.h" />
     <ClInclude Include="..\..\src\common2.h" />
+    <ClInclude Include="..\..\src\External\glew\glxew.h">
+      <Filter>External\GLEW</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\External\glew\glew.h">
+      <Filter>External\GLEW</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\External\glew\wglew.h">
+      <Filter>External\GLEW</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\External\mus2mid\mus2mid.h">
+      <Filter>External\Mus2Mid</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="slade.ico" />


### PR DESCRIPTION
Old settings for a few headers didn't reference the correct directories, missing out the fact that some of the files were in the "External" folder. Ignore the branch name; I'm working on a new feature and this commit precedes my work on that.