### PR TITLE
Take 2

### DIFF
--- a/dist/res/config/games/include/specials_doom1.cfg
+++ b/dist/res/config/games/include/specials_doom1.cfg
@@ -26,7 +26,7 @@ action_specials
 
 			special 29	= "S1 Door";
 			special 63	= "SR Door";
-			special 4	= "W1 Door Stay Open";
+			special 4	= "W1 Door";
 			special 90	= "WR Door";
 			special 103	= "S1 Door Stay Open";
 			special 61	= "SR Door Stay Open";

--- a/dist/res/config/games/include/specials_heretic.cfg
+++ b/dist/res/config/games/include/specials_heretic.cfg
@@ -26,7 +26,7 @@ action_specials
 
 			special 29	= "S1 Door";
 			special 63	= "SR Door";
-			special 4	= "W1 Door Stay Open";
+			special 4	= "W1 Door";
 			special 90	= "WR Door";
 			special 103	= "S1 Door Stay Open";
 			special 61	= "SR Door Stay Open";

--- a/dist/res/config/ports/include/props_zdoom.cfg
+++ b/dist/res/config/ports/include/props_zdoom.cfg
@@ -93,6 +93,12 @@ udmf_properties
 				type = string;
 				default = "";
 			}
+			property arg1str
+			{
+				name = "Arg 1 String";
+				type = string;
+				default = "";
+			}
 		}
 	}
 

