### PR TITLE
cmake: Use find_packages for all libraries and small improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(COMMAND cmake_policy)
 	cmake_policy( SET CMP0011 NEW )
 endif(COMMAND cmake_policy)
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 if (NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release")

--- a/cmake/FindFTGL.cmake
+++ b/cmake/FindFTGL.cmake
@@ -1,32 +1,22 @@
+# - Find FTGL
+# Find the native FTGL includes and library
 #
-#
-# Try to find the FTGL libraries
-# Once done this will define
-#
-# FTGL_FOUND          - system has ftgl
-# FTGL_INCLUDE_DIR    - path to FTGL/FTGL.h
-# FTGL_LIBRARY      - the library that must be included
-#
-#
+#  FTGL_INCLUDE_DIR - where to find FTGL/ftgl.h
+#  FTGL_LIBRARIES   - List of libraries when using ftgl.
+#  FTGL_FOUND       - True if ftgl found.
 
-IF (FTGL_LIBRARY AND FTGL_INCLUDE_DIR)
-  SET(FTGL_FOUND "YES")
-ELSE (FTGL_LIBRARY AND FTGL_INCLUDE_DIR)
-  FIND_PATH(FTGL_INCLUDE_DIR FTGL/ftgl.h PATHS /usr/local/include /usr/include)
-  FIND_LIBRARY(FTGL_LIBRARY ftgl PATHS /usr/local/lib /usr/lib)
-  
-  IF (FTGL_INCLUDE_DIR AND FTGL_LIBRARY)
-    SET(FTGL_FOUND "YES")
-  ELSE (FTGL_INCLUDE_DIR AND FTGL_LIBRARY)
-    SET(FTGL_FOUND "NO")
-  ENDIF (FTGL_INCLUDE_DIR AND FTGL_LIBRARY)
-ENDIF (FTGL_LIBRARY AND FTGL_INCLUDE_DIR)
+IF (FTGL_INCLUDE_DIR AND FTGL_LIBRARIES)
+  # Already in cache, be silent
+  SET(FTGL_FIND_QUIETLY TRUE)
+ENDIF (FTGL_INCLUDE_DIR AND FTGL_LIBRARIES)
 
-IF (FTGL_FOUND)
-  MESSAGE(STATUS "Found FTGL libraries at ${FTGL_LIBRARY} and includes at ${FTGL_INCLUDE_DIR}")
-ELSE (FTGL_FOUND)
-  IF (FTGL_FIND_REQUIRED)
-    MESSAGE(FATAL_ERROR "Could not find FTGL libraries")
-  ENDIF (FTGL_FIND_REQUIRED)
-ENDIF (FTGL_FOUND)
+FIND_PATH(FTGL_INCLUDE_DIR FTGL/ftgl.h)
+
+FIND_LIBRARY(FTGL_LIBRARIES NAMES ftgl )
+MARK_AS_ADVANCED( FTGL_LIBRARIES FTGL_INCLUDE_DIR )
+
+# handle the QUIETLY and REQUIRED arguments and set FTGL_FOUND to TRUE if 
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(FTGL DEFAULT_MSG FTGL_LIBRARIES FTGL_INCLUDE_DIR)
 

--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -1,46 +1,69 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+# See https://cmake.org/licensing for details.
+
+#.rst:
+# FindGLEW
+# --------
 #
-# Try to find GLEW library and include path.
-# Once done this will define
+# Find the OpenGL Extension Wrangler Library (GLEW)
 #
-# GLEW_FOUND
-# GLEW_INCLUDE_PATH
-# GLEW_LIBRARY
-# 
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the :prop_tgt:`IMPORTED` target ``GLEW::GLEW``,
+# if GLEW has been found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ::
+#
+#   GLEW_INCLUDE_DIRS - include directories for GLEW
+#   GLEW_LIBRARIES - libraries to link against GLEW
+#   GLEW_FOUND - true if GLEW has been found and can be used
 
-IF (WIN32)
-	FIND_PATH( GLEW_INCLUDE_PATH GL/glew.h
-		$ENV{PROGRAMFILES}/GLEW/include
-		${PROJECT_SOURCE_DIR}/src/nvgl/glew/include
-		DOC "The directory where GL/glew.h resides")
-	FIND_LIBRARY( GLEW_LIBRARY
-		NAMES glew GLEW glew32 glew32s
-		PATHS
-		$ENV{PROGRAMFILES}/GLEW/lib
-		${PROJECT_SOURCE_DIR}/src/nvgl/glew/bin
-		${PROJECT_SOURCE_DIR}/src/nvgl/glew/lib
-		DOC "The GLEW library")
-ELSE (WIN32)
-	FIND_PATH( GLEW_INCLUDE_PATH GL/glew.h
-		/usr/include
-		/usr/local/include
-		/sw/include
-		/opt/local/include
-		DOC "The directory where GL/glew.h resides")
-	FIND_LIBRARY( GLEW_LIBRARY
-		NAMES GLEW glew
-		PATHS
-		/usr/lib64
-		/usr/lib
-		/usr/local/lib64
-		/usr/local/lib
-		/sw/lib
-		/opt/local/lib
-		DOC "The GLEW library")
-ENDIF (WIN32)
+find_path(GLEW_INCLUDE_DIR GL/glew.h)
 
-IF (GLEW_INCLUDE_PATH)
-	SET( GLEW_FOUND 1)
-ELSE (GLEW_INCLUDE_PATH)
-	SET( GLEW_FOUND 0)
-ENDIF (GLEW_INCLUDE_PATH)
+if(NOT GLEW_LIBRARY)
+  find_library(GLEW_LIBRARY_RELEASE NAMES GLEW glew32 glew glew32s PATH_SUFFIXES lib64)
+  find_library(GLEW_LIBRARY_DEBUG NAMES GLEWd glew32d glewd PATH_SUFFIXES lib64)
 
+  include(SelectLibraryConfigurations)
+  select_library_configurations(GLEW)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLEW
+                                  REQUIRED_VARS GLEW_INCLUDE_DIR GLEW_LIBRARY)
+
+if(GLEW_FOUND)
+  set(GLEW_INCLUDE_DIRS ${GLEW_INCLUDE_DIR})
+
+  if(NOT GLEW_LIBRARIES)
+    set(GLEW_LIBRARIES ${GLEW_LIBRARY})
+  endif()
+
+  if (NOT TARGET GLEW::GLEW)
+    add_library(GLEW::GLEW UNKNOWN IMPORTED)
+    set_target_properties(GLEW::GLEW PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIRS}")
+
+    if(GLEW_LIBRARY_RELEASE)
+      set_property(TARGET GLEW::GLEW APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+      set_target_properties(GLEW::GLEW PROPERTIES IMPORTED_LOCATION_RELEASE "${GLEW_LIBRARY_RELEASE}")
+    endif()
+
+    if(GLEW_LIBRARY_DEBUG)
+      set_property(TARGET GLEW::GLEW APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+      set_target_properties(GLEW::GLEW PROPERTIES IMPORTED_LOCATION_DEBUG "${GLEW_LIBRARY_DEBUG}")
+    endif()
+
+    if(NOT GLEW_LIBRARY_RELEASE AND NOT GLEW_LIBRARY_DEBUG)
+      set_property(TARGET GLEW::GLEW APPEND PROPERTY IMPORTED_LOCATION "${GLEW_LIBRARY}")
+    endif()
+  endif()
+endif()
+
+mark_as_advanced(GLEW_INCLUDE_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT NO_COTIRE)
-	include(../cmake/cotire.cmake)
+	include(cotire)
 endif()
 
 # wxWidgets version minimum 3.0
@@ -45,48 +45,22 @@ else (APPLE)
 endif (APPLE)
 
 if(NOT NO_FLUIDSYNTH)
-	include(../cmake/FindFluidSynth.cmake)
+	find_package(FluidSynth REQUIRED)
 else(NO_FLUIDSYNTH)
 	message(STATUS "Fluidsynth support is disabled.")
 endif()
 
-find_package(CURL)
-
-include(../cmake/FindFreeImage.cmake)
-include(../cmake/FindSFML.cmake)
-include(../cmake/FindFTGL.cmake)
-include(../cmake/FindGLEW.cmake)
-include(FindFreetype)
-if(NOT NO_FLUIDSYNTH)
-	if(NOT ${FLUIDSYNTH_FOUND})
-		message(SEND_ERROR "Fluidsynth required.")
-	endif()
-endif()
-if(NOT ${FREEIMAGE_FOUND})
-	message(SEND_ERROR "FreeImage required.")
-endif()
-if(NOT ${SFML_FOUND})
-	message(SEND_ERROR "SFML required.")
-endif()
-if(NOT ${FTGL_FOUND})
-	message(SEND_ERROR "FTGL required.")
-endif()
-if(NOT ${FREETYPE_FOUND})
-	message(SEND_ERROR "Freetype required.")
-endif()
-if(NOT ${GLEW_FOUND})
-	message(SEND_ERROR "GLEW required.")
-endif()
-if(NOT ${CURL_FOUND})
-	message(SEND_ERROR "CURL required.")
-endif()
-include_directories(${FREEIMAGE_INCLUDE_DIR} ${SFML_INCLUDE_DIR} ${FTGL_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS} ${GLEW_INCLUDE_PATH} ${GTK2_INCLUDE_DIRS} . ./External/dumb ./Application)
+find_package(FreeImage REQUIRED)
+find_package(SFML COMPONENTS ${SFML_FIND_COMPONENTS} REQUIRED)
+find_package(FTGL REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(Freetype REQUIRED)
+find_package(CURL REQUIRED)
+include_directories(${FREEIMAGE_INCLUDE_DIR} ${SFML_INCLUDE_DIR} ${FTGL_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS} ${GLEW_INCLUDE_PATH} ${GTK2_INCLUDE_DIRS} ${CURL_INCLUDE_DIR} . ./External/dumb ./Application)
 
 if (NOT NO_FLUIDSYNTH)
 	include_directories(${FLUIDSYNTH_INCLUDE_DIR})
 endif()
-
-	include_directories(${CURL_INCLUDE_DIR})
 
 set(SLADE_SOURCES
 )
@@ -116,10 +90,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_USE_SSE -msse")
 
 # c++14 is required to compile
 if(CMAKE_VERSION VERSION_LESS 3.1)
-    add_compile_options(-std=c++14)
+	add_compile_options(-std=c++14)
 else()
-    set(CMAKE_CXX_STANDARD 14)
-    set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+	set(CMAKE_CXX_STANDARD 14)
+	set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 endif()
 
 add_executable(slade WIN32 MACOSX_BUNDLE
@@ -145,7 +119,7 @@ target_link_libraries(slade
 	${wxWidgets_LIBRARIES}
 	${FREEIMAGE_LIBRARIES}
 	${SFML_LIBRARY}
-	${FTGL_LIBRARY}
+	${FTGL_LIBRARIES}
 	${OPENGL_LIBRARIES}
 	${FREETYPE_LIBRARIES}
 	${GLEW_LIBRARY}


### PR DESCRIPTION
This changes all libraries to be included in cmake using the `find_packages` command, the main benefit of which is ~that configuration, rather than compilation, will fail if needed libraries are missing~ conciseness, it seems. (This PR was supposed to have other changes, but I scrapped them.)