### PR TITLE
Fix calltip drawing on osx with high dpi

### DIFF
--- a/src/UI/TextEditor/SCallTip.h
+++ b/src/UI/TextEditor/SCallTip.h
@@ -54,6 +54,7 @@ private:
 	void	updateSize();
 
 	int		drawText(wxDC& dc, string text, int left, int top, wxRect* bounds);
+	wxSize	drawCallTip(wxDC& dc, int xoff = 0, int yoff = 0);
 	void	updateBuffer();
 
 	// Events


### PR DESCRIPTION
Not sure exactly if it's an osx or dpi issue, but wx isn't scaling the calltip bitmap correctly when drawing it