### PR TITLE
Save config file when applying preferences

### DIFF
--- a/src/Dialogs/Preferences/PreferencesDialog.cpp
+++ b/src/Dialogs/Preferences/PreferencesDialog.cpp
@@ -224,6 +224,9 @@ void PreferencesDialog::applyPreferences()
 	for (unsigned a = 0; a < prefs_pages.size(); a++)
 		prefs_pages[a]->applyPreferences();
 	prefs_advanced->applyPreferences();
+
+	// Write file so changes are not lost
+	theApp->saveConfigFile();
 }
 
 


### PR DESCRIPTION
Unfortunately, SLADE will never be free of crashes (it already crashes a bit more frequently than I'm sure everyone would like it to), which cause the user to have to redo any changes to their config since the last boot.

I don't know if you have any specific thoughts on the issue, but this seems like a pretty satisfying solution to me.