### PR TITLE
Improved Text Editor syntax highlighting (and more) via custom lexer

### DIFF
--- a/build/msvc/SLADE.vcxproj
+++ b/build/msvc/SLADE.vcxproj
@@ -1220,6 +1220,7 @@
     <ClCompile Include="..\..\src\UI\SToolBar\SToolBar.cpp" />
     <ClCompile Include="..\..\src\UI\SToolBar\SToolBarButton.cpp" />
     <ClCompile Include="..\..\src\UI\STopWindow.cpp" />
+    <ClCompile Include="..\..\src\UI\TextEditor\Lexer.cpp" />
     <ClCompile Include="..\..\src\UI\TextEditor\SCallTip.cpp" />
     <ClCompile Include="..\..\src\UI\TextEditor\TextEditor.cpp" />
     <ClCompile Include="..\..\src\UI\TextEditor\TextLanguage.cpp" />
@@ -1651,6 +1652,7 @@
     <ClInclude Include="..\..\src\UI\SToolBar\SToolBar.h" />
     <ClInclude Include="..\..\src\UI\SToolBar\SToolBarButton.h" />
     <ClInclude Include="..\..\src\UI\STopWindow.h" />
+    <ClInclude Include="..\..\src\UI\TextEditor\Lexer.h" />
     <ClInclude Include="..\..\src\UI\TextEditor\SCallTip.h" />
     <ClInclude Include="..\..\src\UI\TextEditor\TextEditor.h" />
     <ClInclude Include="..\..\src\UI\TextEditor\TextLanguage.h" />

--- a/build/msvc/SLADE.vcxproj.filters
+++ b/build/msvc/SLADE.vcxproj.filters
@@ -1371,6 +1371,9 @@
     <ClCompile Include="_CreatePCH.cpp">
       <Filter>Application</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\UI\TextEditor\Lexer.cpp">
+      <Filter>UI\Text Editor</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />
@@ -2377,6 +2380,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\External\mus2mid\mus2mid.h">
       <Filter>External\Mus2Mid</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\UI\TextEditor\Lexer.h">
