### PR TITLE
Remove hard-coding of a wealth of UDMF rendering features

### DIFF
--- a/dist/res/config/ports/eternity.cfg
+++ b/dist/res/config/ports/eternity.cfg
@@ -43,6 +43,16 @@ port eternity
 
 	// UDMF namespace
 	udmf_namespace = "Eternity";
+
+	udmf_slopes = true;
+	udmf_flat_lighting = true;
+	udmf_flat_panning = true;
+	udmf_flat_rotation = true;
+	udmf_flat_scaling = true;
+	udmf_line_transparency = true;
+	udmf_side_scaling = false;
+	udmf_texture_scaling = false;
+	udmf_texture_offsets = false;
 }
 
 // Action specials

--- a/dist/res/config/ports/eternity.cfg
+++ b/dist/res/config/ports/eternity.cfg
@@ -44,12 +44,13 @@ port eternity
 	// UDMF namespace
 	udmf_namespace = "Eternity";
 
-	udmf_slopes = true;
+	udmf_slopes = false; // Only supports slopes via lines
 	udmf_flat_lighting = true;
 	udmf_flat_panning = true;
 	udmf_flat_rotation = true;
 	udmf_flat_scaling = true;
 	udmf_line_transparency = true;
+	udmf_sector_color = false;
 	udmf_side_scaling = false;
 	udmf_texture_scaling = false;
 	udmf_texture_offsets = false;

--- a/dist/res/config/ports/eternity.cfg
+++ b/dist/res/config/ports/eternity.cfg
@@ -51,6 +51,9 @@ port eternity
 	udmf_flat_scaling = true;
 	udmf_line_transparency = true;
 	udmf_sector_color = false;
+	udmf_sector_fog = false;
+	udmf_side_lighting = false;
+	udmf_side_midtex_wrapping = false;
 	udmf_side_scaling = false;
 	udmf_texture_scaling = false;
 	udmf_texture_offsets = false;

--- a/dist/res/config/ports/zdoom.cfg
+++ b/dist/res/config/ports/zdoom.cfg
@@ -62,7 +62,8 @@ port zdoom
 	udmf_flat_rotation = true;
 	udmf_flat_scaling = true;
 	udmf_line_transparency = true;
-	udmf_side_scaling = true;
+	udmf_sector_color = true;
+	udmf_side_scaling = false;
 	udmf_texture_scaling = true;
 	udmf_texture_offsets = true;
 }

--- a/dist/res/config/ports/zdoom.cfg
+++ b/dist/res/config/ports/zdoom.cfg
@@ -55,6 +55,16 @@ port zdoom
 	
 	// UDMF namespace
 	udmf_namespace = "ZDoom";
+
+	udmf_slopes = true;
+	udmf_flat_lighting = true;
+	udmf_flat_panning = true;
+	udmf_flat_rotation = true;
+	udmf_flat_scaling = true;
+	udmf_line_transparency = true;
+	udmf_side_scaling = true;
+	udmf_texture_scaling = true;
+	udmf_texture_offsets = true;
 }
 
 // Action specials

--- a/dist/res/config/ports/zdoom.cfg
+++ b/dist/res/config/ports/zdoom.cfg
@@ -63,6 +63,9 @@ port zdoom
 	udmf_flat_scaling = true;
 	udmf_line_transparency = true;
 	udmf_sector_color = true;
+	udmf_sector_fog = true;
+	udmf_side_lighting = true;
+	udmf_side_midtex_wrapping = true;
 	udmf_side_scaling = false;
 	udmf_texture_scaling = true;
 	udmf_texture_offsets = true;

--- a/src/MapEditor/GameConfiguration/GameConfiguration.cpp
+++ b/src/MapEditor/GameConfiguration/GameConfiguration.cpp
@@ -116,7 +116,7 @@ void GameConfiguration::setDefaults()
 
 	udmf_texture_offsets = udmf_slopes = udmf_flat_lighting = udmf_flat_panning =
 	udmf_flat_rotation = udmf_flat_scaling = udmf_line_transparency =
