### PR TITLE
Fix small typo in things_zdoom.cfg

### DIFF
--- a/dist/res/config/ports/include/things_zdoom.cfg
+++ b/dist/res/config/ports/include/things_zdoom.cfg
@@ -548,7 +548,7 @@ thing_types
 			thing 14027 { name = "Ambient Sound #27"; arg1 = "Arg1", "Ignored, Always 27"; }
 			thing 14028 { name = "Ambient Sound #28"; arg1 = "Arg1", "Ignored, Always 28"; }
 			thing 14029 { name = "Ambient Sound #29"; arg1 = "Arg1", "Ignored, Always 29"; }
-			thing 14020 { name = "Ambient Sound #30"; arg1 = "Arg1", "Ignored, Always 30"; }
+			thing 14030 { name = "Ambient Sound #30"; arg1 = "Arg1", "Ignored, Always 30"; }
 			thing 14031 { name = "Ambient Sound #31"; arg1 = "Arg1", "Ignored, Always 31"; }
 			thing 14032 { name = "Ambient Sound #32"; arg1 = "Arg1", "Ignored, Always 32"; }
 			thing 14033 { name = "Ambient Sound #33"; arg1 = "Arg1", "Ignored, Always 33"; }


### PR DESCRIPTION
Ambient Sound \#30 (Thing ID 14030) was configured as thing 14020.