+      <Filter>UI\Text Editor</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/dist/res/config/languages/0_base.txt
+++ b/dist/res/config/languages/0_base.txt
@@ -4,6 +4,7 @@ cstyle {
 	comment_begin = "/*";
 	comment_end = "*/";
 	comment_line = "//";
+	comment_doc = "///";
 	preprocessor = "#";
 	case_sensitive = true;
 

--- a/dist/res/config/languages/0_base.txt
+++ b/dist/res/config/languages/0_base.txt
@@ -1,5 +1,6 @@
 
-cstyle {
+cstyle
+{
 	name = "C/C++";
 	comment_begin = "/*";
 	comment_end = "*/";
@@ -7,15 +8,21 @@ cstyle {
 	comment_doc = "///";
 	preprocessor = "#";
 	case_sensitive = true;
+	block_begin = "{";
+	block_end = "}";
+	pp_block_begin = "if", "ifdef", "ifndef", "region";
+	pp_block_end = "endif", "endregion";
 
-	keywords = {
+	keywords =
+	{
 		void, char, short, long, int, float, double, unsigned, bool,
 		if, else, do, while, for, true, false, return, const, new, delete,
 		until, switch, default, case, continue, break, define, goto,
 		include, enum, struct, region
 	}
 
-	constants = {
+	constants =
+	{
 		NULL
 	}
 }

--- a/dist/res/config/languages/decorate.txt
+++ b/dist/res/config/languages/decorate.txt
@@ -6,6 +6,7 @@ decorate : cstyle {
 	function_link = "http://zdoom.org/wiki/%s";
 	case_sensitive = false;
 	blocks = "Actor", "DamageType";
+	comment_doc = "//$";
 
 	keywords = {
 		$override,
@@ -17,7 +18,11 @@ decorate : cstyle {
 		Hold, AltHold, Flash, AltFlash, Reload, Zoom, Pickup, Use, Drop, Bright, Fast, Slow, NoDelay,
 		CanRaise, Idle, Active, Inactive, Light, Offset, Action, Native, Const, Enum, Replaces,
 		LightDone, Super, Spray, GenericFreezeDeath, GenericCrush, User1, User2, User3, User4,
-		DeadLowered,
+		DeadLowered
+	}
+
+	properties = {
+		$override,
 
 		// Actor properties
 		

--- a/dist/res/config/text_styles/0default_dark.sss
+++ b/dist/res/config/text_styles/0default_dark.sss
@@ -112,7 +112,7 @@ styleset
 
 	foldmargin
     {
-		foreground = 143, 177, 158;
+		foreground = 115, 140, 126;
 		background = 47, 51, 49;
 	}
 

--- a/dist/res/config/text_styles/0default_dark.sss
+++ b/dist/res/config/text_styles/0default_dark.sss
@@ -1,0 +1,134 @@
+
+styleset
+{
+	name = "SLADE (Dark)";
+
+	default
+    {
+		size = 10;
+		foreground = 215, 215, 215;
+		background = 37, 37, 37;
+		bold = 0;
+		italic = 0;
+		underlined = 0;
+	}
+
+	selection
+    {
+		background = 72, 72, 72;
+	}
+
+	preprocessor
+    {
+		foreground = 85, 113, 128;
+	}
+
+	comment
+    {
+		foreground = 102, 124, 97;
+		italic = 1;
+	}
+
+	comment_doc
+	{
+		foreground = 97, 116, 124;
+		italic = 1;
+	}
+
+	string
+    {
+		foreground = 216, 101, 84;
+	}
+
+	character
+    {
+		foreground = 216, 101, 84;
+	}
+
+	keyword
+    {
+		foreground = 94, 142, 232;
+	}
+
+	constant
+    {
+		foreground = 188, 117, 198;
+	}
+
+	type
+    {
+		foreground = 125, 105, 220;
+	}
+
+	property
+    {
+		foreground = 121, 234, 214;
+	}
+
+	function
+    {
+		foreground = 239, 222, 154;
+	}
+
+	number
+    {
+		foreground = 188, 174, 225;
+	}
+
+	operator
+    {
+		foreground = 175, 205, 198;
+	}
+
+	bracematch
+    {
+		background = 36, 96, 67;
+		bold = 1;
+	}
+
+	bracebad
+    {
+		background = 255, 170, 170;
+		bold = 1;
+	}
+
+	linenum
+    {
+		foreground = 176, 200, 186;
+		background = 47, 51, 49;
+	}
+
+	calltip
+    {
+		foreground = 215, 215, 215;
+		background = 58, 61, 58;
+	}
+
+	calltip_hl
+    {
+		foreground = 39, 194, 133;
+		bold = 1;
+	}
+
+	foldmargin
+    {
+		foreground = 143, 177, 158;
+		background = 47, 51, 49;
+	}
+
+	guides
+    {
+		foreground = 48, 82, 82;
+	}
+
+	wordmatch
+	{
+		foreground = 81, 185, 255;
+	}
+
+	current_line
+	{
+		foreground = 30, 51, 51;
+		background = 27, 27, 27;
+	}
+}

--- a/dist/res/config/text_styles/default.sss
+++ b/dist/res/config/text_styles/default.sss
@@ -112,7 +112,7 @@ styleset
 
 	foldmargin
 	{
-		foreground = 81, 115, 96;
+		foreground = 145, 172, 157;
 		background = 237, 239, 238;
 	}
 

--- a/dist/res/config/text_styles/default.sss
+++ b/dist/res/config/text_styles/default.sss
@@ -1,17 +1,16 @@
 
 styleset
 {
-	name = "SLADE Default";
+	name = "SLADE (Light)";
 
 	default
 	{
-		//font = "";					// Undefined means use system default (monospace)
-		size = 10;						// Default is 10
-		foreground = 0, 0, 0;			// Default is black (0,0,0)
-		background = 255, 255, 255;		// Default is white (255,255,255)
-		bold = false;					// Default is false
-		italic = false;					// Default is false
-		underlined = false;				// Default is false
+		size = 10;
+		foreground = 75, 75, 75;
+		background = 255, 255, 255;
+		bold = false;
+		italic = false;
+		underlined = false;
 	}
 
 	selection
@@ -21,74 +20,115 @@ styleset
 
 	preprocessor
 	{
-		// Any omitted properties will be inherited from 'default'
-		foreground = 0, 150, 200;
+		foreground = 117, 147, 164;
 	}
 
 	comment
 	{
-		foreground = 0, 150, 60;
+		foreground = 106, 147, 98;
+		italic = 1;
+	}
+
+	comment_doc
+	{
+		foreground = 108, 142, 157;
+		italic = 1;
 	}
 
 	string
 	{
-		foreground = 0, 120, 130;
+		foreground = 156, 32, 14;
 	}
 
 	character
 	{
-		foreground = 0, 120, 130;
+		foreground = 157, 20, 0;
 	}
 
 	keyword
 	{
-		foreground = 0, 30, 200;
+		foreground = 9, 78, 206;
 	}
 
 	constant
 	{
-		foreground = 180, 30, 200;
+		foreground = 169, 82, 182;
+	}
+
+	type
+	{
+		foreground = 89, 2, 208;
+	}
+
+	property
+	{
+		foreground = 22, 141, 120;
 	}
 
 	function
 	{
-		foreground = 200, 100, 30;
+		foreground = 143, 120, 24;
+	}
+
+	number
+	{
+		foreground = 83, 57, 159;
+	}
+
+	operator
+	{
+		foreground = 56, 88, 80;
 	}
 
 	bracematch
 	{
-		background = 170, 255, 170;
+		background = 217, 244, 231;
+		bold = 1;
 	}
 
 	bracebad
 	{
 		background = 255, 170, 170;
+		bold = 1;
 	}
 
 	linenum
 	{
-		background = 240, 240, 240;
+		foreground = 81, 115, 96;
+		background = 237, 239, 238;
 	}
 
 	calltip
 	{
-		background = 255, 255, 180;
-		foreground = 0, 0, 0;
+		foreground = 46, 46, 46;
+		background = 245, 248, 241;
 	}
 
 	calltip_hl
 	{
-		foreground = 0, 0, 200;
+		foreground = 0, 181, 108;
+		bold = 1;
 	}
 
 	foldmargin
 	{
-		background = 240, 240, 240;
-		foreground = 100, 170, 170;
+		foreground = 81, 115, 96;
+		background = 237, 239, 238;
 	}
 
 	guides
 	{
-		foreground = 180, 210, 210;
+		foreground = 158, 197, 197;
+	}
+
+	wordmatch
+	{
+		foreground = 9, 78, 206;
+	}
+
+	current_line
+	{
+		foreground = 218, 233, 225;
+		background = 247, 247, 247;
 	}
 }

--- a/dist/res/config/text_styles/material.sss
+++ b/dist/res/config/text_styles/material.sss
@@ -1,0 +1,110 @@
+styleset {
+	name = "Material";
+
+	default {
+		font = "Courier New";
+		size = 10;
+		foreground = 171, 178, 191;
+		background = 40, 44, 52;
+		bold = 0;
+		italic = 0;
+		underlined = 0;
+	}
+
+	selection {
+		background = 62, 68, 81;
+	}
+
+	preprocessor {
+		foreground = 92, 99, 112;
+	}
+
+	comment {
+		foreground = 92, 99, 112;
+		italic = 1;
+	}
+
+	comment_doc {
+		foreground = 92, 99, 112;
+		italic = 1;
+	}
+
+	string {
+		foreground = 152, 195, 121;
+	}
+
+	character {
+		foreground = 152, 195, 121;
+	}
+
+	keyword {
+		foreground = 198, 120, 221;
+	}
+
+	constant {
+		foreground = 86, 182, 194;
+	}
+
+	type {
+		foreground = 229, 192, 123;
+	}
+
+	property {
+		foreground = 224, 108, 117;
+	}
+
+	function {
+		foreground = 97, 175, 239;
+	}
+
+	number {
+		foreground = 209, 154, 102;
+	}
+
+	operator {
+		foreground = 171, 178, 191;
+	}
+
+	bracematch {
+		foreground = 152, 195, 121;
+		bold = 1;
+	}
+
+	bracebad {
+		bold = 1;
+	}
+
+	linenum {
+		foreground = 116, 115, 105;
+		background = 40, 44, 52;
+	}
+
+	calltip {
+		foreground = 171, 178, 191;
+		background = 66, 72, 85;
+	}
+
+	calltip_hl {
+		foreground = 0, 181, 108;
+		bold = 1;
+	}
+
+	foldmargin {
+		foreground = 116, 115, 105;
+		background = 40, 44, 52;
+	}
+
+	guides {
+		foreground = 92, 99, 112;
+	}
+
+	wordmatch {
+		foreground = 9, 78, 206;
+	}
+
+	current_line {
+		foreground = 44, 50, 60;
+		background = 44, 50, 60;
+	}
+
+}

--- a/dist/res/config/text_styles/old_dark.sss
+++ b/dist/res/config/text_styles/old_dark.sss
@@ -1,6 +1,6 @@
 styleset
 {
-	name = "Dark";
+	name = "Old Dark";
 
 	default
 	{

--- a/dist/res/config/text_styles/old_default.sss
+++ b/dist/res/config/text_styles/old_default.sss
@@ -1,0 +1,94 @@
+
+styleset
+{
+	name = "Old SLADE Default";
+
+	default
+	{
+		//font = "";					// Undefined means use system default (monospace)
+		size = 10;						// Default is 10
+		foreground = 0, 0, 0;			// Default is black (0,0,0)
+		background = 255, 255, 255;		// Default is white (255,255,255)
+		bold = false;					// Default is false
+		italic = false;					// Default is false
+		underlined = false;				// Default is false
+	}
+
+	selection
+	{
+		background = 200, 200, 200;
+	}
+
+	preprocessor
+	{
+		// Any omitted properties will be inherited from 'default'
+		foreground = 0, 150, 200;
+	}
+
+	comment
+	{
+		foreground = 0, 150, 60;
+	}
+
+	string
+	{
+		foreground = 0, 120, 130;
+	}
+
+	character
+	{
+		foreground = 0, 120, 130;
+	}
+
+	keyword
+	{
+		foreground = 0, 30, 200;
+	}
+
+	constant
+	{
+		foreground = 180, 30, 200;
+	}
+
+	function
+	{
+		foreground = 200, 100, 30;
+	}
+
+	bracematch
+	{
+		background = 170, 255, 170;
+	}
+
+	bracebad
+	{
+		background = 255, 170, 170;
+	}
+
+	linenum
+	{
+		background = 240, 240, 240;
+	}
+
+	calltip
+	{
+		background = 255, 255, 180;
+		foreground = 0, 0, 0;
+	}
+
+	calltip_hl
+	{
+		foreground = 0, 0, 200;
+	}
+
+	foldmargin
+	{
+		background = 240, 240, 240;
+		foreground = 100, 170, 170;
+	}
+
+	guides
+	{
+		foreground = 180, 210, 210;
+	}
+}

--- a/src/Dialogs/Preferences/PreferencesDialog.cpp
+++ b/src/Dialogs/Preferences/PreferencesDialog.cpp
@@ -85,7 +85,9 @@ PreferencesDialog::PreferencesDialog(wxWindow* parent) : SDialog(parent, "SLADE 
 
 	// Create preferences TreeBook
 	tree_prefs = new wxTreebook(this, -1, wxDefaultPosition, wxDefaultSize);
+#if wxMAJOR_VERSION > 3 || (wxMAJOR_VERSION == 3 && wxMINOR_VERSION >= 1)
 	tree_prefs->GetTreeCtrl()->EnableSystemTheme(true);
+#endif
 
 	// Setup preferences TreeBook
 	PrefsPanelBase* panel;

--- a/src/Dialogs/Preferences/TextEditorPrefsPanel.cpp
+++ b/src/Dialogs/Preferences/TextEditorPrefsPanel.cpp
@@ -50,6 +50,8 @@ EXTERN_CVAR(Bool, txed_calltips_use_font)
 EXTERN_CVAR(Bool, txed_fold_enable)
 EXTERN_CVAR(Bool, txed_fold_comments)
 EXTERN_CVAR(Bool, txed_fold_preprocessor)
+EXTERN_CVAR(Bool, txed_match_cursor_word)
+EXTERN_CVAR(Int, txed_hilight_current_line)
 
 
 /*******************************************************************
@@ -103,9 +105,24 @@ TextEditorPrefsPanel::TextEditorPrefsPanel(wxWindow* parent) : PrefsPanelBase(pa
 	cb_indent_guides = new wxCheckBox(this, -1, "Show Indentation Guides");
 	sizer->Add(cb_indent_guides, 0, wxEXPAND|wxALL, 4);
 
+	// Hilight current line
+	string choices[] = { "Off", "Background", "Background + Underline" };
+	hbox = new wxBoxSizer(wxHORIZONTAL);
+	choice_line_hilight = new wxChoice(this, -1, wxDefaultPosition, wxDefaultSize, 3, choices);
+	hbox->Add(new wxStaticText(this, -1, "Current Line Hilight: "), 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 2);
+	hbox->Add(choice_line_hilight, 1, wxEXPAND);
+	sizer->Add(hbox, 0, wxALL, 4);
+
 	// Brace matching
 	cb_brace_match = new wxCheckBox(this, -1, "Hilight Matching Braces");
 	sizer->Add(cb_brace_match, 0, wxEXPAND|wxALL, 4);
+
+	// Word matching
+	cb_match_cursor_word = new wxCheckBox(this, -1, "Hilight Matching Words");
+	cb_match_cursor_word->SetToolTip(
+		"When enabled, any words matching the word at the current cursor position will be hilighted"
+	);
+	sizer->Add(cb_match_cursor_word, 0, wxEXPAND|wxALL, 4);
 
 	// Separator
 	sizer->Add(new wxStaticLine(this, -1, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL), 0, wxEXPAND | wxALL, 4);
@@ -165,6 +182,7 @@ void TextEditorPrefsPanel::init()
 	cb_syntax_hilight->SetValue(txed_syntax_hilight);
 	cb_indent_guides->SetValue(txed_indent_guides);
 	cb_brace_match->SetValue(txed_brace_match);
+	cb_match_cursor_word->SetValue(txed_match_cursor_word);
 	cb_calltips_mouse->SetValue(txed_calltips_mouse);
 	cb_calltips_parenthesis->SetValue(txed_calltips_parenthesis);
 	cb_calltips_colourise->SetValue(txed_calltips_colourise);
@@ -175,6 +193,7 @@ void TextEditorPrefsPanel::init()
 	cb_fold_enable->SetValue(txed_fold_enable);
 	cb_fold_comments->SetValue(txed_fold_comments);
 	cb_fold_preprocessor->SetValue(txed_fold_preprocessor);
+	choice_line_hilight->SetSelection(txed_hilight_current_line);
 }
 
 /* TextEditorPrefsPanel::applyPreferences
@@ -187,6 +206,7 @@ void TextEditorPrefsPanel::applyPreferences()
 	txed_syntax_hilight = cb_syntax_hilight->GetValue();
 	txed_indent_guides = cb_indent_guides->GetValue();
 	txed_brace_match = cb_brace_match->GetValue();
+	txed_match_cursor_word = cb_match_cursor_word->GetValue();
 	txed_tab_width = spin_tab_width->GetValue();
 	txed_edge_column = spin_right_margin->GetValue();
 	txed_calltips_mouse = cb_calltips_mouse->GetValue();
@@ -197,4 +217,5 @@ void TextEditorPrefsPanel::applyPreferences()
 	txed_fold_enable = cb_fold_enable->GetValue();
 	txed_fold_comments = cb_fold_comments->GetValue();
 	txed_fold_preprocessor = cb_fold_preprocessor->GetValue();
+	txed_hilight_current_line = choice_line_hilight->GetSelection();
 }

--- a/src/Dialogs/Preferences/TextEditorPrefsPanel.cpp
+++ b/src/Dialogs/Preferences/TextEditorPrefsPanel.cpp
@@ -50,6 +50,7 @@ EXTERN_CVAR(Bool, txed_calltips_use_font)
 EXTERN_CVAR(Bool, txed_fold_enable)
 EXTERN_CVAR(Bool, txed_fold_comments)
 EXTERN_CVAR(Bool, txed_fold_preprocessor)
+EXTERN_CVAR(Bool, txed_fold_lines)
 EXTERN_CVAR(Bool, txed_match_cursor_word)
 EXTERN_CVAR(Int, txed_hilight_current_line)
 
@@ -163,6 +164,10 @@ TextEditorPrefsPanel::TextEditorPrefsPanel(wxWindow* parent) : PrefsPanelBase(pa
 	cb_fold_preprocessor = new wxCheckBox(this, -1, "Fold preprocessor regions");
 	cb_fold_preprocessor->SetToolTip("Enable folding for preprocessor regions, eg. #if/#endif, #region/#endregion");
 	sizer->Add(cb_fold_preprocessor, 0, wxEXPAND | wxALL, 4);
+
+	// Fold Lines
+	cb_fold_lines = new wxCheckBox(this, -1, "Show lines at contracted code folding regions");
+	sizer->Add(cb_fold_lines, 0, wxEXPAND | wxALL, 4);
 }
 
 /* TextEditorPrefsPanel::~TextEditorPrefsPanel
@@ -193,6 +198,7 @@ void TextEditorPrefsPanel::init()
 	cb_fold_enable->SetValue(txed_fold_enable);
 	cb_fold_comments->SetValue(txed_fold_comments);
 	cb_fold_preprocessor->SetValue(txed_fold_preprocessor);
+	cb_fold_lines->SetValue(txed_fold_lines);
 	choice_line_hilight->SetSelection(txed_hilight_current_line);
 }
 
@@ -217,5 +223,6 @@ void TextEditorPrefsPanel::applyPreferences()
 	txed_fold_enable = cb_fold_enable->GetValue();
 	txed_fold_comments = cb_fold_comments->GetValue();
 	txed_fold_preprocessor = cb_fold_preprocessor->GetValue();
+	txed_fold_lines = cb_fold_lines->GetValue();
 	txed_hilight_current_line = choice_line_hilight->GetSelection();
 }

--- a/src/Dialogs/Preferences/TextEditorPrefsPanel.h
+++ b/src/Dialogs/Preferences/TextEditorPrefsPanel.h
@@ -22,6 +22,7 @@ private:
 	wxCheckBox*	cb_fold_enable;
 	wxCheckBox*	cb_fold_comments;
 	wxCheckBox*	cb_fold_preprocessor;
+	wxCheckBox*	cb_fold_lines;
 	wxCheckBox*	cb_match_cursor_word;
 	wxChoice*	choice_line_hilight;
 

--- a/src/Dialogs/Preferences/TextEditorPrefsPanel.h
+++ b/src/Dialogs/Preferences/TextEditorPrefsPanel.h
@@ -22,6 +22,8 @@ private:
 	wxCheckBox*	cb_fold_enable;
 	wxCheckBox*	cb_fold_comments;
 	wxCheckBox*	cb_fold_preprocessor;
+	wxCheckBox*	cb_match_cursor_word;
+	wxChoice*	choice_line_hilight;
 
 public:
 	TextEditorPrefsPanel(wxWindow* parent);

--- a/src/Dialogs/Preferences/TextStylePrefsPanel.cpp
+++ b/src/Dialogs/Preferences/TextStylePrefsPanel.cpp
@@ -227,19 +227,24 @@ void TextStylePrefsPanel::init()
 			"\t{\n"
 				"\t\tx = CONSTANT;\n"
 				"\t\ty += 50;\n"
+				"\t\tobject.x_property = x;\n"
+				"\t\tobject.y_property = y;\n"
 			"\t}\n"
 		"}\n"
 		);
 
 	language_preview = new TextLanguage("preview");
-	language_preview->addConstant("CONSTANT");
-	language_preview->addConstant("OTHER_CONSTANT");
-	language_preview->addKeyword("string");
-	language_preview->addKeyword("char");
-	language_preview->addKeyword("void");
-	language_preview->addKeyword("return");
-	language_preview->addKeyword("int");
-	language_preview->addKeyword("if");
+	language_preview->addWord(TextLanguage::WordType::Constant, "CONSTANT");
+	language_preview->addWord(TextLanguage::WordType::Constant, "OTHER_CONSTANT");
+	language_preview->addWord(TextLanguage::WordType::Type, "string");
+	language_preview->addWord(TextLanguage::WordType::Type, "char");
+	language_preview->addWord(TextLanguage::WordType::Keyword, "void");
+	language_preview->addWord(TextLanguage::WordType::Keyword, "return");
+	language_preview->addWord(TextLanguage::WordType::Type, "int");
+	language_preview->addWord(TextLanguage::WordType::Keyword, "if");
+	language_preview->addWord(TextLanguage::WordType::Type, "object");
+	language_preview->addWord(TextLanguage::WordType::Property, "x_property");
+	language_preview->addWord(TextLanguage::WordType::Property, "y_property");
 	language_preview->addFunction("function", "int x, int y");
 	te_preview->setLanguage(language_preview);
 

--- a/src/MapEditor/UI/ScriptEditorPanel.cpp
+++ b/src/MapEditor/UI/ScriptEditorPanel.cpp
@@ -183,7 +183,7 @@ void ScriptEditorPanel::populateWordList()
 	// Get functions and constants
 	TextLanguage* tl = TextLanguage::getLanguage("acs_z");
 	wxArrayString functions = tl->getFunctionsSorted();
-	wxArrayString constants = tl->getConstantsSorted();
+	wxArrayString constants = tl->getWordListSorted(TextLanguage::WordType::Constant);
 
 	// Add functions to list
 	wxTreeListItem item = list_words->AppendItem(list_words->GetRootItem(), "Functions");

--- a/src/UI/TextEditor/Lexer.cpp
+++ b/src/UI/TextEditor/Lexer.cpp
@@ -1,0 +1,153 @@
+
+#include "Main.h"
+#include "Lexer.h"
+#include "TextEditor.h"
+
+Lexer::Lexer()
+{
+	// Default word characters
+	setWordChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.$");
+}
+
+void Lexer::doStyling(TextEditor* editor, int start, int end)
+{
+	State state = State::Unknown;
+	int length = 0;
+	vector<char> current_word;
+
+	editor->StartStyling(start, 0);
+	while (start <= end)
+	{
+		char c = editor->GetCharAt(start);
+		char nc = editor->GetCharAt(start + 1);
+
+		// Update state
+		switch (state)
+		{
+		case State::Unknown:
+			if (c == '"')
+			{
+				editor->SetStyling(length, Style::Default);
+				state = State::String;
+				length = 1;
+			}
+			else if (c == '\'')
+			{
+				editor->SetStyling(length, Style::Default);
+				state = State::Char;
+				length = 1;
+			}
+			else if (c == '/')
+			{
+				// Line comment
+				if (nc == '/')
+				{
+					editor->SetStyling(length, Style::Default);
+					editor->SetStyling(end - start + 1, Style::Comment);
+					return;
+				}
+
+				// Block comment
+				else if (nc == '*')
+				{
+					editor->SetStyling(length, Style::Default);
+					state = State::Comment;
+					length = 2;
+					start++; // Skip *
+				}
+			}
+			else if (VECTOR_EXISTS(word_chars, c))
+			{
+				editor->SetStyling(length, Style::Default);
+				state = State::Word;
+				current_word.clear();
+				current_word.push_back(c);
+			}
+			else
+				length++;
+			break;
+
+		case State::String:
+			if (c == '"')
+			{
+				editor->SetStyling(length + 1, Style::String);
+				state = State::Unknown;
+				length = 0;
+			}
+			else
+				length++;
+			break;
+
+		case State::Char:
+			if (c == '\'')
+			{
+				editor->SetStyling(length + 1, Style::Char);
+				state = State::Unknown;
+				length = 0;
+			}
+			else
+				length++;
+			break;
+
+		case State::Comment:
+			if (c == '*' && nc == '/')
+			{
+				editor->SetStyling(length + 2, Style::Comment);
+				state = State::Unknown;
+				length = 0;
+				start++;
+			}
+			else
+				length++;
+			break;
+
+		case State::Word:
+			if (!(VECTOR_EXISTS(word_chars, c)))
+			{
+				styleWord(editor, wxString::FromAscii(&current_word[0], current_word.size()));
+				state = State::Unknown;
+				length = 0;
+				start--;
+			}
+			else
+				current_word.push_back(c);
+			break;
+		}
+		
+		start++;
+	}
+
+	if (length > 0)
+	{
+		switch (state)
+		{
+		case State::Comment: editor->SetStyling(length, Style::Comment); break;
+		case State::String: editor->SetStyling(length, Style::String); break;
+		case State::Char: editor->SetStyling(length, Style::Char); break;
+		case State::Word: styleWord(editor, wxString::FromAscii(&current_word[0], current_word.size())); break;
+		default: editor->SetStyling(length, Style::Default); break;
+		}
+	}
+}
+
+void Lexer::addWord(string word, int style)
+{
+	word_list[word.Lower()].style = style;
+}
+
+void Lexer::styleWord(TextEditor* editor, string word)
+{
+	string wl = word.Lower();
+
+	if (word_list[wl].style > 0)
+		editor->SetStyling(word.length(), word_list[wl].style);
+	else
+		editor->SetStyling(word.length(), Style::Default);
+}
+
+void Lexer::setWordChars(string chars)
+{
+	word_chars.clear();
+	for (unsigned a = 0; a < chars.length(); a++)
+		word_chars.push_back(chars[a]);
+}

--- a/src/UI/TextEditor/Lexer.cpp
+++ b/src/UI/TextEditor/Lexer.cpp
@@ -3,129 +3,58 @@
 #include "Lexer.h"
 #include "TextEditor.h"
 
+vector<char> char_num_start = { '0','1','2','3','4','5','6','7','8','9' };
+vector<char> char_num = { '0','1','2','3','4','5','6','7','8','9','.','x','a','b','c','d','e','f' };
+vector<char> char_whitespace = { ' ', '\n', '\r', '\t' };
+
 Lexer::Lexer()
 {
 	// Default word characters
-	setWordChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.$");
+	setWordChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.$");
+
+	// Default operator characters
+	setOperatorChars("+-*/=><|~&!");
+
+	// Default comments
+	comment_line = "//";
+	comment_block_start = "/*";
+	comment_block_end = "*/";
+
+	// Default preprocessor
+	preprocessor = '#';
 }
 
 void Lexer::doStyling(TextEditor* editor, int start, int end)
 {
-	State state = State::Unknown;
-	int length = 0;
-	vector<char> current_word;
+	if (start < 0)
+		start = 0;
+
+	LexerState state{ start, end, State::Unknown, editor };
 
 	editor->StartStyling(start, 0);
-	while (start <= end)
+	//LOG_MESSAGE(3, "START STYLING FROM %d TO %d", start, end);
+
+	bool done = false;
+	while (!done)
 	{
-		char c = editor->GetCharAt(start);
-		char nc = editor->GetCharAt(start + 1);
-
-		// Update state
-		switch (state)
+		switch (state.state)
 		{
-		case State::Unknown:
-			if (c == '"')
-			{
-				editor->SetStyling(length, Style::Default);
-				state = State::String;
-				length = 1;
-			}
-			else if (c == '\'')
-			{
-				editor->SetStyling(length, Style::Default);
-				state = State::Char;
-				length = 1;
-			}
-			else if (c == '/')
-			{
-				// Line comment
-				if (nc == '/')
-				{
-					editor->SetStyling(length, Style::Default);
-					editor->SetStyling(end - start + 1, Style::Comment);
-					return;
-				}
-
-				// Block comment
-				else if (nc == '*')
-				{
-					editor->SetStyling(length, Style::Default);
-					state = State::Comment;
-					length = 2;
-					start++; // Skip *
-				}
-			}
-			else if (VECTOR_EXISTS(word_chars, c))
-			{
-				editor->SetStyling(length, Style::Default);
-				state = State::Word;
-				current_word.clear();
-				current_word.push_back(c);
-			}
-			else
-				length++;
-			break;
-
-		case State::String:
-			if (c == '"')
-			{
-				editor->SetStyling(length + 1, Style::String);
-				state = State::Unknown;
-				length = 0;
-			}
-			else
-				length++;
-			break;
-
-		case State::Char:
-			if (c == '\'')
-			{
-				editor->SetStyling(length + 1, Style::Char);
-				state = State::Unknown;
-				length = 0;
-			}
-			else
-				length++;
-			break;
-
+		case State::Whitespace:
+			done = processWhitespace(state); break;
 		case State::Comment:
-			if (c == '*' && nc == '/')
-			{
-				editor->SetStyling(length + 2, Style::Comment);
-				state = State::Unknown;
-				length = 0;
-				start++;
-			}
-			else
-				length++;
-			break;
-
+			done = processComment(state); break;
+		case State::String:
+			done = processString(state); break;
+		case State::Char:
+			done = processChar(state); break;
 		case State::Word:
-			if (!(VECTOR_EXISTS(word_chars, c)))
-			{
-				styleWord(editor, wxString::FromAscii(&current_word[0], current_word.size()));
-				state = State::Unknown;
-				length = 0;
-				start--;
-			}
-			else
-				current_word.push_back(c);
-			break;
-		}
-		
-		start++;
-	}
-
-	if (length > 0)
-	{
-		switch (state)
-		{
-		case State::Comment: editor->SetStyling(length, Style::Comment); break;
-		case State::String: editor->SetStyling(length, Style::String); break;
-		case State::Char: editor->SetStyling(length, Style::Char); break;
-		case State::Word: styleWord(editor, wxString::FromAscii(&current_word[0], current_word.size())); break;
-		default: editor->SetStyling(length, Style::Default); break;
+			done = processWord(state); break;
+		case State::Number:
+			done = processNumber(state); break;
+		case State::Operator:
+			done = processOperator(state); break;
+		default:
+			done = processUnknown(state); break;
 		}
 	}
 }
@@ -141,6 +70,8 @@ void Lexer::styleWord(TextEditor* editor, string word)
 
 	if (word_list[wl].style > 0)
 		editor->SetStyling(word.length(), word_list[wl].style);
+	else if (word.StartsWith(preprocessor))
+		editor->SetStyling(word.length(), Style::Preprocessor);
 	else
 		editor->SetStyling(word.length(), Style::Default);
 }
@@ -150,4 +81,329 @@ void Lexer::setWordChars(string chars)
 	word_chars.clear();
 	for (unsigned a = 0; a < chars.length(); a++)
 		word_chars.push_back(chars[a]);
+}
+
+void Lexer::setOperatorChars(string chars)
+{
+	operator_chars.clear();
+	for (unsigned a = 0; a < chars.length(); a++)
+		operator_chars.push_back(chars[a]);
+}
+
+bool Lexer::processUnknown(LexerState& state)
+{
+	int length = 0;
+	bool end = false;
+	bool pp = false;
+
+	while (true)
+	{
+		// Check for end of line
+		if (state.position > state.end)
+		{
+			end = true;
+			break;
+		}
+		
+		char c = state.editor->GetCharAt(state.position);
+
+		// Start of string
+		if (c == '"')
+		{
+			state.state = State::String;
+			state.position++;
+			break;
+		}
+
+		// Start of char
+		else if (c == '\'')
+		{
+			state.state = State::Char;
+			state.position++;
+			break;
+		}
+
+		// Start of line comment
+		else if (!comment_line.IsEmpty() && c == comment_line[0])
+		{
+			// Check following characters are the line comment string
+			bool comment = true;
+			for (int a = 1; a < comment_line.size(); a++)
+				if (state.editor->GetCharAt(state.position + a) != (int)comment_line[a])
+					comment = false;
+
+			if (comment)
+			{
+				// Format as comment to end of line
+				state.editor->SetStyling(length, Style::Default);
+				state.editor->SetStyling((state.end - state.position) + 1, Style::Comment);
+				return true;
+			}
+		}
+
+		// Whitespace
+		else if (VECTOR_EXISTS(char_whitespace, c))
+		{
+			state.state = State::Whitespace;
+			state.position++;
+			break;
+		}
+
+		// Preprocessor
+		else if (c == preprocessor)
+		{
+			pp = true;
+			length++;
+			state.position++;
+			continue;
+		}
+
+		// Operator
+		else if (VECTOR_EXISTS(operator_chars, c))
+		{
+			state.position++;
+			state.state = State::Operator;
+			break;
+		}
+
+		// Number
+		else if (VECTOR_EXISTS(char_num_start, c))
+		{
+			state.state = State::Number;
+			break;
+		}
+
+		// Word
+		else if (VECTOR_EXISTS(word_chars, c))
+		{
+			// Include preprocessor character if it was the previous character
+			if (pp)
+			{
+				state.position--;
+				length--;
+			}
+
+			state.state = State::Word;
+			break;
+		}
+
+		//LOG_MESSAGE(4, "unknown char '%c' (%d)", c, c);
+		length++;
+		state.position++;
+		pp = false;
+	}
+
+	LOG_MESSAGE(4, "unknown:%d", length);
+	state.editor->SetStyling(length, Style::Default);
+
+	return end;
+}
+
+bool Lexer::processComment(LexerState& state)
+{
+	return false;
+}
+
+bool Lexer::processWord(LexerState& state)
+{
+	vector<char> word;
+	bool end = false;
+
+	// Add first letter
+	word.push_back(state.editor->GetCharAt(state.position++));
+
+	while (true)
+	{
+		// Check for end of line
+		if (state.position > state.end)
+		{
+			end = true;
+			break;
+		}
+
+		char c = state.editor->GetCharAt(state.position);
+		if (VECTOR_EXISTS(word_chars, c))
+		{
+			word.push_back(c);
+			state.position++;
+		}
+		else
+		{
+			state.state = State::Unknown;
+			break;
+		}
+	}
+
+	string word_string = wxString::FromAscii(&word[0], word.size());
+	LOG_MESSAGE(4, "word:%s", word_string);
+	styleWord(state.editor, word_string);
+
+	return end;
+}
+
+bool Lexer::processString(LexerState& state)
+{
+	int length = 1;
+	bool end = false;
+
+	while (true)
+	{
+		// Check for end of line
+		if (state.position > state.end)
+		{
+			end = true;
+			break;
+		}
+
+		// End of string
+		char c = state.editor->GetCharAt(state.position);
+		if (c == '"')	
+		{
+			length++;
+			state.position++;
+			state.state = State::Unknown;
+			break;
+		}
+
+		length++;
+		state.position++;
+	}
+
+	LOG_MESSAGE(4, "string:%d", length);
+	state.editor->SetStyling(length, Style::String);
+
+	return end;
+}
+
+bool Lexer::processChar(LexerState& state)
+{
+	int length = 1;
+	bool end = false;
+
+	while (true)
+	{
+		// Check for end of line
+		if (state.position > state.end)
+		{
+			end = true;
+			break;
+		}
+
+		// End of string
+		char c = state.editor->GetCharAt(state.position);
+		if (c == '\'')
+		{
+			length++;
+			state.position++;
+			state.state = State::Unknown;
+			break;
+		}
+
+		length++;
+		state.position++;
+	}
+
+	LOG_MESSAGE(4, "char:%d", length);
+	state.editor->SetStyling(length, Style::Char);
+
+	return end;
+}
+
+bool Lexer::processNumber(LexerState& state)
+{
+	int length = 0;
+	bool end = false;
+
+	while (true)
+	{
+		// Check for end of line
+		if (state.position > state.end)
+		{
+			end = true;
+			break;
+		}
+
+		char c = state.editor->GetCharAt(state.position);
+		if (VECTOR_EXISTS(char_num, c))
+		{
+			length++;
+			state.position++;
+		}
+		else
+		{
+			state.state = State::Unknown;
+			break;
+		}
+	}
+
+	LOG_MESSAGE(4, "number:%d", length);
+	state.editor->SetStyling(length, Style::Number);
+
+	return end;
+}
+
+bool Lexer::processOperator(LexerState& state)
+{
+	int length = 1;
+	bool end = false;
+
+	while (true)
+	{
+		// Check for end of line
+		if (state.position > state.end)
+		{
+			end = true;
+			break;
+		}
+
+		char c = state.editor->GetCharAt(state.position);
+		if (VECTOR_EXISTS(operator_chars, c))
+		{
+			length++;
+			state.position++;
+		}
+		else
+		{
+			state.state = State::Unknown;
+			break;
+		}
+	}
+
+	LOG_MESSAGE(4, "operator:%d", length);
+	state.editor->SetStyling(length, Style::Operator);
+
+	return end;
+}
+
+bool Lexer::processWhitespace(LexerState& state)
+{
+	int length = 1;
+	bool end = false;
+
+	while (true)
+	{
+		// Check for end of line
+		if (state.position > state.end)
+		{
+			end = true;
+			break;
+		}
+
+		char c = state.editor->GetCharAt(state.position);
+		if (VECTOR_EXISTS(char_whitespace, c))
+		{
+			length++;
+			state.position++;
+		}
+		else
+		{
+			state.state = State::Unknown;
+			break;
+		}
+	}
+
+	LOG_MESSAGE(4, "whitespace:%d", length);
+	state.editor->SetStyling(length, Style::Default);
+
+	return end;
 }

--- a/src/UI/TextEditor/Lexer.cpp
+++ b/src/UI/TextEditor/Lexer.cpp
@@ -2,37 +2,78 @@
 #include "Main.h"
 #include "Lexer.h"
 #include "TextEditor.h"
+#include "TextLanguage.h"
 
-vector<char> char_num_start = { '0','1','2','3','4','5','6','7','8','9' };
-vector<char> char_num = { '0','1','2','3','4','5','6','7','8','9','.','x','a','b','c','d','e','f' };
-vector<char> char_whitespace = { ' ', '\n', '\r', '\t' };
-
-Lexer::Lexer()
+Lexer::Lexer() :
+	re_int1{ "^[+-]?[0-9]+[0-9]*$", wxRE_DEFAULT|wxRE_NOSUB },
+	re_int2{ "^0[0-9]+$", wxRE_DEFAULT|wxRE_NOSUB },
+	re_int3{ "^0x[0-9A-Fa-f]+$", wxRE_DEFAULT|wxRE_NOSUB },
+	re_float{ "^[-+]?[0-9]*.?[0-9]+([eE][-+]?[0-9]+)?$", wxRE_DEFAULT|wxRE_NOSUB },
+	comment_line{ "//" },
+	comment_block_start{ "/*" },
+	comment_block_end{ "*/" },
+	comment_doc_line{ "///" },
+	preprocessor{ '#' },
+	whitespace_chars{ { ' ', '\n', '\r', '\t' } },
+	basic_mode{ false }
 {
 	// Default word characters
-	setWordChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.$");
+	setWordChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_");
 
 	// Default operator characters
 	setOperatorChars("+-*/=><|~&!");
-
-	// Default comments
-	comment_line = "//";
-	comment_block_start = "/*";
-	comment_block_end = "*/";
-
-	// Default preprocessor
-	preprocessor = '#';
 }
 
-void Lexer::doStyling(TextEditor* editor, int start, int end)
+void Lexer::loadLanguage(TextLanguage* language)
+{
+	clearWords();
+
+	// If no language given, enable basic mode
+	if (!language)
+	{
+		basic_mode = true;
+		return;
+	}
+
+	// Setup from language
+	basic_mode = false;
+	comment_line = language->getLineComment();
+	comment_block_start = language->getCommentBegin();
+	comment_block_end = language->getCommentEnd();
+	comment_doc_line = language->getDocComment();
+	preprocessor = language->getPreprocessor()[0];
+
+	// Load language words
+	for (auto word : language->getWordListSorted(TextLanguage::WordType::Constant))
+		addWord(word, Lexer::Style::Constant);
+	for (auto word : language->getWordListSorted(TextLanguage::WordType::Property))
+		addWord(word, Lexer::Style::Property);
+	for (auto word : language->getFunctionsSorted())
+		addWord(word, Lexer::Style::Function);
+	for (auto word : language->getWordListSorted(TextLanguage::WordType::Type))
+		addWord(word, Lexer::Style::Type);
+	for (auto word : language->getWordListSorted(TextLanguage::WordType::Keyword))
+		addWord(word, Lexer::Style::Keyword);
+}
+
+bool Lexer::doStyling(TextEditor* editor, int start, int end)
 {
 	if (start < 0)
 		start = 0;
 
-	LexerState state{ start, end, State::Unknown, editor };
+	int line = editor->LineFromPosition(start);
+	LexerState state
+	{
+		start,
+		end,
+		line,
+		lines[line].commented ? State::Comment : State::Unknown,
+		0,
+		editor
+	};
 
 	editor->StartStyling(start, 0);
-	//LOG_MESSAGE(3, "START STYLING FROM %d TO %d", start, end);
+	LOG_MESSAGE(3, "START STYLING FROM %d TO %d (LINE %d)", start, end, line + 1);
 
 	bool done = false;
 	while (!done)
@@ -49,14 +90,18 @@ void Lexer::doStyling(TextEditor* editor, int start, int end)
 			done = processChar(state); break;
 		case State::Word:
 			done = processWord(state); break;
-		case State::Number:
-			done = processNumber(state); break;
 		case State::Operator:
 			done = processOperator(state); break;
 		default:
 			done = processUnknown(state); break;
 		}
 	}
+
+	// Set the next line's 'commented' state
+	lines[line+1].commented = (state.state == State::Comment);
+
+	// Return true if we are still inside a comment
+	return (state.state == State::Comment);
 }
 
 void Lexer::addWord(string word, int style)
@@ -73,7 +118,13 @@ void Lexer::styleWord(TextEditor* editor, string word)
 	else if (word.StartsWith(preprocessor))
 		editor->SetStyling(word.length(), Style::Preprocessor);
 	else
-		editor->SetStyling(word.length(), Style::Default);
+	{
+		// Check for number
+		if (re_int2.Matches(word) || re_int1.Matches(word) || re_float.Matches(word) || re_int3.Matches(word))
+			editor->SetStyling(word.length(), Style::Number);
+		else
+			editor->SetStyling(word.length(), Style::Default);
+	}
 }
 
 void Lexer::setWordChars(string chars)
@@ -92,7 +143,7 @@ void Lexer::setOperatorChars(string chars)
 
 bool Lexer::processUnknown(LexerState& state)
 {
-	int length = 0;
+	int u_length = 0;
 	bool end = false;
 	bool pp = false;
 
@@ -112,7 +163,16 @@ bool Lexer::processUnknown(LexerState& state)
 		{
 			state.state = State::String;
 			state.position++;
+			state.length = 1;
 			break;
+		}
+
+		// Basic mode only supports strings
+		else if (basic_mode)
+		{
+			u_length++;
+			state.position++;
+			continue;
 		}
 
 		// Start of char
@@ -120,32 +180,43 @@ bool Lexer::processUnknown(LexerState& state)
 		{
 			state.state = State::Char;
 			state.position++;
+			state.length = 1;
 			break;
 		}
 
-		// Start of line comment
-		else if (!comment_line.IsEmpty() && c == comment_line[0])
+		// Start of doc line comment
+		else if (checkToken(state.editor, state.position, comment_doc_line))
 		{
-			// Check following characters are the line comment string
-			bool comment = true;
-			for (int a = 1; a < comment_line.size(); a++)
-				if (state.editor->GetCharAt(state.position + a) != (int)comment_line[a])
-					comment = false;
+			// Format as comment to end of line
+			state.editor->SetStyling(u_length, Style::Default);
+			state.editor->SetStyling((state.end - state.position) + 1, Style::CommentDoc);
+			return true;
+		}
 
-			if (comment)
-			{
-				// Format as comment to end of line
-				state.editor->SetStyling(length, Style::Default);
-				state.editor->SetStyling((state.end - state.position) + 1, Style::Comment);
-				return true;
-			}
+		// Start of line comment
+		else if (checkToken(state.editor, state.position, comment_line))
+		{
+			// Format as comment to end of line
+			state.editor->SetStyling(u_length, Style::Default);
+			state.editor->SetStyling((state.end - state.position) + 1, Style::Comment);
+			return true;
+		}
+
+		// Start of block comment
+		else if (checkToken(state.editor, state.position, comment_block_start))
+		{
+			state.state = State::Comment;
+			state.position += comment_block_start.size();
+			state.length = comment_block_start.size();
+			break;
 		}
 
 		// Whitespace
-		else if (VECTOR_EXISTS(char_whitespace, c))
+		else if (VECTOR_EXISTS(whitespace_chars, c))
 		{
 			state.state = State::Whitespace;
 			state.position++;
+			state.length = 1;
 			break;
 		}
 
@@ -153,7 +224,7 @@ bool Lexer::processUnknown(LexerState& state)
 		else if (c == preprocessor)
 		{
 			pp = true;
-			length++;
+			u_length++;
 			state.position++;
 			continue;
 		}
@@ -163,13 +234,7 @@ bool Lexer::processUnknown(LexerState& state)
 		{
 			state.position++;
 			state.state = State::Operator;
-			break;
-		}
-
-		// Number
-		else if (VECTOR_EXISTS(char_num_start, c))
-		{
-			state.state = State::Number;
+			state.length = 1;
 			break;
 		}
 
@@ -180,28 +245,56 @@ bool Lexer::processUnknown(LexerState& state)
 			if (pp)
 			{
 				state.position--;
-				length--;
+				u_length--;
 			}
 
 			state.state = State::Word;
+			state.length = 0;
 			break;
 		}
 
 		//LOG_MESSAGE(4, "unknown char '%c' (%d)", c, c);
-		length++;
+		u_length++;
 		state.position++;
 		pp = false;
 	}
 
-	LOG_MESSAGE(4, "unknown:%d", length);
-	state.editor->SetStyling(length, Style::Default);
+	//LOG_MESSAGE(4, "unknown:%d", u_length);
+	state.editor->SetStyling(u_length, Style::Default);
 
 	return end;
 }
 
 bool Lexer::processComment(LexerState& state)
 {
-	return false;
+	bool end = false;
+
+	while (true)
+	{
+		// Check for end of line
+		if (state.position > state.end)
+		{
+			end = true;
+			break;
+		}
+
+		// End of comment
+		if (checkToken(state.editor, state.position, comment_block_end))
+		{
+			state.length += comment_block_end.size();
+			state.position += comment_block_end.size();
+			state.state = State::Unknown;
+			break;
+		}
+
+		state.length++;
+		state.position++;
+	}
+
+	LOG_MESSAGE(4, "comment:%d", state.length);
+	state.editor->SetStyling(state.length, Style::Comment);
+
+	return end;
 }
 
 bool Lexer::processWord(LexerState& state)
@@ -243,7 +336,6 @@ bool Lexer::processWord(LexerState& state)
 
 bool Lexer::processString(LexerState& state)
 {
-	int length = 1;
 	bool end = false;
 
 	while (true)
@@ -259,25 +351,24 @@ bool Lexer::processString(LexerState& state)
 		char c = state.editor->GetCharAt(state.position);
 		if (c == '"')	
 		{
-			length++;
+			state.length++;
 			state.position++;
 			state.state = State::Unknown;
 			break;
 		}
 
-		length++;
+		state.length++;
 		state.position++;
 	}
 
-	LOG_MESSAGE(4, "string:%d", length);
-	state.editor->SetStyling(length, Style::String);
+	LOG_MESSAGE(4, "string:%d", state.length);
+	state.editor->SetStyling(state.length, Style::String);
 
 	return end;
 }
 
 bool Lexer::processChar(LexerState& state)
 {
-	int length = 1;
 	bool end = false;
 
 	while (true)
@@ -293,58 +384,24 @@ bool Lexer::processChar(LexerState& state)
 		char c = state.editor->GetCharAt(state.position);
 		if (c == '\'')
 		{
-			length++;
+			state.length++;
 			state.position++;
 			state.state = State::Unknown;
 			break;
 		}
 
-		length++;
+		state.length++;
 		state.position++;
 	}
 
-	LOG_MESSAGE(4, "char:%d", length);
-	state.editor->SetStyling(length, Style::Char);
-
-	return end;
-}
-
-bool Lexer::processNumber(LexerState& state)
-{
-	int length = 0;
-	bool end = false;
-
-	while (true)
-	{
-		// Check for end of line
-		if (state.position > state.end)
-		{
-			end = true;
-			break;
-		}
-
-		char c = state.editor->GetCharAt(state.position);
-		if (VECTOR_EXISTS(char_num, c))
-		{
-			length++;
-			state.position++;
-		}
-		else
-		{
-			state.state = State::Unknown;
-			break;
-		}
-	}
-
-	LOG_MESSAGE(4, "number:%d", length);
-	state.editor->SetStyling(length, Style::Number);
+	LOG_MESSAGE(4, "char:%d", state.length);
+	state.editor->SetStyling(state.length, Style::Char);
 
 	return end;
 }
 
 bool Lexer::processOperator(LexerState& state)
 {
-	int length = 1;
 	bool end = false;
 
 	while (true)
@@ -359,7 +416,7 @@ bool Lexer::processOperator(LexerState& state)
 		char c = state.editor->GetCharAt(state.position);
 		if (VECTOR_EXISTS(operator_chars, c))
 		{
-			length++;
+			state.length++;
 			state.position++;
 		}
 		else
@@ -369,15 +426,14 @@ bool Lexer::processOperator(LexerState& state)
 		}
 	}
 