--- a/src/Graphics/SImage/Formats/SIFDoom.h
+++ b/src/Graphics/SImage/Formats/SIFDoom.h
@@ -193,8 +193,24 @@ protected:
 			uint8_t row_off = 0;
 			for (int r = 0; r < image.getHeight(); r++)
 			{
+				// For vanilla-compatible dimensions, use a split at 128 to prevent tiling.
+				if (image.getHeight() < 256)
+				{
+					if (row_off == 128)
+					{
+						// Finish current post if any
+						if (ispost)
+						{
+							col.posts.push_back(post);
+							post.pixels.clear();
+							ispost = false;
+						}
+					}
+				}
+
+				// Taller images cannot be expressed without tall patch support.
 				// If we're at offset 254, create a dummy post for tall doom gfx support
-				if (row_off == 254)
+				else if (row_off == 254)
 				{
 					// Finish current post if any
 					if (ispost)

--- a/src/Graphics/SImage/Formats/SIFDoom.h
+++ b/src/Graphics/SImage/Formats/SIFDoom.h
@@ -68,6 +68,30 @@ protected:
 		memset(img_data, 0, width * height);	// Set colour to palette index 0
 		uint8_t* img_mask = imageMask(image);
 		memset(img_mask, 0, width * height);	// Set mask to fully transparent
+
+		// Check for the Pleiades hack:
+		// Roger Ritenour's pleiades.wad for ZDoom uses 256-tall sky textures, 
+		// and since the patch format uses 8-bit values for the length of a column,
+		// the 256 height overflows to 0. To detect this situation, we check if
+		// every column represents precisely 261 bytes, in other words just enough
+		// for a single post of 256 pixels.
+		bool pleiadeshack = false;
+		if (height == 256)
+		{
+			pleiadeshack = true;
+			for (int c = 1; c < width; ++c)
+			{
+				if (col_offsets[c] - col_offsets[c - 1] != 261)
+				{
+					pleiadeshack = false;
+					break;
+				}
+			}
+			if (data.getSize() - col_offsets[width - 1] != 261)
+				pleiadeshack = false;
+		}
+
+		// Load data
 		for (int c = 0; c < width; c++)
 		{
 			// Get current column offset (byteswap if needed)
@@ -99,10 +123,14 @@ protected:
 
 				// Get no. of pixels
 				bits++;
-				uint8_t n_pix = *bits;
+				uint16_t n_pix = *bits;
+
+				// If this is a Pleiades sky, the height is 256.
+				if (pleiadeshack)
+					n_pix = 256;
 
 				if (version == 0) bits++; // Skip buffer
-				for (uint8_t p = 0; p < n_pix; p++)
+				for (uint16_t p = 0; p < n_pix; p++)
 				{
 					// Get pixel position
 					bits++;

--- a/src/MapEditor/GameConfiguration/ActionSpecial.cpp
+++ b/src/MapEditor/GameConfiguration/ActionSpecial.cpp
@@ -237,7 +237,7 @@ void ActionSpecial::parseArg(ParseTreeNode* node, SpecialArgMap* shared_args, ar
  * Returns a string representation of the action special's args
  * given the values in [args]
  *******************************************************************/
-string ActionSpecial::getArgsString(int args[5])
+string ActionSpecial::getArgsString(int args[5], string argstr[2])
 {
 	string ret;
 
@@ -250,7 +250,10 @@ string ActionSpecial::getArgsString(int args[5])
 
 		ret += this->args[a].name;
 		ret += ": ";
-		ret += this->args[a].valueString(args[a]);
+		if (a < 2 && args[a] == 0 && !argstr[a].IsEmpty())
+			ret += argstr[a];
+		else
+			ret += this->args[a].valueString(args[a]);
 		ret += ", ";
 	}
 

--- a/src/MapEditor/GameConfiguration/ActionSpecial.h
+++ b/src/MapEditor/GameConfiguration/ActionSpecial.h
@@ -32,7 +32,7 @@ public:
 	void	setGroup(string group) { this->group = group; }
 	void	setTagged(int tagged) { this->tagged = tagged; }
 
-	string	getArgsString(int args[5]);
+	string	getArgsString(int args[5], string argstr[2]);
 
 	void	reset();
 	void	parse(ParseTreeNode* node, SpecialArgMap* shared_args);

--- a/src/MapEditor/GameConfiguration/ThingType.cpp
+++ b/src/MapEditor/GameConfiguration/ThingType.cpp
@@ -113,7 +113,7 @@ void ThingType::copy(ThingType* copy)
  * Returns a string representation of the thing type's args given
  * the values in [args]
  *******************************************************************/
-string ThingType::getArgsString(int args[5])
+string ThingType::getArgsString(int args[5], string argstr[2])
 {
 	string ret;
 
@@ -126,7 +126,10 @@ string ThingType::getArgsString(int args[5])
 
 		ret += this->args[a].name;
 		ret += ": ";
-		ret += this->args[a].valueString(args[a]);
+		if (a < 2 && args[a] == 0 && !argstr[a].IsEmpty())
+			ret += argstr[a];
+		else
+			ret += this->args[a].valueString(args[a]);
 		ret += ", ";
 	}
 

--- a/src/MapEditor/GameConfiguration/ThingType.h
+++ b/src/MapEditor/GameConfiguration/ThingType.h
@@ -71,7 +71,7 @@ public:
 	string	getTranslation() { return translation; }
 	string	getPalette() { return palette; }
 	const argspec_t getArgspec() { return argspec_t(args, arg_count); }
-	string	getArgsString(int args[5]);
+	string	getArgsString(int args[5], string argstr[2]);
 	void	setSprite(string sprite) { this->sprite = sprite; }
 
 	void	reset();

--- a/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/InfoOverlay3d.cpp
@@ -442,7 +442,10 @@ void InfoOverlay3D::update(int item_index, int item_type, SLADEMap* map)
 			args[2] = thing->intProperty("arg2");
 			args[3] = thing->intProperty("arg3");
 			args[4] = thing->intProperty("arg4");
-			string argstr = tt->getArgsString(args);
+			string argxstr[2];
+			argxstr[0] = thing->stringProperty("arg0str");
+			argxstr[1] = thing->stringProperty("arg1str");
+			string argstr = tt->getArgsString(args, argxstr);
 
 			if (argstr.IsEmpty())
 				info2.push_back("No Args");

--- a/src/MapEditor/Renderer/Overlays/LineInfoOverlay.cpp
+++ b/src/MapEditor/Renderer/Overlays/LineInfoOverlay.cpp
@@ -112,7 +112,10 @@ void LineInfoOverlay::update(MapLine* line)
 		args[2] = line->intProperty("arg2");
 		args[3] = line->intProperty("arg3");
 		args[4] = line->intProperty("arg4");
-		string argstr = theGameConfiguration->actionSpecial(as_id)->getArgsString(args);
+		string argxstr[2];
+		argxstr[0] = line->stringProperty("arg0str");
+		argxstr[1] = line->stringProperty("arg1str");
+		string argstr = theGameConfiguration->actionSpecial(as_id)->getArgsString(args, argxstr);
 		if (!argstr.IsEmpty())
 			info_text += (S_FMT("%s", argstr));
 		else

--- a/src/MapEditor/Renderer/Overlays/ThingInfoOverlay.cpp
+++ b/src/MapEditor/Renderer/Overlays/ThingInfoOverlay.cpp
@@ -130,11 +130,14 @@ void ThingInfoOverlay::update(MapThing* thing)
 		args[2] = thing->intProperty("arg2");
 		args[3] = thing->intProperty("arg3");
 		args[4] = thing->intProperty("arg4");
+		string argxstr[2];
+		argxstr[0] = thing->stringProperty("arg0str");
+		argxstr[1] = thing->stringProperty("arg1str");
 		string argstr;
 		if (tt->getArgspec().count > 0)
-			argstr = tt->getArgsString(args);
+			argstr = tt->getArgsString(args, argxstr);
 		else
-			argstr = theGameConfiguration->actionSpecial(as_id)->getArgsString(args);
+			argstr = theGameConfiguration->actionSpecial(as_id)->getArgsString(args, argxstr);
 
 		if (!argstr.IsEmpty())
 			info_text += S_FMT("%s\n", argstr);


### PR DESCRIPTION
* Partial argxstr support: displays arg0str and arg1str instead of arg0 and arg1 when appropriate in the overlay.
* Config fix: linetype 4 W1 door doesn't stay open.
* Patch format can now write vanilla-compatible tall patches and display properly the Pleiades skies.