-	udmf_side_scaling = udmf_texture_scaling = false;
+	udmf_sector_color = udmf_side_scaling = udmf_texture_scaling = false;
 }
 
 /* GameConfiguration::udmfNamespace
@@ -970,6 +970,7 @@ void GameConfiguration::readGameSection(ParseTreeNode* node_game, bool port_sect
 		READ_BOOL(udmf_flat_rotation, udmf_flat_rotation); // UDMF flat rotation
 		READ_BOOL(udmf_flat_scaling, udmf_flat_scaling); // UDMF flat scaling
 		READ_BOOL(udmf_line_transparency, udmf_line_transparency); // UDMF line transparency
+		READ_BOOL(udmf_sector_color, udmf_sector_color); // UDMF sector color
 		READ_BOOL(udmf_side_scaling, udmf_side_scaling); // UDMF per-sidedef scaling
 		READ_BOOL(udmf_texture_scaling, udmf_texture_scaling); // UDMF per-texture scaling
 		READ_BOOL(udmf_texture_offsets, udmf_texture_offsets); // UDMF per-texture offsets

--- a/src/MapEditor/GameConfiguration/GameConfiguration.cpp
+++ b/src/MapEditor/GameConfiguration/GameConfiguration.cpp
@@ -115,8 +115,9 @@ void GameConfiguration::setDefaults()
 	as_generalized_m.setTagged(AS_TT_SECTOR_BACK);
 
 	udmf_texture_offsets = udmf_slopes = udmf_flat_lighting = udmf_flat_panning =
-	udmf_flat_rotation = udmf_flat_scaling = udmf_line_transparency =
-	udmf_sector_color = udmf_side_scaling = udmf_texture_scaling = false;
+	udmf_flat_rotation = udmf_flat_scaling = udmf_line_transparency = udmf_sector_color =
+	udmf_sector_fog = udmf_side_lighting = udmf_side_midtex_wrapping = udmf_side_scaling =
+	udmf_texture_scaling = false;
 }
 
 /* GameConfiguration::udmfNamespace
@@ -971,6 +972,9 @@ void GameConfiguration::readGameSection(ParseTreeNode* node_game, bool port_sect
 		READ_BOOL(udmf_flat_scaling, udmf_flat_scaling); // UDMF flat scaling
 		READ_BOOL(udmf_line_transparency, udmf_line_transparency); // UDMF line transparency
 		READ_BOOL(udmf_sector_color, udmf_sector_color); // UDMF sector color
+		READ_BOOL(udmf_sector_fog, udmf_sector_fog); // UDMF sector fog
+		READ_BOOL(udmf_side_lighting, udmf_side_lighting); // UDMF per-sidedef lighting
+		READ_BOOL(udmf_side_midtex_wrapping, udmf_side_midtex_wrapping); // UDMF per-sidetex midtex wrapping
 		READ_BOOL(udmf_side_scaling, udmf_side_scaling); // UDMF per-sidedef scaling
 		READ_BOOL(udmf_texture_scaling, udmf_texture_scaling); // UDMF per-texture scaling
 		READ_BOOL(udmf_texture_offsets, udmf_texture_offsets); // UDMF per-texture offsets

--- a/src/MapEditor/GameConfiguration/GameConfiguration.cpp
+++ b/src/MapEditor/GameConfiguration/GameConfiguration.cpp
@@ -113,6 +113,10 @@ void GameConfiguration::setDefaults()
 	as_generalized_s.setTagged(AS_TT_SECTOR);
 	as_generalized_m.setName("Boom Generalized Manual Special");
 	as_generalized_m.setTagged(AS_TT_SECTOR_BACK);
+
+	udmf_texture_offsets = udmf_slopes = udmf_flat_lighting = udmf_flat_panning =
+	udmf_flat_rotation = udmf_flat_scaling = udmf_line_transparency =
+	udmf_side_scaling = udmf_texture_scaling = false;
 }
 
 /* GameConfiguration::udmfNamespace
@@ -874,6 +878,9 @@ void GameConfiguration::readUDMFProperties(ParseTreeNode* block, UDMFPropMap& pl
 	}
 }
 
+#define READ_BOOL(obj, field)	else if (S_CMPNOCASE(node->getName(), #field)) \
+									obj = node->getBoolValue()
+
 /* GameConfiguration::readGameSection
  * Reads a game or port definition from a parsed tree [node]. If
  * [port_section] is true it is a port definition
@@ -956,6 +963,16 @@ void GameConfiguration::readGameSection(ParseTreeNode* node_game, bool port_sect
 		// Long names
 		else if (S_CMPNOCASE(node->getName(), "long_names"))
 			allow_long_names = node->getBoolValue();
+
+		READ_BOOL(udmf_slopes, udmf_slopes); // UDMF slopes
+		READ_BOOL(udmf_flat_lighting, udmf_flat_lighting); // UDMF flat lighting
+		READ_BOOL(udmf_flat_panning, udmf_flat_panning); // UDMF flat panning
+		READ_BOOL(udmf_flat_rotation, udmf_flat_rotation); // UDMF flat rotation
+		READ_BOOL(udmf_flat_scaling, udmf_flat_scaling); // UDMF flat scaling
+		READ_BOOL(udmf_line_transparency, udmf_line_transparency); // UDMF line transparency
+		READ_BOOL(udmf_side_scaling, udmf_side_scaling); // UDMF per-sidedef scaling
+		READ_BOOL(udmf_texture_scaling, udmf_texture_scaling); // UDMF per-texture scaling
+		READ_BOOL(udmf_texture_offsets, udmf_texture_offsets); // UDMF per-texture offsets
 
 		// Defaults section
 		else if (S_CMPNOCASE(node->getName(), "defaults"))

--- a/src/MapEditor/GameConfiguration/GameConfiguration.h
+++ b/src/MapEditor/GameConfiguration/GameConfiguration.h
@@ -129,6 +129,9 @@ private:
 	bool				udmf_flat_scaling;	// If UDMF has flat scaling
 	bool				udmf_line_transparency;	// If UDMF has line transparency
 	bool				udmf_sector_color;	// If UDMF has sector colour
+	bool				udmf_sector_fog;	// If UDMF has sector fog
+	bool				udmf_side_lighting;	// If UDMF has sidedef lighting independent from sector lighting
+	bool				udmf_side_midtex_wrapping;	// If UDMF has per-sidedef midtex wrapping
 	bool				udmf_side_scaling;	// If UDMF has line scaling
 	bool				udmf_texture_scaling;	// If UDMF has per-texture line scaling
 	bool				udmf_texture_offsets;	// If UDMF has per-texture offsets compared to per-sidedef
@@ -239,6 +242,9 @@ public:
 	bool	udmfFlatScaling() { return udmf_flat_scaling; }
 	bool	udmfLineTransparency() { return udmf_line_transparency; }
 	bool	udmfSectorColor() { return udmf_sector_color; }
+	bool	udmfSectorFog() { return udmf_sector_fog; }
+	bool	udmfSideLighting() { return udmf_side_lighting; }
+	bool	udmfSideMidtexWrapping() { return udmf_side_midtex_wrapping; }
 	bool	udmfSideScaling() { return udmf_side_scaling; }
 	bool	udmfTextureScaling() { return udmf_texture_scaling; }
 	bool	udmfTextureOffsets() { return udmf_texture_offsets; }
@@ -351,6 +357,8 @@ public:
 	void	dumpUDMFProperties();
 };
 
+// Define for less cumbersome map->currentFormat() == MAP_UDMF && theGameConfiguration->udmf
+#define UDMF_AND_HAS(prop) (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmf##prop())
 // Define for less cumbersome GameConfiguration::getInstance()
 #define theGameConfiguration GameConfiguration::getInstance()
 

--- a/src/MapEditor/GameConfiguration/GameConfiguration.h
+++ b/src/MapEditor/GameConfiguration/GameConfiguration.h
@@ -122,6 +122,16 @@ private:
 	vector<int>			light_levels;		// Light levels for up/down light in editor
 	bool				allow_long_names;	// Allow long names for maps/textures
 
+	bool				udmf_slopes;		// If UDMF has slope support
+	bool				udmf_flat_lighting;	// If UDMF has flat lighting independent from sector lighting
+	bool				udmf_flat_panning;	// If UDMF has flat panning
+	bool				udmf_flat_rotation;	// If UDMF has flat rotation
+	bool				udmf_flat_scaling;	// If UDMF has flat scaling
+	bool				udmf_line_transparency;	// If UDMF has line transparency
+	bool				udmf_side_scaling;	// If UDMF has line scaling
+	bool				udmf_texture_scaling;	// If UDMF has per-texture line scaling
+	bool				udmf_texture_offsets;	// If UDMF has per-texture offsets compared to per-sidedef
+
 	// Basic game configuration info
 	struct gconf_t
 	{
@@ -221,6 +231,15 @@ public:
 	string	scriptLanguage() { return script_language; }
 	int		lightLevelInterval();
 	bool	allowLongNames() { return allow_long_names; }
+	bool	udmfSlopes() { return udmf_slopes; }
+	bool	udmfFlatLighting() { return udmf_flat_lighting; }
+	bool	udmfFlatPanning() { return udmf_flat_panning; }
+	bool	udmfFlatRotation() { return udmf_flat_rotation; }
+	bool	udmfFlatScaling() { return udmf_flat_scaling; }
+	bool	udmfLineTransparency() { return udmf_line_transparency; }
+	bool	udmfSideScaling() { return udmf_side_scaling; }
+	bool	udmfTextureScaling() { return udmf_texture_scaling; }
+	bool	udmfTextureOffsets() { return udmf_texture_offsets; }
 
 	string			readConfigName(MemChunk& mc);
 	gconf_t			readBasicGameConfig(MemChunk& mc);

--- a/src/MapEditor/GameConfiguration/GameConfiguration.h
+++ b/src/MapEditor/GameConfiguration/GameConfiguration.h
@@ -357,8 +357,6 @@ public:
 	void	dumpUDMFProperties();
 };
 
-// Define for less cumbersome map->currentFormat() == MAP_UDMF && theGameConfiguration->udmf
-#define UDMF_AND_HAS(prop) (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmf##prop())
 // Define for less cumbersome GameConfiguration::getInstance()
 #define theGameConfiguration GameConfiguration::getInstance()
 

--- a/src/MapEditor/GameConfiguration/GameConfiguration.h
+++ b/src/MapEditor/GameConfiguration/GameConfiguration.h
@@ -128,6 +128,7 @@ private:
 	bool				udmf_flat_rotation;	// If UDMF has flat rotation
 	bool				udmf_flat_scaling;	// If UDMF has flat scaling
 	bool				udmf_line_transparency;	// If UDMF has line transparency
+	bool				udmf_sector_color;	// If UDMF has sector colour
 	bool				udmf_side_scaling;	// If UDMF has line scaling
 	bool				udmf_texture_scaling;	// If UDMF has per-texture line scaling
 	bool				udmf_texture_offsets;	// If UDMF has per-texture offsets compared to per-sidedef
@@ -237,6 +238,7 @@ public:
 	bool	udmfFlatRotation() { return udmf_flat_rotation; }
 	bool	udmfFlatScaling() { return udmf_flat_scaling; }
 	bool	udmfLineTransparency() { return udmf_line_transparency; }
+	bool	udmfSectorColor() { return udmf_sector_color; }
 	bool	udmfSideScaling() { return udmf_side_scaling; }
 	bool	udmfTextureScaling() { return udmf_texture_scaling; }
 	bool	udmfTextureOffsets() { return udmf_texture_offsets; }

--- a/src/MapEditor/MapEditor.cpp
+++ b/src/MapEditor/MapEditor.cpp
@@ -5052,7 +5052,7 @@ bool MapEditor::handleKeyBind(string key, fpoint2_t position)
 	else if (key.StartsWith("me3d_") && edit_mode == MODE_3D)
 	{
 		// Check is UDMF
-		bool is_udmf = theMapEditor->currentMapDesc().format == MAP_UDMF;
+		bool is_udmf = map.currentFormat() == MAP_UDMF;
 
 		// Clear selection
 		if (key == "me3d_clear_selection")
@@ -5064,7 +5064,7 @@ bool MapEditor::handleKeyBind(string key, fpoint2_t position)
 		// Toggle linked light levels
 		else if (key == "me3d_light_toggle_link")
 		{
-			if (!theGameConfiguration->udmfFlatLighting())
+			if (!is_udmf || !theGameConfiguration->udmfFlatLighting())
 				addEditorMessage("Unlinked light levels not supported in this game configuration");
 			else
 			{
@@ -5079,7 +5079,7 @@ bool MapEditor::handleKeyBind(string key, fpoint2_t position)
 		// Toggle linked offsets
 		else if (key == "me3d_wall_toggle_link_ofs")
 		{
-			if (!theGameConfiguration->udmfTextureOffsets())
+			if (!is_udmf || !theGameConfiguration->udmfTextureOffsets())
 				addEditorMessage("Unlinked wall offsets not supported in this game configuration");
 			else
 			{

--- a/src/MapEditor/MapEditor.cpp
+++ b/src/MapEditor/MapEditor.cpp
@@ -4468,7 +4468,7 @@ void MapEditor::resetOffsets3d()
 		}
 
 		// Reset scaling
-		if (theGameConfiguration->udmfNamespace() == "zdoom")
+		if (theMapEditor->currentMapDesc().format == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			if (walls[a].type == SEL_SIDE_TOP)
 			{
@@ -4489,7 +4489,7 @@ void MapEditor::resetOffsets3d()
 	}
 
 	// Go through flats
-	if (theGameConfiguration->udmfNamespace() != "")
+	if (theMapEditor->currentMapDesc().format == MAP_UDMF)
 	{
 		for (unsigned a = 0; a < flats.size(); a++)
 		{
@@ -4522,7 +4522,8 @@ void MapEditor::resetOffsets3d()
 	endUndoRecord();
 
 	// Editor message
-	if (theGameConfiguration->udmfNamespace() == "zdoom")
+	if (theMapEditor->currentMapDesc().format == MAP_UDMF && (theGameConfiguration->udmfFlatScaling() ||
+		theGameConfiguration->udmfSideScaling() || theGameConfiguration->udmfTextureScaling()))
 		addEditorMessage("Offsets and scaling reset");
 	else
 		addEditorMessage("Offsets reset");
@@ -4851,19 +4852,23 @@ void MapEditor::changeScale3d(double amount, bool x)
 	for (unsigned a = 0; a < items.size(); a++)
 	{
 		// Wall
-		if (items[a].type >= SEL_SIDE_TOP && items[a].type <= SEL_SIDE_BOTTOM)
+		if (items[a].type >= SEL_SIDE_TOP && items[a].type <= SEL_SIDE_BOTTOM &&
+			(theGameConfiguration->udmfSideScaling() || theGameConfiguration->udmfTextureScaling()))
 		{
 			MapSide* side = map.getSide(items[a].index);
 
 			// Build property string (offset[x/y]_[top/mid/bottom])
 			string ofs = "scalex";
 			if (!x) ofs = "scaley";
-			if (items[a].type == SEL_SIDE_BOTTOM)
-				ofs += "_bottom";
-			else if (items[a].type == SEL_SIDE_TOP)
-				ofs += "_top";
-			else
-				ofs += "_mid";
+			if (theGameConfiguration->udmfTextureScaling())
+			{
+				if (items[a].type == SEL_SIDE_BOTTOM)
+					ofs += "_bottom";
+				else if (items[a].type == SEL_SIDE_TOP)
+					ofs += "_top";
+				else
+					ofs += "_mid";
+			}
 
 			// Change the offset
 			double scale = side->floatProperty(ofs);
@@ -4871,8 +4876,8 @@ void MapEditor::changeScale3d(double amount, bool x)
 				side->setFloatProperty(ofs, scale + amount);
 		}
 
-		// Flat (UDMF+ZDoom only)
-		else
+		// Flat (UDMF only)
+		else if (theGameConfiguration->udmfFlatScaling())
 		{
 			MapSector* sector = map.getSector(items[a].index);
 
@@ -5046,14 +5051,8 @@ bool MapEditor::handleKeyBind(string key, fpoint2_t position)
 	// --- 3d mode keybinds ---
 	else if (key.StartsWith("me3d_") && edit_mode == MODE_3D)
 	{
-		// Check for extended udmf properties
-		bool ext = false;
-		if (theMapEditor->currentMapDesc().format == MAP_UDMF &&
-				S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "zdoom"))
-			ext = true;
-		if(theMapEditor->currentMapDesc().format == MAP_UDMF &&
-			S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "eternity"))
-			ext = true;
+		// Check is UDMF
+		bool is_udmf = theMapEditor->currentMapDesc().format == MAP_UDMF;
 
 		// Clear selection
 		if (key == "me3d_clear_selection")
@@ -5125,14 +5124,14 @@ bool MapEditor::handleKeyBind(string key, fpoint2_t position)
 		else if (key == "me3d_thing_down8")	changeThingZ3d(-8);
 
 		// Wall/Flat scale changes
-		else if (key == "me3d_scalex_up_l" && ext) changeScale3d(1, true);
-		else if (key == "me3d_scalex_up_s" && ext) changeScale3d(0.1, true);
-		else if (key == "me3d_scalex_down_l" && ext) changeScale3d(-1, true);
-		else if (key == "me3d_scalex_down_s" && ext) changeScale3d(-0.1, true);
-		else if (key == "me3d_scaley_up_l" && ext) changeScale3d(1, false);
-		else if (key == "me3d_scaley_up_s" && ext) changeScale3d(0.1, false);
-		else if (key == "me3d_scaley_down_l" && ext) changeScale3d(-1, false);
-		else if (key == "me3d_scaley_down_s" && ext) changeScale3d(-0.1, false);
+		else if (key == "me3d_scalex_up_l" && is_udmf) changeScale3d(1, true);
+		else if (key == "me3d_scalex_up_s" && is_udmf) changeScale3d(0.1, true);
+		else if (key == "me3d_scalex_down_l" && is_udmf) changeScale3d(-1, true);
+		else if (key == "me3d_scalex_down_s" && is_udmf) changeScale3d(-0.1, true);
+		else if (key == "me3d_scaley_up_l" && is_udmf) changeScale3d(1, false);
+		else if (key == "me3d_scaley_up_s" && is_udmf) changeScale3d(0.1, false);
+		else if (key == "me3d_scaley_down_l" && is_udmf) changeScale3d(-1, false);
+		else if (key == "me3d_scaley_down_s" && is_udmf) changeScale3d(-0.1, false);
 
 		// Auto-align
 		else if (key == "me3d_wall_autoalign_x")

--- a/src/MapEditor/Renderer/MapRenderer2D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer2D.cpp
@@ -1891,7 +1891,7 @@ void MapRenderer2D::renderFlatsImmediate(int type, bool texture, float alpha)
 						sx *= (1.0 / sector->floatProperty("xscaleceiling"));
 						sy *= (1.0 / sector->floatProperty("yscaleceiling"));
 					}
-					if(theGameConfiguration->udmfFlatRotation())
+					if (theGameConfiguration->udmfFlatRotation())
 						rot = sector->floatProperty("rotationceiling");
 				}
 			}
@@ -2043,7 +2043,7 @@ void MapRenderer2D::renderFlatsVBO(int type, bool texture, float alpha)
 						sx *= (1.0 / sector->floatProperty("xscaleceiling"));
 						sy *= (1.0 / sector->floatProperty("yscaleceiling"));
 					}
-					if(theGameConfiguration->udmfFlatRotation())
+					if (theGameConfiguration->udmfFlatRotation())
 						rot = sector->floatProperty("rotationceiling");
 				}
 			}

--- a/src/MapEditor/Renderer/MapRenderer2D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer2D.cpp
@@ -1859,48 +1859,40 @@ void MapRenderer2D::renderFlatsImmediate(int type, bool texture, float alpha)
 			double sx = tex->getScaleX();
 			double sy = tex->getScaleY();
 			double rot = 0;
-			// Check for UDMF + ZDoom extensions
-			if (theMapEditor->currentMapDesc().format == MAP_UDMF && S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "zdoom"))
+			// Check for various UDMF extensions
+			if (theMapEditor->currentMapDesc().format == MAP_UDMF)
 			{
 				// Floor
 				if (type <= 1)
 				{
-					ox = sector->floatProperty("xpanningfloor");
-					oy = sector->floatProperty("ypanningfloor");
-					sx *= (1.0 / sector->floatProperty("xscalefloor"));
-					sy *= (1.0 / sector->floatProperty("yscalefloor"));
-					rot = sector->floatProperty("rotationfloor");
+					if (theGameConfiguration->udmfFlatPanning())
+					{
+						ox = sector->floatProperty("xpanningfloor");
+						oy = sector->floatProperty("ypanningfloor");
+					}
+					if (theGameConfiguration->udmfFlatScaling())
+					{
+						sx *= (1.0 / sector->floatProperty("xscalefloor"));
+						sy *= (1.0 / sector->floatProperty("yscalefloor"));
+					}
+					if (theGameConfiguration->udmfFlatRotation())
+						rot = sector->floatProperty("rotationfloor");
 				}
 				// Ceiling
 				else
 				{
-					ox = sector->floatProperty("xpanningceiling");
-					oy = sector->floatProperty("ypanningceiling");
-					sx *= (1.0 / sector->floatProperty("xscaleceiling"));
-					sy *= (1.0 / sector->floatProperty("yscaleceiling"));
-					rot = sector->floatProperty("rotationceiling");
-				}
-			}
-			// Check for UDMF + Eternity extensions
-			if(theMapEditor->currentMapDesc().format == MAP_UDMF && S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "eternity"))
-			{
-				// Floor
-				if(type <= 1)
-				{
-					ox = sector->floatProperty("xpanningfloor");
-					oy = sector->floatProperty("ypanningfloor");
-					//sx *= (1.0 / sector->floatProperty("xscalefloor"));
-					//sy *= (1.0 / sector->floatProperty("yscalefloor"));
-					rot = sector->floatProperty("rotationfloor");
-				}
-				// Ceiling
-				else
-				{
-					ox = sector->floatProperty("xpanningceiling");
-					oy = sector->floatProperty("ypanningceiling");
-					//sx *= (1.0 / sector->floatProperty("xscaleceiling"));
-					//sy *= (1.0 / sector->floatProperty("yscaleceiling"));
-					rot = sector->floatProperty("rotationceiling");
+					if (theGameConfiguration->udmfFlatPanning())
+					{
+						ox = sector->floatProperty("xpanningceiling");
+						oy = sector->floatProperty("ypanningceiling");
+					}
+					if (theGameConfiguration->udmfFlatScaling())
+					{
+						sx *= (1.0 / sector->floatProperty("xscaleceiling"));
+						sy *= (1.0 / sector->floatProperty("yscaleceiling"));
+					}
+					if(theGameConfiguration->udmfFlatRotation())
+						rot = sector->floatProperty("rotationceiling");
 				}
 			}
 
@@ -2019,48 +2011,40 @@ void MapRenderer2D::renderFlatsVBO(int type, bool texture, float alpha)
 			double sx = tex->getScaleX();
 			double sy = tex->getScaleY();
 			double rot = 0;
-			// Check for UDMF + ZDoom extensions
-			if (theMapEditor->currentMapDesc().format == MAP_UDMF && S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "zdoom"))
+			// Check for various UDMF extensions
+			if (theMapEditor->currentMapDesc().format == MAP_UDMF)
 			{
 				// Floor
 				if (type <= 1)
 				{
-					ox = sector->floatProperty("xpanningfloor");
-					oy = sector->floatProperty("ypanningfloor");
-					sx *= (1.0 / sector->floatProperty("xscalefloor"));
-					sy *= (1.0 / sector->floatProperty("yscalefloor"));
-					rot = sector->floatProperty("rotationfloor");
+					if (theGameConfiguration->udmfFlatPanning())
+					{
+						ox = sector->floatProperty("xpanningfloor");
+						oy = sector->floatProperty("ypanningfloor");
+					}
+					if (theGameConfiguration->udmfFlatScaling())
+					{
+						sx *= (1.0 / sector->floatProperty("xscalefloor"));
+						sy *= (1.0 / sector->floatProperty("yscalefloor"));
+					}
+					if (theGameConfiguration->udmfFlatRotation())
+						rot = sector->floatProperty("rotationfloor");
 				}
 				// Ceiling
 				else
 				{
-					ox = sector->floatProperty("xpanningceiling");
-					oy = sector->floatProperty("ypanningceiling");
-					sx *= (1.0 / sector->floatProperty("xscaleceiling"));
-					sy *= (1.0 / sector->floatProperty("yscaleceiling"));
-					rot = sector->floatProperty("rotationceiling");
-				}
-			}
-			// Check for UDMF + Eternity extensions
-			if(theMapEditor->currentMapDesc().format == MAP_UDMF && S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "eternity"))
-			{
-				// Floor
-				if(type <= 1)
-				{
-					ox = sector->floatProperty("xpanningfloor");
-					oy = sector->floatProperty("ypanningfloor");
-					sx *= (1.0 / sector->floatProperty("xscalefloor"));
-					sy *= (1.0 / sector->floatProperty("yscalefloor"));
-					rot = sector->floatProperty("rotationfloor");
-				}
-				// Ceiling
-				else
-				{
-					ox = sector->floatProperty("xpanningceiling");
-					oy = sector->floatProperty("ypanningceiling");
-					sx *= (1.0 / sector->floatProperty("xscaleceiling"));
-					sy *= (1.0 / sector->floatProperty("yscaleceiling"));
-					rot = sector->floatProperty("rotationceiling");
+					if (theGameConfiguration->udmfFlatPanning())
+					{
+						ox = sector->floatProperty("xpanningceiling");
+						oy = sector->floatProperty("ypanningceiling");
+					}
+					if (theGameConfiguration->udmfFlatScaling())
+					{
+						sx *= (1.0 / sector->floatProperty("xscaleceiling"));
+						sy *= (1.0 / sector->floatProperty("yscaleceiling"));
+					}
+					if(theGameConfiguration->udmfFlatRotation())
+						rot = sector->floatProperty("rotationceiling");
 				}
 			}
 			// Scaling applies to offsets as well.

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -799,37 +799,37 @@ void MapRenderer3D::updateFlatTexCoords(unsigned index, bool floor)
 	double sy = floor ? floors[index].texture->getScaleY() : ceilings[index].texture->getScaleY();
 	double rot = 0;
 
-	// Check for UDMF + ZDoom extensions
+	// Check for UDMF + panning/scaling/rotation
 	if (theMapEditor->currentMapDesc().format == MAP_UDMF)
 	{
 		if (floor)
 		{
-			if(theGameConfiguration->udmfFlatPanning())
+			if (theGameConfiguration->udmfFlatPanning())
 			{
 				ox = sector->floatProperty("xpanningfloor");
 				oy = sector->floatProperty("ypanningfloor");
 			}
-			if(theGameConfiguration->udmfFlatScaling())
+			if (theGameConfiguration->udmfFlatScaling())
 			{
 				sx *= (1.0 / sector->floatProperty("xscalefloor"));
 				sy *= (1.0 / sector->floatProperty("yscalefloor"));
 			}
-			if(theGameConfiguration->udmfFlatRotation())
+			if (theGameConfiguration->udmfFlatRotation())
 				rot = sector->floatProperty("rotationfloor");
 		}
 		else
 		{
-			if(theGameConfiguration->udmfFlatPanning())
+			if (theGameConfiguration->udmfFlatPanning())
 			{
 				ox = sector->floatProperty("xpanningceiling");
 				oy = sector->floatProperty("ypanningceiling");
 			}
-			if(theGameConfiguration->udmfFlatScaling())
+			if (theGameConfiguration->udmfFlatScaling())
 			{
 				sx *= (1.0 / sector->floatProperty("xscaleceiling"));
 				sy *= (1.0 / sector->floatProperty("yscaleceiling"));
 			}
-			if(theGameConfiguration->udmfFlatRotation())
+			if (theGameConfiguration->udmfFlatRotation())
 				rot = sector->floatProperty("rotationceiling");
 		}
 	}

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -800,44 +800,39 @@ void MapRenderer3D::updateFlatTexCoords(unsigned index, bool floor)
 	double rot = 0;
 
 	// Check for UDMF + ZDoom extensions
-	if (theMapEditor->currentMapDesc().format == MAP_UDMF && S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "zdoom"))
+	if (theMapEditor->currentMapDesc().format == MAP_UDMF)
 	{
 		if (floor)
 		{
-			ox = sector->floatProperty("xpanningfloor");
-			oy = sector->floatProperty("ypanningfloor");
-			sx *= (1.0 / sector->floatProperty("xscalefloor"));
-			sy *= (1.0 / sector->floatProperty("yscalefloor"));
-			rot = sector->floatProperty("rotationfloor");
+			if(theGameConfiguration->udmfFlatPanning())
+			{
+				ox = sector->floatProperty("xpanningfloor");
+				oy = sector->floatProperty("ypanningfloor");
+			}
+			if(theGameConfiguration->udmfFlatScaling())
+			{
+				sx *= (1.0 / sector->floatProperty("xscalefloor"));
+				sy *= (1.0 / sector->floatProperty("yscalefloor"));
+			}
+			if(theGameConfiguration->udmfFlatRotation())
+				rot = sector->floatProperty("rotationfloor");
 		}
 		else
 		{
-			ox = sector->floatProperty("xpanningceiling");
-			oy = sector->floatProperty("ypanningceiling");
-			sx *= (1.0 / sector->floatProperty("xscaleceiling"));
-			sy *= (1.0 / sector->floatProperty("yscaleceiling"));
-			rot = sector->floatProperty("rotationceiling");
+			if(theGameConfiguration->udmfFlatPanning())
+			{
+				ox = sector->floatProperty("xpanningceiling");
+				oy = sector->floatProperty("ypanningceiling");
+			}
+			if(theGameConfiguration->udmfFlatScaling())
+			{
+				sx *= (1.0 / sector->floatProperty("xscaleceiling"));
+				sy *= (1.0 / sector->floatProperty("yscaleceiling"));
+			}
+			if(theGameConfiguration->udmfFlatRotation())
+				rot = sector->floatProperty("rotationceiling");
 		}
 	}
-	else if (theMapEditor->currentMapDesc().format == MAP_UDMF && S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "eternity"))
-	{
-		if(floor)
-		{
-			ox = sector->floatProperty("xpanningfloor");
-			oy = sector->floatProperty("ypanningfloor");
-			sx *= (1.0 / sector->floatProperty("xscalefloor"));
-			sy *= (1.0 / sector->floatProperty("yscalefloor"));
-			rot = sector->floatProperty("rotationfloor");
-		}
-      else
-      {
-         ox = sector->floatProperty("xpanningceiling");
-         oy = sector->floatProperty("ypanningceiling");
-         sx *= (1.0 / sector->floatProperty("xscaleceiling"));
-         sy *= (1.0 / sector->floatProperty("yscaleceiling"));
-         rot = sector->floatProperty("rotationceiling");
-      }
-   }
 
 	// Scaling applies to offsets as well.
 	// Note for posterity: worldpanning only applies to textures, not flats

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -1338,7 +1338,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		yoff = yoff1;
 		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
-			// ZDoom UDMF extra offsets
+			// UDMF extra offsets
 			if (line->s1()->hasProp("offsetx_bottom"))
 				xoff += line->s1()->floatProperty("offsetx_bottom");
 			if (line->s1()->hasProp("offsety_bottom"))
@@ -1464,7 +1464,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		yoff = yoff1;
 		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
-			// ZDoom UDMF extra offsets
+			// UDMF extra offsets
 			if (line->s1()->hasProp("offsetx_top"))
 				xoff += line->s1()->floatProperty("offsetx_top");
 			if (line->s1()->hasProp("offsety_top"))
@@ -1508,7 +1508,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		yoff = yoff2;
 		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
-			// ZDoom UDMF extra offsets
+			// UDMF extra offsets
 			if (line->s2()->hasProp("offsetx_bottom"))
 				xoff += line->s2()->floatProperty("offsetx_bottom");
 			if (line->s2()->hasProp("offsety_bottom"))
@@ -1635,7 +1635,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		yoff = yoff2;
 		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
-			// ZDoom UDMF extra offsets
+			// UDMF extra offsets
 			if (line->s2()->hasProp("offsetx_top"))
 				xoff += line->s2()->floatProperty("offsetx_top");
 			if (line->s2()->hasProp("offsety_top"))

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -121,10 +121,6 @@ MapRenderer3D::~MapRenderer3D()
  *******************************************************************/
 bool MapRenderer3D::init()
 {
-	// Check to enable zdoom udmf extensions
-	if (S_CMPNOCASE(theGameConfiguration->udmfNamespace(), "zdoom") && map->currentFormat() == MAP_UDMF)
-		udmf_zdoom = true;
-
 	// Init camera
 	bbox_t bbox = map->getMapBBox();
 	cam_position.set(bbox.min.x + ((bbox.max.x - bbox.min.x)*0.5), bbox.min.y + ((bbox.max.y - bbox.min.y)*0.5), 64);
@@ -1250,7 +1246,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		// Determine offsets
 		xoff = xoff1;
 		yoff = yoff1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
 			if (line->s1()->hasProp("offsetx_mid"))
 				xoff += line->s1()->floatProperty("offsetx_mid");
@@ -1260,7 +1256,7 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Texture scale
 		sx = sy = 1;
-		if (udmf_zdoom)
+		if (theGameConfiguration->udmfTextureScaling())
 		{
 			if (line->s1()->hasProp("scalex_mid"))
 				sx = 1.0 / line->s1()->floatProperty("scalex_mid");
@@ -1340,7 +1336,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		// Determine offsets
 		xoff = xoff1;
 		yoff = yoff1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
 			// ZDoom UDMF extra offsets
 			if (line->s1()->hasProp("offsetx_bottom"))
@@ -1351,7 +1347,7 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Texture scale
 		sx = sy = 1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			if (line->s1()->hasProp("scalex_bottom"))
 				sx = 1.0 / line->s1()->floatProperty("scalex_bottom");
@@ -1392,7 +1388,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		xoff = xoff1;
 		yoff = yoff1;
 		double ytex = 0;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
 			if (line->s1()->hasProp("offsetx_mid"))
 				xoff += line->s1()->floatProperty("offsetx_mid");
@@ -1402,7 +1398,7 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Texture scale
 		sx = sy = 1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			if (line->s1()->hasProp("scalex_mid"))
 				sx = 1.0 / line->s1()->floatProperty("scalex_mid");
@@ -1414,7 +1410,8 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Setup quad coordinates
 		double top, bottom;
-		if ((map->currentFormat() == MAP_DOOM64) || (udmf_zdoom && line->boolProperty("wrapmidtex")))
+		if ((map->currentFormat() == MAP_DOOM64) || ((map->currentFormat() == MAP_UDMF &&
+			theGameConfiguration->udmfSideMidtexWrapping() && line->boolProperty("wrapmidtex"))))
 		{
 			top = lowceil;
 			bottom = highfloor;
@@ -1465,7 +1462,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		// Determine offsets
 		xoff = xoff1;
 		yoff = yoff1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
 			// ZDoom UDMF extra offsets
 			if (line->s1()->hasProp("offsetx_top"))
@@ -1476,7 +1473,7 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Texture scale
 		sx = sy = 1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			if (line->s1()->hasProp("scalex_top"))
 				sx = 1.0 / line->s1()->floatProperty("scalex_top");
@@ -1509,7 +1506,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		// Determine offsets
 		xoff = xoff2;
 		yoff = yoff2;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
 			// ZDoom UDMF extra offsets
 			if (line->s2()->hasProp("offsetx_bottom"))
@@ -1520,7 +1517,7 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Texture scale
 		sx = sy = 1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			if (line->s2()->hasProp("scalex_bottom"))
 				sx = 1.0 / line->s2()->floatProperty("scalex_bottom");
@@ -1561,7 +1558,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		xoff = xoff2;
 		yoff = yoff2;
 		double ytex = 0;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
 			if (line->s2()->hasProp("offsetx_mid"))
 				xoff += line->s2()->floatProperty("offsetx_mid");
@@ -1571,7 +1568,7 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Texture scale
 		sx = sy = 1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			if (line->s2()->hasProp("scalex_mid"))
 				sx = 1.0 / line->s2()->floatProperty("scalex_mid");
@@ -1583,7 +1580,8 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Setup quad coordinates
 		double top, bottom;
-		if ((map->currentFormat() == MAP_DOOM64) || (udmf_zdoom && line->boolProperty("wrapmidtex")))
+		if ((map->currentFormat() == MAP_DOOM64) || (map->currentFormat() == MAP_UDMF &&
+			theGameConfiguration->udmfSideMidtexWrapping() && line->boolProperty("wrapmidtex")))
 		{
 			top = lowceil;
 			bottom = highfloor;
@@ -1635,7 +1633,7 @@ void MapRenderer3D::updateLine(unsigned index)
 		// Determine offsets
 		xoff = xoff2;
 		yoff = yoff2;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
 			// ZDoom UDMF extra offsets
 			if (line->s2()->hasProp("offsetx_top"))
@@ -1646,7 +1644,7 @@ void MapRenderer3D::updateLine(unsigned index)
 
 		// Texture scale
 		sx = sy = 1;
-		if (udmf_zdoom)
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			if (line->s2()->hasProp("scalex_top"))
 				sx = 1.0 / line->s2()->floatProperty("scalex_top");

--- a/src/MapEditor/Renderer/MapRenderer3D.h
+++ b/src/MapEditor/Renderer/MapRenderer3D.h
@@ -190,7 +190,6 @@ public:
 
 private:
 	SLADEMap*	map;
-	bool		udmf_zdoom;
 	bool		fullbright;
 	bool		fog;
 	GLTexture*	tex_last;

--- a/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
@@ -127,7 +127,7 @@ void InfoOverlay3D::update(int item_index, int item_type, SLADEMap* map)
 			info2.push_back("Upper Texture");
 
 		// Offsets
-		if (theGameConfiguration->udmfNamespace() == "zdoom")
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureOffsets())
 		{
 			// Get x offset info
 			int xoff = side->intProperty("offsetx");
@@ -176,7 +176,7 @@ void InfoOverlay3D::update(int item_index, int item_type, SLADEMap* map)
 		}
 
 		// ZDoom UDMF extras
-		if (theGameConfiguration->udmfNamespace() == "zdoom")
+		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			// Scale
 			double xscale, yscale;

--- a/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
@@ -357,7 +357,7 @@ void InfoOverlay3D::update(int item_index, int item_type, SLADEMap* map)
 			info2.push_back(S_FMT("Light: %d", light));
 
 		// UDMF extras
-		if (theGameConfiguration->udmfNamespace() != "")
+		if (theMapEditor->currentMapDesc().format == MAP_UDMF)
 		{
 			// Offsets
 			double xoff, yoff;

--- a/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
@@ -356,64 +356,42 @@ void InfoOverlay3D::update(int item_index, int item_type, SLADEMap* map)
 		else
 			info2.push_back(S_FMT("Light: %d", light));
 
-		// ZDoom UDMF extras
-		if (theGameConfiguration->udmfNamespace() == "zdoom")
+		// UDMF extras
+		if (theGameConfiguration->udmfNamespace() != "")
 		{
 			// Offsets
 			double xoff, yoff;
-			if (item_type == MapEditor::SEL_FLOOR)
+			xoff = yoff = 0.0;
+			if (theGameConfiguration->udmfFlatPanning())
 			{
-				xoff = sector->floatProperty("xpanningfloor");
-				yoff = sector->floatProperty("ypanningfloor");
-			}
-			else
-			{
-				xoff = sector->floatProperty("xpanningceiling");
-				yoff = sector->floatProperty("ypanningceiling");
+				if (item_type == MapEditor::SEL_FLOOR)
+				{
+					xoff = sector->floatProperty("xpanningfloor");
+					yoff = sector->floatProperty("ypanningfloor");
+				}
+				else
+				{
+					xoff = sector->floatProperty("xpanningceiling");
+					yoff = sector->floatProperty("ypanningceiling");
+				}
 			}
 			info2.push_back(S_FMT("Offsets: %1.2f, %1.2f", xoff, yoff));
 
 			// Scaling
 			double xscale, yscale;
-			if (item_type == MapEditor::SEL_FLOOR)
+			xscale = yscale = 1.0;
+			if (theGameConfiguration->udmfFlatScaling())
 			{
-				xscale = sector->floatProperty("xscalefloor");
-				yscale = sector->floatProperty("yscalefloor");
-			}
-			else
-			{
-				xscale = sector->floatProperty("xscaleceiling");
-				yscale = sector->floatProperty("yscaleceiling");
-			}
-			info2.push_back(S_FMT("Scale: %1.2fx, %1.2fx", xscale, yscale));
-		}
-		else if(theGameConfiguration->udmfNamespace() == "eternity")
-		{
-			// Offsets
-			double xoff, yoff;
-			if(item_type == MapEditor::SEL_FLOOR)
-			{
-				xoff = sector->floatProperty("xpanningfloor");
-				yoff = sector->floatProperty("ypanningfloor");
-			}
-			else
-			{
-				xoff = sector->floatProperty("xpanningceiling");
-				yoff = sector->floatProperty("ypanningceiling");
-			}
-			info2.push_back(S_FMT("Offsets: %1.2f, %1.2f", xoff, yoff));
-
-			// Scaling
-			double xscale, yscale;
-			if (item_type == MapEditor::SEL_FLOOR)
-			{
-				xscale = sector->floatProperty("xscalefloor");
-				yscale = sector->floatProperty("yscalefloor");
-			}
-			else
-			{
-				xscale = sector->floatProperty("xscaleceiling");
-				yscale = sector->floatProperty("yscaleceiling");
+				if (item_type == MapEditor::SEL_FLOOR)
+				{
+					xscale = sector->floatProperty("xscalefloor");
+					yscale = sector->floatProperty("yscalefloor");
+				}
+				else
+				{
+					xscale = sector->floatProperty("xscaleceiling");
+					yscale = sector->floatProperty("yscaleceiling");
+				}
 			}
 			info2.push_back(S_FMT("Scale: %1.2fx, %1.2fx", xscale, yscale));
 		}

--- a/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
@@ -175,7 +175,7 @@ void InfoOverlay3D::update(int item_index, int item_type, SLADEMap* map)
 			info2.push_back(S_FMT("Offsets: %d, %d", side->intProperty("offsetx"), side->intProperty("offsety")));
 		}
 
-		// ZDoom UDMF extras
+		// UDMF extras
 		if (map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfTextureScaling())
 		{
 			// Scale

--- a/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
@@ -322,7 +322,7 @@ void InfoOverlay3D::update(int item_index, int item_type, SLADEMap* map)
 
 		// Light
 		int light = sector->intProperty("lightlevel");
-		if (theGameConfiguration->udmfNamespace() == "zdoom" || theGameConfiguration->udmfNamespace() == "eternity")
+		if (theGameConfiguration->udmfFlatLighting())
 		{
 			// Get extra light info
 			int fl = 0;

--- a/src/MapEditor/SLADEMap/MapSector.cpp
+++ b/src/MapEditor/SLADEMap/MapSector.cpp
@@ -535,10 +535,7 @@ void MapSector::changeLight(int amount, int where)
 		amount = -ll;
 
 	// Check for UDMF+ZDoom/UDMF+Eternity namespace
-	bool separate = false;
-	if (parent_map->currentFormat() == MAP_UDMF && 
-		 (S_CMPNOCASE(parent_map->udmfNamespace(), "zdoom") || S_CMPNOCASE(parent_map->udmfNamespace(), "eternity")))
-		separate = true;
+	bool separate = parent_map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfFlatLighting();
 
 	// Change light level by amount
 	if (where == 1 && separate)

--- a/src/MapEditor/SLADEMap/MapSector.cpp
+++ b/src/MapEditor/SLADEMap/MapSector.cpp
@@ -662,7 +662,7 @@ rgba_t MapSector::getFogColour()
 	}
 
 	// udmf
-	if (parent_map->currentFormat() == MAP_UDMF && S_CMPNOCASE(parent_map->udmfNamespace(), "zdoom"))
+	if (parent_map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfSectorFog())
 	{
 		int intcol = MapObject::intProperty("fadecolor");
 

--- a/src/MapEditor/SLADEMap/MapSector.cpp
+++ b/src/MapEditor/SLADEMap/MapSector.cpp
@@ -192,7 +192,7 @@ void MapSector::setStringProperty(string key, string value)
  *******************************************************************/
 void MapSector::setFloatProperty(string key, double value)
 {
-	// Check if flat offset/scale/rotation is changing (if UDMF + ZDoom)
+	// Check if flat offset/scale/rotation is changing (if UDMF)
 	if (parent_map->currentFormat() == MAP_UDMF)
 	{
 		if ((theGameConfiguration->udmfFlatPanning() && (key == "xpanningfloor" || key == "ypanningfloor")) ||
@@ -461,7 +461,7 @@ bool MapSector::getVertices(vector<MapObject*>& list)
  *******************************************************************/
 uint8_t MapSector::getLight(int where)
 {
-	// Check for UDMF+ZDoom/UDMF+Eternity namespace
+	// Check for UDMF + flat lighting
 	if (parent_map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfFlatLighting())
 	{
 		// Get general light level
@@ -522,7 +522,7 @@ void MapSector::changeLight(int amount, int where)
 	else if (ll + amount < 0)
 		amount = -ll;
 
-	// Check for UDMF+ZDoom/UDMF+Eternity namespace
+	// Check for UDMF + flat lighting independent from the sector
 	bool separate = parent_map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfFlatLighting();
 
 	// Change light level by amount

--- a/src/MapEditor/SLADEMap/MapSector.cpp
+++ b/src/MapEditor/SLADEMap/MapSector.cpp
@@ -193,23 +193,12 @@ void MapSector::setStringProperty(string key, string value)
 void MapSector::setFloatProperty(string key, double value)
 {
 	// Check if flat offset/scale/rotation is changing (if UDMF + ZDoom)
-	if (parent_map->currentFormat() == MAP_UDMF && S_CMPNOCASE(parent_map->udmfNamespace(), "zdoom"))
+	if (parent_map->currentFormat() == MAP_UDMF)
 	{
-		if (key == "xpanningfloor" || key == "ypanningfloor" ||
-		        key == "xpanningceiling" || key == "ypanningceiling" ||
-		        key == "xscalefloor" || key == "yscalefloor" ||
-		        key == "xscaleceiling" || key == "yscaleceiling" ||
-		        key == "rotationfloor" || key == "rotationceiling")
-			polygon.setTexture(NULL);	// Clear texture to force update
-	}
-	// Even though they're both the same as of 2016/12/28, these may differ in future, so keep them apart
-	else if(parent_map->currentFormat() == MAP_UDMF && S_CMPNOCASE(parent_map->udmfNamespace(), "eternity"))
-	{
-		if (key == "xpanningfloor" || key == "ypanningfloor" ||
-		        key == "xpanningceiling" || key == "ypanningceiling" ||
-		        key == "xscalefloor" || key == "yscalefloor" ||
-		        key == "xscaleceiling" || key == "yscaleceiling" ||
-		        key == "rotationfloor" || key == "rotationceiling")
+		if ((theGameConfiguration->udmfFlatPanning() && (key == "xpanningfloor" || key == "ypanningfloor")) ||
+			(theGameConfiguration->udmfFlatScaling() && (key == "xscalefloor" || key == "yscalefloor" ||
+			 key == "xscaleceiling" || key == "yscaleceiling")) || 
+			(theGameConfiguration->udmfFlatRotation() && (key == "rotationfloor" || key == "rotationceiling")))
 			polygon.setTexture(NULL);	// Clear texture to force update
 	}
 
@@ -473,8 +462,7 @@ bool MapSector::getVertices(vector<MapObject*>& list)
 uint8_t MapSector::getLight(int where)
 {
 	// Check for UDMF+ZDoom/UDMF+Eternity namespace
-	if (parent_map->currentFormat() == MAP_UDMF &&
-		 (S_CMPNOCASE(parent_map->udmfNamespace(), "zdoom") || S_CMPNOCASE(parent_map->udmfNamespace(), "eternity")))
+	if (parent_map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfFlatLighting())
 	{
 		// Get general light level
 		int l = light;

--- a/src/MapEditor/SLADEMap/MapSector.cpp
+++ b/src/MapEditor/SLADEMap/MapSector.cpp
@@ -574,12 +574,20 @@ rgba_t MapSector::getColour(int where, bool fullbright)
 		}
 	}
 
-	// Check for UDMF+ZDoom namespace
-	if ((parent_map->currentFormat() == MAP_UDMF && S_CMPNOCASE(parent_map->udmfNamespace(), "zdoom")))
+	// Check for UDMF
+	if (parent_map->currentFormat() == MAP_UDMF && (theGameConfiguration->udmfSectorColor() ||
+		theGameConfiguration->udmfFlatLighting()))
 	{
 		// Get sector light colour
-		int intcol = MapObject::intProperty("lightcolor");
-		wxColour wxcol(intcol);
+		wxColour wxcol;
+		if(theGameConfiguration->udmfSectorColor())
+		{
+			int intcol = MapObject::intProperty("lightcolor");
+			wxcol = wxColour(intcol);
+		}
+		else
+			wxcol = wxColour(255, 255, 255, 255);
+		
 
 		// Ignore light level if fullbright
 		if (fullbright)
@@ -588,24 +596,27 @@ rgba_t MapSector::getColour(int where, bool fullbright)
 		// Get sector light level
 		int ll = light;
 
-		// Get specific light level
-		if (where == 1)
+		if (theGameConfiguration->udmfFlatLighting())
 		{
-			// Floor
-			int fl = MapObject::intProperty("lightfloor");
-			if (boolProperty("lightfloorabsolute"))
-				ll = fl;
-			else
-				ll += fl;
-		}
-		else if (where == 2)
-		{
-			// Ceiling
-			int cl = MapObject::intProperty("lightceiling");
-			if (boolProperty("lightceilingabsolute"))
-				ll = cl;
-			else
-				ll += cl;
+			// Get specific light level
+			if(where == 1)
+			{
+				// Floor
+				int fl = MapObject::intProperty("lightfloor");
+				if(boolProperty("lightfloorabsolute"))
+					ll = fl;
+				else
+					ll += fl;
+			}
+			else if(where == 2)
+			{
+				// Ceiling
+				int cl = MapObject::intProperty("lightceiling");
+				if(boolProperty("lightceilingabsolute"))
+					ll = cl;
+				else
+					ll += cl;
+			}
 		}
 
 		// Clamp light level

--- a/src/MapEditor/SLADEMap/MapSide.cpp
+++ b/src/MapEditor/SLADEMap/MapSide.cpp
@@ -32,6 +32,7 @@
 #include "MapSector.h"
 #include "SLADEMap.h"
 #include "MainApp.h"
+#include "MapEditor/GameConfiguration/GameConfiguration.h"
 
 
 /*******************************************************************
@@ -115,7 +116,7 @@ uint8_t MapSide::getLight()
 	int light = 0;
 	bool include_sector = true;
 
-	if (parent_map->currentFormat() == MAP_UDMF && S_CMPNOCASE(parent_map->udmfNamespace(), "zdoom"))
+	if (parent_map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfSideLighting())
 	{
 		light += intProperty("light");
 		if (boolProperty("lightabsolute"))
@@ -138,7 +139,7 @@ uint8_t MapSide::getLight()
  *******************************************************************/
 void MapSide::changeLight(int amount)
 {
-	if (parent_map->currentFormat() == MAP_UDMF && S_CMPNOCASE(parent_map->udmfNamespace(), "zdoom"))
+	if (parent_map->currentFormat() == MAP_UDMF && theGameConfiguration->udmfSideLighting())
 		setIntProperty("light", intProperty("light") + amount);
 }
 


### PR DESCRIPTION
This makes it so that a great deal of features that ZDoom and Eternity UDMF have are not hard-coded string checks against the namespace. Instead they are delegated to the config files. This avoids code duplication, and provides an example of what can be done in future to avoid code duplication when EE or ZDoom get their own specific UDMF features that work their way into being rendered.
A couple things still are hard-coded though.