-	LOG_MESSAGE(4, "operator:%d", length);
-	state.editor->SetStyling(length, Style::Operator);
+	LOG_MESSAGE(4, "operator:%d", state.length);
+	state.editor->SetStyling(state.length, Style::Operator);
 
 	return end;
 }
 
 bool Lexer::processWhitespace(LexerState& state)
 {
-	int length = 1;
 	bool end = false;
 
 	while (true)
@@ -390,9 +446,9 @@ bool Lexer::processWhitespace(LexerState& state)
 		}
 
 		char c = state.editor->GetCharAt(state.position);
-		if (VECTOR_EXISTS(char_whitespace, c))
+		if (VECTOR_EXISTS(whitespace_chars, c))
 		{
-			length++;
+			state.length++;
 			state.position++;
 		}
 		else
@@ -402,8 +458,22 @@ bool Lexer::processWhitespace(LexerState& state)
 		}
 	}
 
-	LOG_MESSAGE(4, "whitespace:%d", length);
-	state.editor->SetStyling(length, Style::Default);
+	LOG_MESSAGE(4, "whitespace:%d", state.length);
+	state.editor->SetStyling(state.length, Style::Default);
 
 	return end;
+}
+
+bool Lexer::checkToken(TextEditor* editor, int pos, string& token)
+{
+	if (!token.empty())
+	{
+		for (int a = 0; a < token.size(); a++)
+			if (editor->GetCharAt(pos + a) != (int)token[a])
+				return false;
+
+		return true;
+	}
+
+	return false;
 }

