### PR TITLE
Fix crash on saving ZIP archives

### DIFF
--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -291,6 +291,9 @@ uint16_t ResourceManager::getTextureHash(string name)
  *******************************************************************/
 void ResourceManager::addEntry(ArchiveEntry::SPtr& entry)
 {
+	if (!entry.get())
+		return;
+
 	// Detect type if unknown
 	if (entry->getType() == EntryType::unknownType())
 		EntryType::detectEntryType(entry.get());
@@ -395,6 +398,9 @@ void ResourceManager::addEntry(ArchiveEntry::SPtr& entry)
  *******************************************************************/
 void ResourceManager::removeEntry(ArchiveEntry::SPtr& entry)
 {
+	if (!entry.get())
+		return;
+
 	// Get resource name (extension cut, uppercase)
 	string name = entry->getUpperNameNoExt();
 	string path = entry->getPath(true).Upper().Mid(1);

--- a/src/MapEditor/SLADEMap/MapSector.cpp
+++ b/src/MapEditor/SLADEMap/MapSector.cpp
@@ -732,7 +732,7 @@ void MapSector::readBackup(mobj_backup_t* backup)
 	c_tex = backup->props_internal["textureceiling"].getStringValue();
 	f_height = backup->props_internal["heightfloor"].getIntValue();
 	c_height = backup->props_internal["heightceiling"].getIntValue();
-	plane_floor.set(0, 0, 1, c_height);
+	plane_floor.set(0, 0, 1, f_height);
 	plane_ceiling.set(0, 0, 1, c_height);
 	light = backup->props_internal["lightlevel"].getIntValue();
 	special = backup->props_internal["special"].getIntValue();


### PR DESCRIPTION
Basically, the resource manager is notified when entries of an archive are changed, including directories, but in `ResourceManager::onAnnouncement` it does some indirection which looks like
```
entry->getParent()->entryAtPathShared(entry->getPath(true));
```
This only works on file entries, not directories, because directories don't show up as entries in the archive tree, i.e. `entryAtPath` doesn't "see" directories and so returns null causing an error. It's pretty confusing that directories are treated as entries in some contexts but not in others.

Also fixes a bug left behind in a previous PR.