--- a/src/UI/TextEditor/Lexer.cpp
+++ b/src/UI/TextEditor/Lexer.cpp
@@ -105,7 +105,7 @@ bool Lexer::doStyling(TextEditor* editor, int start, int end)
 		editor
 	};
 
-	editor->StartStyling(start, 0);
+	editor->StartStyling(start, 31);
 	LOG_MESSAGE(3, "START STYLING FROM %d TO %d (LINE %d)", start, end, line + 1);
 
 	bool done = false;
@@ -199,6 +199,10 @@ bool Lexer::processUnknown(LexerState& state)
 	bool end = false;
 	bool pp = false;
 	string comment_begin = language ? language->getCommentBegin() : "";
+	string comment_doc = language ? language->getDocComment() : "";
+	string comment_line = language ? language->getLineComment() : "";
+	string block_begin = language ? language->getBlockBegin() : "";
+	string block_end = language ? language->getBlockEnd() : "";
 
 	while (true)
 	{
@@ -240,7 +244,7 @@ bool Lexer::processUnknown(LexerState& state)
 		}
 
 		// Start of doc line comment
-		else if (checkToken(state.editor, state.position, language->getDocComment()))
+		else if (checkToken(state.editor, state.position, comment_doc))
 		{
 			// Format as comment to end of line
 			state.editor->SetStyling(u_length, Style::Default);
@@ -249,7 +253,7 @@ bool Lexer::processUnknown(LexerState& state)
 		}
 
 		// Start of line comment
-		else if (checkToken(state.editor, state.position, language->getLineComment()))
+		else if (checkToken(state.editor, state.position, comment_line))
 		{
 			// Format as comment to end of line
 			state.editor->SetStyling(u_length, Style::Default);
@@ -316,13 +320,13 @@ bool Lexer::processUnknown(LexerState& state)
 		}
 
 		// Block begin
-		else if (checkToken(state.editor, state.position, language->getBlockBegin()))
+		else if (checkToken(state.editor, state.position, block_begin))
 		{
 			state.fold_increment++;
 		}
 
 		// Block end
-		else if (checkToken(state.editor, state.position, language->getBlockEnd()))
+		else if (checkToken(state.editor, state.position, block_end))
 		{
 			state.fold_increment--;
 		}

--- a/src/UI/TextEditor/Lexer.h
+++ b/src/UI/TextEditor/Lexer.h
@@ -24,7 +24,7 @@ public:
 		Function		= wxSTC_C_WORD2,
 		Constant		= wxSTC_C_GLOBALCLASS,
 		Type			= wxSTC_C_IDENTIFIER,
-		Property		= wxSTC_C_USERLITERAL,
+		Property		= wxSTC_C_UUID,
 	};
 
 	void	loadLanguage(TextLanguage* language);

--- a/src/UI/TextEditor/Lexer.h
+++ b/src/UI/TextEditor/Lexer.h
@@ -35,9 +35,6 @@ public:
 
 	void	setWordChars(string chars);
 	void	setOperatorChars(string chars);
-	void	setLineComment(string token) { comment_line = token; }
-	void	setBlockComment(string start, string end) { comment_block_start = start; comment_block_end = end; }
-	void	setDocComment(string token) { comment_doc_line = token; }
 
 	void	updateFolding(TextEditor* editor, int line_start);
 	void	foldComments(bool fold) { fold_comments = fold; }
@@ -56,15 +53,10 @@ private:
 		Whitespace,
 	};
 
-	bool			basic_mode;
 	vector<char>	word_chars;
 	vector<char>	operator_chars;
 	vector<char>	whitespace_chars;
-	string			comment_line;
-	string			comment_block_start;
-	string			comment_block_end;
-	string			comment_doc_line;
-	char			preprocessor;
+	TextLanguage*	language;
 	wxRegEx			re_int1;
 	wxRegEx			re_int2;
 	wxRegEx			re_int3;

--- a/src/UI/TextEditor/Lexer.h
+++ b/src/UI/TextEditor/Lexer.h
@@ -39,6 +39,10 @@ public:
 	void	setBlockComment(string start, string end) { comment_block_start = start; comment_block_end = end; }
 	void	setDocComment(string token) { comment_doc_line = token; }
 
+	void	updateFolding(TextEditor* editor, int line_start);
+	void	foldComments(bool fold) { fold_comments = fold; }
+	void	foldPreprocessor(bool fold) { fold_preprocessor = fold; }
+
 private:
 	enum class State
 	{
@@ -65,6 +69,8 @@ private:
 	wxRegEx			re_int2;
 	wxRegEx			re_int3;
 	wxRegEx			re_float;
+	bool			fold_comments;
+	bool			fold_preprocessor;
 
 	struct WLIndex
 	{
@@ -76,8 +82,9 @@ private:
 	struct LineInfo
 	{
 		bool	commented;
-		int		fold_level;
-		LineInfo() : commented{ false }, fold_level{ 0 } {}
+		int		fold_increment;
+		bool	has_word;
+		LineInfo() : commented{ false }, fold_increment{ 0 }, has_word{ false } {}
 	};
 	std::map<int, LineInfo>	lines;
 
@@ -88,6 +95,8 @@ private:
 		int			line;
 		State		state;
 		int			length;
+		int			fold_increment;
+		bool		has_word;
 		TextEditor*	editor;
 	};
 	bool	processUnknown(LexerState& state);

--- a/src/UI/TextEditor/Lexer.h
+++ b/src/UI/TextEditor/Lexer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 class TextEditor;
+class TextLanguage;
 class Lexer
 {
 public:
@@ -11,19 +12,32 @@ public:
 	{
 		Default			= wxSTC_STYLE_DEFAULT,
 		Comment			= wxSTC_C_COMMENT,
+		CommentDoc		= wxSTC_C_COMMENTDOC,
 		String			= wxSTC_C_STRING,
 		Char			= wxSTC_C_CHARACTER,
 		Number			= wxSTC_C_NUMBER,
 		Operator		= wxSTC_C_OPERATOR,
 		Preprocessor	= wxSTC_C_PREPROCESSOR,
+
+		// Words
+		Keyword			= wxSTC_C_WORD,
+		Function		= wxSTC_C_WORD2,
+		Constant		= wxSTC_C_GLOBALCLASS,
+		Type			= wxSTC_C_IDENTIFIER,
+		Property		= wxSTC_C_USERLITERAL,
 	};
 
-	void	doStyling(TextEditor* editor, int start, int end);
+	void	loadLanguage(TextLanguage* language);
+
+	bool	doStyling(TextEditor* editor, int start, int end);
 	void	addWord(string word, int style);
 	void	clearWords() { word_list.clear(); }
-	void	styleWord(TextEditor* editor, string word);
+
 	void	setWordChars(string chars);
 	void	setOperatorChars(string chars);
+	void	setLineComment(string token) { comment_line = token; }
+	void	setBlockComment(string start, string end) { comment_block_start = start; comment_block_end = end; }
+	void	setDocComment(string token) { comment_doc_line = token; }
 
 private:
 	enum class State
@@ -38,24 +52,42 @@ private:
 		Whitespace,
 	};
 
+	bool			basic_mode;
+	vector<char>	word_chars;
+	vector<char>	operator_chars;
+	vector<char>	whitespace_chars;
+	string			comment_line;
+	string			comment_block_start;
+	string			comment_block_end;
+	string			comment_doc_line;
+	char			preprocessor;
+	wxRegEx			re_int1;
+	wxRegEx			re_int2;
+	wxRegEx			re_int3;
+	wxRegEx			re_float;
+
 	struct WLIndex
 	{
 		char style;
 		WLIndex() : style(0) {}
 	};
 	std::map<string, WLIndex>	word_list;
-	vector<char>				word_chars;
-	vector<char>				operator_chars;
-	string						comment_line;
-	string						comment_block_start;
-	string						comment_block_end;
-	char						preprocessor;
+
+	struct LineInfo
+	{
+		bool	commented;
+		int		fold_level;
+		LineInfo() : commented{ false }, fold_level{ 0 } {}
+	};
+	std::map<int, LineInfo>	lines;
 
 	struct LexerState
 	{
 		int			position;
 		int			end;
+		int			line;
 		State		state;
+		int			length;
 		TextEditor*	editor;
 	};
 	bool	processUnknown(LexerState& state);
@@ -63,7 +95,9 @@ private:
 	bool	processWord(LexerState& state);
 	bool	processString(LexerState& state);
 	bool	processChar(LexerState& state);
-	bool	processNumber(LexerState& state);
 	bool	processOperator(LexerState& state);
 	bool	processWhitespace(LexerState& state);
+
+	void	styleWord(TextEditor* editor, string word);
+	bool	checkToken(TextEditor* editor, int pos, string& token);
 };

--- a/src/UI/TextEditor/Lexer.h
+++ b/src/UI/TextEditor/Lexer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+class TextEditor;
+class Lexer
+{
+public:
+	Lexer();
+	~Lexer() {}
+
+	enum Style
+	{
+		Default = wxSTC_STYLE_DEFAULT,
+		Comment = wxSTC_C_COMMENT,
+		String	= wxSTC_C_STRING,
+		Char	= wxSTC_C_CHARACTER,
+	};
+
+	void	doStyling(TextEditor* editor, int start, int end);
+	void	addWord(string word, int style);
+	void	clearWords() { word_list.clear(); }
+	void	styleWord(TextEditor* editor, string word);
+	void	setWordChars(string chars);
+
+private:
+	enum class State
+	{
+		Unknown,
+		Word,
+		Comment,
+		String,
+		Char,
+	};
+
+	struct WLIndex
+	{
+		char style;
+		WLIndex() : style(0) {}
+	};
+	std::map<string, WLIndex>	word_list;
+	vector<char>				word_chars;
+};

--- a/src/UI/TextEditor/Lexer.h
+++ b/src/UI/TextEditor/Lexer.h
@@ -9,10 +9,13 @@ public:
 
 	enum Style
 	{
-		Default = wxSTC_STYLE_DEFAULT,
-		Comment = wxSTC_C_COMMENT,
-		String	= wxSTC_C_STRING,
-		Char	= wxSTC_C_CHARACTER,
+		Default			= wxSTC_STYLE_DEFAULT,
+		Comment			= wxSTC_C_COMMENT,
+		String			= wxSTC_C_STRING,
+		Char			= wxSTC_C_CHARACTER,
+		Number			= wxSTC_C_NUMBER,
+		Operator		= wxSTC_C_OPERATOR,
+		Preprocessor	= wxSTC_C_PREPROCESSOR,
 	};
 
 	void	doStyling(TextEditor* editor, int start, int end);
@@ -20,6 +23,7 @@ public:
 	void	clearWords() { word_list.clear(); }
 	void	styleWord(TextEditor* editor, string word);
 	void	setWordChars(string chars);
+	void	setOperatorChars(string chars);
 
 private:
 	enum class State
@@ -29,6 +33,9 @@ private:
 		Comment,
 		String,
 		Char,
+		Number,
+		Operator,
+		Whitespace,
 	};
 
 	struct WLIndex
@@ -38,4 +45,25 @@ private:
 	};
 	std::map<string, WLIndex>	word_list;
 	vector<char>				word_chars;
+	vector<char>				operator_chars;
+	string						comment_line;
+	string						comment_block_start;
+	string						comment_block_end;
+	char						preprocessor;
+
+	struct LexerState
+	{
+		int			position;
+		int			end;
+		State		state;
+		TextEditor*	editor;
+	};
+	bool	processUnknown(LexerState& state);
+	bool	processComment(LexerState& state);
+	bool	processWord(LexerState& state);
+	bool	processString(LexerState& state);
+	bool	processChar(LexerState& state);
+	bool	processNumber(LexerState& state);
+	bool	processOperator(LexerState& state);
+	bool	processWhitespace(LexerState& state);
 };

--- a/src/UI/TextEditor/TextEditor.cpp
+++ b/src/UI/TextEditor/TextEditor.cpp
@@ -1751,6 +1751,11 @@ void TextEditor::onStyleNeeded(wxStyledTextEvent& e)
 		{
 			int start = GetLineEndPosition(l - 1);
 			int end = GetLineEndPosition(l) - 1;
+
+			// Skip endline characters
+			while (GetCharAt(start) == '\n' || GetCharAt(start) == '\r')
+				start++;
+
 			lexer->doStyling(this, start, end);
 		}
 

--- a/src/UI/TextEditor/TextEditor.cpp
+++ b/src/UI/TextEditor/TextEditor.cpp
@@ -483,12 +483,6 @@ void TextEditor::setup()
 	StyleSetFont(wxSTC_STYLE_CALLTIP, font_ct);
 	CallTipSetForegroundHighlight(WXCOL(StyleSet::currentSet()->getStyle("calltip_hl")->getForeground()));
 
-	// Set lexer
-	//if (txed_syntax_hilight)
-	//	SetLexer(wxSTC_LEX_CPPNOCASE);
-	//else
-		SetLexer(0);
-
 	// Set folding options
 	setupFolding();
 
@@ -577,12 +571,6 @@ bool TextEditor::setLanguage(TextLanguage* lang)
 		// Load autocompletion list
 		autocomp_list = lang->getAutocompletionList();
 	}
-
-	// Set lexer
-	//if (txed_syntax_hilight)
-	//	SetLexer(wxSTC_LEX_CPPNOCASE);
-	//else
-		SetLexer(0);
 
 	// Set folding options
 	setupFolding();

--- a/src/UI/TextEditor/TextEditor.h
+++ b/src/UI/TextEditor/TextEditor.h
@@ -67,6 +67,7 @@ private:
 
 class SCallTip;
 class wxChoice;
+class Lexer;
 class TextEditor : public wxStyledTextCtrl
 {
 private:
@@ -76,6 +77,7 @@ private:
 	wxChoice*			choice_jump_to;
 	JumpToCalculator*	jump_to_calculator;
 	wxTimer				timer_update;
+	Lexer*				lexer;
 
 	// Calltip stuff
 	TLFunction*	ct_function;
@@ -150,6 +152,7 @@ public:
 	void	onJumpToChoiceSelected(wxCommandEvent& e);
 	void	onModified(wxStyledTextEvent& e);
 	void	onUpdateTimer(wxTimerEvent& e);
+	void	onStyleNeeded(wxStyledTextEvent& e);
 };
 
 #endif //__TEXTEDITOR_H__

--- a/src/UI/TextEditor/TextEditor.h
+++ b/src/UI/TextEditor/TextEditor.h
@@ -6,6 +6,7 @@
 #include "Archive/ArchiveEntry.h"
 #include "TextLanguage.h"
 #include "TextStyle.h"
+#include "Lexer.h"
 
 class wxButton;
 class wxCheckBox;
@@ -67,7 +68,6 @@ private:
 
 class SCallTip;
 class wxChoice;
-class Lexer;
 class TextEditor : public wxStyledTextCtrl
 {
 private:
@@ -77,7 +77,7 @@ private:
 	wxChoice*			choice_jump_to;
 	JumpToCalculator*	jump_to_calculator;
 	wxTimer				timer_update;
-	Lexer*				lexer;
+	Lexer				lexer;
 	string				prev_word_match;
 	string				autocomp_list;
 	int					bm_cursor_last_pos;
@@ -130,6 +130,7 @@ public:
 	// Folding
 	void	foldAll(bool fold = true);
 	void	setupFolding();
+	void	updateFolding();
 
 	// Events
 	void	onKeyDown(wxKeyEvent& e);

--- a/src/UI/TextEditor/TextEditor.h
+++ b/src/UI/TextEditor/TextEditor.h
@@ -78,21 +78,16 @@ private:
 	JumpToCalculator*	jump_to_calculator;
 	wxTimer				timer_update;
 	Lexer*				lexer;
+	string				prev_word_match;
+	string				autocomp_list;
+	int					bm_cursor_last_pos;
+	vector<int>			jump_to_lines;
 
 	// Calltip stuff
 	TLFunction*	ct_function;
 	int			ct_argset;
 	int			ct_start;
-	bool		ct_dwell;
-
-	// Autocompletion
-	string		autocomp_list;
-
-	// Brace matching
-	int	bm_cursor_last_pos;
-
-	// Jump To
-	vector<int>	jump_to_lines;
+	bool		ct_dwell;	
 
 public:
 	TextEditor(wxWindow* parent, int id);

--- a/src/UI/TextEditor/TextLanguage.cpp
+++ b/src/UI/TextEditor/TextLanguage.cpp
@@ -167,7 +167,9 @@ TextLanguage::TextLanguage(string id) :
 	line_comment{ "//" },
 	comment_begin{ "/*" },
 	comment_end{ "*/" },
-	preprocessor{ "#" }
+	preprocessor{ "#" },
+	block_begin{ "{" },
+	block_end{ "}" }
 {
 	// Init variables
 	this->id = id;
@@ -202,6 +204,8 @@ void TextLanguage::copyTo(TextLanguage* copy)
 	copy->case_sensitive = case_sensitive;
 	copy->f_lookup_url = f_lookup_url;
 	copy->doc_comment = doc_comment;
+	copy->block_begin = block_begin;
+	copy->block_end = block_end;
 
 	// Copy word lists
 	for (unsigned a = 0; a < 4; a++)
@@ -220,6 +224,14 @@ void TextLanguage::copyTo(TextLanguage* copy)
 				f->getReturnType()
 			);
 	}
+
+	// Copy preprocessor block begin/end
+	copy->pp_block_begin.clear();
+	copy->pp_block_end.clear();
+	for (unsigned a = 0; a < pp_block_begin.size(); a++)
+		copy->pp_block_begin.push_back(pp_block_begin[a]);
+	for (unsigned a = 0; a < pp_block_end.size(); a++)
+		copy->pp_block_end.push_back(pp_block_end[a]);
 }
 
 /* TextLanguage::addWord
@@ -526,6 +538,28 @@ bool TextLanguage::readLanguageDefinition(MemChunk& mc, string source)
 			{
 				for (unsigned v = 0; v < child->nValues(); v++)
 					lang->jb_ignore.push_back(child->getStringValue(v));
+			}
+
+			// Block begin
+			else if (S_CMPNOCASE(child->getName(), "block_begin"))
+				lang->block_begin = child->getStringValue();
+
+			// Block end
+			else if (S_CMPNOCASE(child->getName(), "block_end"))
+				lang->block_end = child->getStringValue();
+
+			// Preprocessor block begin
+			else if (S_CMPNOCASE(child->getName(), "pp_block_begin"))
+			{
+				for (unsigned v = 0; v < child->nValues(); v++)
+					lang->pp_block_begin.push_back(child->getStringValue(v));
+			}
+
+			// Preprocessor block end
+			else if (S_CMPNOCASE(child->getName(), "pp_block_end"))
+			{
+				for (unsigned v = 0; v < child->nValues(); v++)
+					lang->pp_block_end.push_back(child->getStringValue(v));
 			}
 
 			// Keywords

--- a/src/UI/TextEditor/TextLanguage.h
+++ b/src/UI/TextEditor/TextLanguage.h
@@ -37,23 +37,21 @@ private:
 	string				comment_begin;	// The beginning token for a block comment
 	string				comment_end;	// The ending token for a block comment
 	string				preprocessor;	// The beginning token for a preprocessor directive
+	string				doc_comment;	// The beginning token for a 'doc' comment (eg. /// in c/c++)
 	bool				case_sensitive;
 	vector<string>		jump_blocks;	// The keywords to search for when creating jump to list (eg. 'script')
 	vector<string>		jb_ignore;		// The keywords to ignore when creating jump to list (eg. 'optional')
 
-	// Keywords
-	vector<string>		keywords;
-	bool				k_upper;
-	bool				k_lower;
-	bool				k_caps;
-	string				k_lookup_url;
-
-	// Constants
-	vector<string>		constants;
-	bool				c_upper;
-	bool				c_lower;
-	bool				c_caps;
-	string				c_lookup_url;
+	// Word lists
+	struct WordList
+	{
+		vector<string>	list;
+		bool			upper;
+		bool			lower;
+		bool			caps;
+		string			lookup_url;
+	};
+	WordList	word_lists[4];
 
 	// Functions
 	vector<TLFunction*>	functions;
@@ -63,11 +61,24 @@ private:
 	string				f_lookup_url;
 
 public:
+	enum WordType
+	{
+		Keyword		= 0,
+		Constant	= 1,
+		Type		= 2,
+		Property	= 3,
+	};
+
 	TextLanguage(string id);
 	~TextLanguage();
 
 	string	getId() { return id; }
 	string	getName() { return name; }
+	string	getLineComment() { return line_comment; }
+	string	getCommentBegin() { return comment_begin; }
+	string	getCommentEnd() { return comment_end; }
+	string	getPreprocessor() { return preprocessor; }
+	string	getDocComment() { return doc_comment; }
 
 	void	copyTo(TextLanguage* copy);
 
@@ -76,9 +87,9 @@ public:
 	void	setCommentBegin(string token) { comment_begin = token; }
 	void	setCommentEnd(string token) { comment_end = token; }
 	void	setPreprocessor(string token) { preprocessor = token; }
+	void	setDocComment(string token) { doc_comment = token; }
 	void	setCaseSensitive(bool cs) { case_sensitive = cs; }
-	void	addKeyword(string keyword);
-	void	addConstant(string constant);
+	void	addWord(WordType type, string word);
 	void	addFunction(
 		string name,
 		string args,
@@ -87,21 +98,17 @@ public:
 		string return_type = ""
 	);
 
-	string	getKeywordsList();
-	string	getConstantsList();
+	string	getWordList(WordType type);
 	string	getFunctionsList();
 	string	getAutocompletionList(string start = "");
 
-	wxArrayString	getKeywordsSorted();
-	wxArrayString	getConstantsSorted();
+	wxArrayString	getWordListSorted(WordType type);
 	wxArrayString	getFunctionsSorted();
 
-	string	getKeywordLink() { return k_lookup_url; }
-	string	getConstantLink() { return c_lookup_url; }
+	string	getWordLink(WordType type) { return word_lists[type].lookup_url; }
 	string	getFunctionLink() { return f_lookup_url; }
 
-	bool	isKeyword(string word);
-	bool	isConstant(string word);
+	bool	isWord(WordType type, string word);
 	bool	isFunction(string word);
 
 	TLFunction*	getFunction(string name);
@@ -111,8 +118,7 @@ public:
 	unsigned	nJBIgnore() { return jb_ignore.size(); }
 	string		jBIgnore(unsigned index) { return jb_ignore[index]; }
 
-	void	clearKeywords() { keywords.clear(); }
-	void	clearConstants() { constants.clear(); }
+	void	clearWordList(WordType type) { word_lists[type].list.clear(); }
 	void	clearFunctions() { functions.clear(); }
 
 	// Static functions

--- a/src/UI/TextEditor/TextLanguage.h
+++ b/src/UI/TextEditor/TextLanguage.h
@@ -41,6 +41,10 @@ private:
 	bool				case_sensitive;
 	vector<string>		jump_blocks;	// The keywords to search for when creating jump to list (eg. 'script')
 	vector<string>		jb_ignore;		// The keywords to ignore when creating jump to list (eg. 'optional')
+	string				block_begin;	// The beginning of a block (eg. '{' in c/c++)
+	string				block_end;		// The end of a block (eg. '}' in c/c++)
+	vector<string>		pp_block_begin;	// Preprocessor words to start a folding block (eg. 'ifdef')
+	vector<string>		pp_block_end;	// Preprocessor words to end a folding block (eg. 'endif')
 
 	// Word lists
 	struct WordList
@@ -120,6 +124,11 @@ public:
 
 	void	clearWordList(WordType type) { word_lists[type].list.clear(); }
 	void	clearFunctions() { functions.clear(); }
+
+	string			getBlockBegin() { return block_begin; }
+	string			getBlockEnd() { return block_end; }
+	vector<string>&	getPPBlockBegin() { return pp_block_begin; }
+	vector<string>&	getPPBlockEnd() { return pp_block_end; }
 
 	// Static functions
 	static bool				readLanguageDefinition(MemChunk& mc, string source);

--- a/src/UI/TextEditor/TextStyle.cpp
+++ b/src/UI/TextEditor/TextStyle.cpp
@@ -35,6 +35,7 @@
 #include "Main.h"
 #include "TextEditor.h"
 #include "TextStyle.h"
+#include "Lexer.h"
 #include "Archive/ArchiveManager.h"
 
 
@@ -299,16 +300,18 @@ StyleSet::StyleSet(string name) : ts_default("default", "Default", wxSTC_STYLE_D
 	this->name = name;
 
 	// Init styles
-	styles.push_back(new TextStyle("preprocessor",	"Preprocessor",		wxSTC_C_PREPROCESSOR));
-	styles.push_back(new TextStyle("comment",		"Comment",			wxSTC_C_COMMENT));
-	styles.back()->addWxStyleId(wxSTC_C_COMMENTLINE);
-	styles.push_back(new TextStyle("string",		"String",			wxSTC_C_STRING));
-	styles.push_back(new TextStyle("character",		"Character",		wxSTC_C_CHARACTER));
-	styles.push_back(new TextStyle("keyword",		"Keyword",			wxSTC_C_WORD));
-	styles.push_back(new TextStyle("constant",		"Constant",			wxSTC_C_GLOBALCLASS));
-	styles.push_back(new TextStyle("function",		"Function",			wxSTC_C_WORD2));
-	styles.push_back(new TextStyle("number",		"Number",			wxSTC_C_NUMBER));
-	styles.push_back(new TextStyle("operator",		"Operator",			wxSTC_C_OPERATOR));
+	styles.push_back(new TextStyle("preprocessor",	"Preprocessor",		Lexer::Style::Preprocessor));
+	styles.push_back(new TextStyle("comment",		"Comment",			Lexer::Style::Comment));
+	styles.push_back(new TextStyle("comment_doc",	"Comment (Doc)",	Lexer::Style::CommentDoc));
+	styles.push_back(new TextStyle("string",		"String",			Lexer::Style::String));
+	styles.push_back(new TextStyle("character",		"Character",		Lexer::Style::Char));
+	styles.push_back(new TextStyle("keyword",		"Keyword",			Lexer::Style::Keyword));
+	styles.push_back(new TextStyle("constant",		"Constant",			Lexer::Style::Constant));
+	styles.push_back(new TextStyle("type",			"Type",				Lexer::Style::Type));
+	styles.push_back(new TextStyle("property",		"Property",			Lexer::Style::Property));
+	styles.push_back(new TextStyle("function",		"Function",			Lexer::Style::Function));
+	styles.push_back(new TextStyle("number",		"Number",			Lexer::Style::Number));
+	styles.push_back(new TextStyle("operator",		"Operator",			Lexer::Style::Operator));
 	styles.push_back(new TextStyle("bracematch",	"Brace Match",		wxSTC_STYLE_BRACELIGHT));
 	styles.push_back(new TextStyle("bracebad",		"Brace Mismatch",	wxSTC_STYLE_BRACEBAD));
 	styles.push_back(new TextStyle("linenum",		"Line Numbers",		wxSTC_STYLE_LINENUMBER));
@@ -316,6 +319,8 @@ StyleSet::StyleSet(string name) : ts_default("default", "Default", wxSTC_STYLE_D
 	styles.push_back(new TextStyle("calltip_hl",	"Call Tip Highlight"));
 	styles.push_back(new TextStyle("foldmargin",	"Code Folding Margin"));
 	styles.push_back(new TextStyle("guides",		"Indent/Right Margin Guide"));
+	styles.push_back(new TextStyle("wordmatch",		"Word Match"));
+	styles.push_back(new TextStyle("current_line",	"Current Line"));
 }
 
 /* StyleSet::~StyleSet
@@ -363,6 +368,31 @@ bool StyleSet::parseSet(ParseTreeNode* root)
 				styles[a]->foreground = ts_default.getForeground();
 				styles[a]->fg_defined = true;
 			}
+			else if (styles[a]->name == "type" || styles[a]->name == "property")
+			{
+				// No 'type' or 'property' style defined, copy it from keyword style
+				styles[a]->copyStyle(getStyle("keyword"));
+			}
+			else if (styles[a]->name == "comment_doc")
+			{
+				// No 'comment_doc' style defined, copy it from comment style
+				styles[a]->copyStyle(getStyle("comment"));
+			}
+			else if (styles[a]->name == "current_line")
+			{
+				// No 'currentline' style defined, use the default background and darken/lighten it a little
+				int fgm = -20;
+				int bgm = -10;
+				if (ts_default.background.greyscale().r < 100)
+				{
+					fgm = 30;
+					bgm = 15;
+				}
+				styles[a]->foreground = ts_default.getBackground().amp(fgm, fgm, fgm, 0);
+				styles[a]->fg_defined = true;
+				styles[a]->background = ts_default.getBackground().amp(bgm, bgm, bgm, 0);
+				styles[a]->bg_defined = true;
+			}
 		}
 	}
 
@@ -407,6 +437,24 @@ void StyleSet::applyTo(TextEditor* stc)
 	stc->SetEdgeColour(WXCOL(getStyle("guides")->getForeground()));
 	stc->StyleSetBackground(wxSTC_STYLE_INDENTGUIDE, WXCOL(getStyleBackground("guides")));
 	stc->StyleSetForeground(wxSTC_STYLE_INDENTGUIDE, WXCOL(getStyleForeground("guides")));
+
+	// Set word match indicator colour
+	stc->SetIndicatorCurrent(8);
+	stc->IndicatorSetForeground(8, WXCOL(getStyleForeground("wordmatch")));
+
+	// Set current line colour
+	stc->MarkerDefine(
+		1,
+		wxSTC_MARK_BACKGROUND,
+		WXCOL(getStyleBackground("current_line")),
+		WXCOL(getStyleBackground("current_line"))
+	);
+	stc->MarkerDefine(
+		2,
+		wxSTC_MARK_UNDERLINE,
+		WXCOL(getStyleForeground("current_line")),
+		WXCOL(getStyleForeground("current_line"))
+	);
 }
 
 /* StyleSet::copySet

--- a/src/Utility/Parser.cpp
+++ b/src/Utility/Parser.cpp
@@ -256,7 +256,7 @@ bool ParseTreeNode::parse(Tokenizer& tz)
 			// Check type of assignment list
 			token = tz.getToken();
 			string list_end = ";";
-			if (token == "{")
+			if (token == "{" && !tz.quotedString())
 			{
 				list_end = "}";
 				token = tz.getToken();


### PR DESCRIPTION
Added a custom lexer implementation for the text editor, does everything the standard one did before but with the following benefits:
- Comment, preprocessor and block start/end tokens are now configurable via TextLanguage
- Allow more word lists to be defined for syntax highlighting (added 'Type' and 'Property' word lists configurable via TextLanguage, in addition to the existing keyword/constant/function lists)
- Improved code folding in some situations, eg. having a block opening `{` on a line on its own will fold from the line above instead

Other improvements and additions:
- Added (optional) highlighting of all occurrences of the word under the cursor
- Added (optional) highlight for current line
- Added new styles for 'Comment (Doc)', 'Type', 'Property', 'Word Match' and 'Current Line'
- Created new SLADE default colour sets (light and dark) and an additional 'Material' colour set
- Added option to show a line at collapsed fold points