### PR TITLE
Unity builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(COMMAND cmake_policy)
 	cmake_policy( SET CMP0011 NEW )
 endif(COMMAND cmake_policy)
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 if (NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,22 +25,6 @@ endif()
 
 set(SLADE_OUTPUT_DIR ${CMAKE_BINARY_DIR} CACHE PATH "Directory where slade will be created.")
 
-find_package(ZLIB)
-find_package(BZip2)
-find_package(OpenGL)
-
-if(NOT ZLIB_FOUND)
-	set(ZLIB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zlib)
-	add_subdirectory(src/External/zlib)
-	set(ZLIB_LIBRARY z)
-endif(NOT ZLIB_FOUND)
-
-if(NOT BZIP2_FOUND)
-	set(BZIP2_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bzip2)
-	add_subdirectory(src/External/bzip2)
-	set(BZIP2_LIBRARIES bz2)
-endif(NOT BZIP2_FOUND)
-
 OPTION(NO_WEBVIEW "Disable wxWebview usage (for start page and documentation)" OFF)
 OPTION(USE_SFML_RENDERWINDOW "Use SFML RenderWindow for OpenGL displays" OFF)
 

--- a/cmake/FindFTGL.cmake
+++ b/cmake/FindFTGL.cmake
@@ -1,32 +1,22 @@
+# - Find FTGL
+# Find the native FTGL includes and library
 #
-#
-# Try to find the FTGL libraries
-# Once done this will define
-#
-# FTGL_FOUND          - system has ftgl
-# FTGL_INCLUDE_DIR    - path to FTGL/FTGL.h
-# FTGL_LIBRARY      - the library that must be included
-#
-#
+#  FTGL_INCLUDE_DIR - where to find FTGL/ftgl.h
+#  FTGL_LIBRARIES   - List of libraries when using ftgl.
+#  FTGL_FOUND       - True if ftgl found.
 
-IF (FTGL_LIBRARY AND FTGL_INCLUDE_DIR)
-  SET(FTGL_FOUND "YES")
-ELSE (FTGL_LIBRARY AND FTGL_INCLUDE_DIR)
-  FIND_PATH(FTGL_INCLUDE_DIR FTGL/ftgl.h PATHS /usr/local/include /usr/include)
-  FIND_LIBRARY(FTGL_LIBRARY ftgl PATHS /usr/local/lib /usr/lib)
-  
-  IF (FTGL_INCLUDE_DIR AND FTGL_LIBRARY)
-    SET(FTGL_FOUND "YES")
-  ELSE (FTGL_INCLUDE_DIR AND FTGL_LIBRARY)
-    SET(FTGL_FOUND "NO")
-  ENDIF (FTGL_INCLUDE_DIR AND FTGL_LIBRARY)
-ENDIF (FTGL_LIBRARY AND FTGL_INCLUDE_DIR)
+IF (FTGL_INCLUDE_DIR AND FTGL_LIBRARIES)
+  # Already in cache, be silent
+  SET(FTGL_FIND_QUIETLY TRUE)
+ENDIF (FTGL_INCLUDE_DIR AND FTGL_LIBRARIES)
 
-IF (FTGL_FOUND)
-  MESSAGE(STATUS "Found FTGL libraries at ${FTGL_LIBRARY} and includes at ${FTGL_INCLUDE_DIR}")
-ELSE (FTGL_FOUND)
-  IF (FTGL_FIND_REQUIRED)
-    MESSAGE(FATAL_ERROR "Could not find FTGL libraries")
-  ENDIF (FTGL_FIND_REQUIRED)
-ENDIF (FTGL_FOUND)
+FIND_PATH(FTGL_INCLUDE_DIR FTGL/ftgl.h)
+
+FIND_LIBRARY(FTGL_LIBRARIES NAMES ftgl )
+MARK_AS_ADVANCED( FTGL_LIBRARIES FTGL_INCLUDE_DIR )
+
+# handle the QUIETLY and REQUIRED arguments and set FTGL_FOUND to TRUE if 
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(FTGL DEFAULT_MSG FTGL_LIBRARIES FTGL_INCLUDE_DIR)
 

--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -1,46 +1,69 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+# See https://cmake.org/licensing for details.
+
+#.rst:
+# FindGLEW
+# --------
 #
-# Try to find GLEW library and include path.
-# Once done this will define
+# Find the OpenGL Extension Wrangler Library (GLEW)
 #
-# GLEW_FOUND
-# GLEW_INCLUDE_PATH
-# GLEW_LIBRARY
-# 
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the :prop_tgt:`IMPORTED` target ``GLEW::GLEW``,
+# if GLEW has been found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ::
+#
+#   GLEW_INCLUDE_DIRS - include directories for GLEW
+#   GLEW_LIBRARIES - libraries to link against GLEW
+#   GLEW_FOUND - true if GLEW has been found and can be used
 
-IF (WIN32)
-	FIND_PATH( GLEW_INCLUDE_PATH GL/glew.h
-		$ENV{PROGRAMFILES}/GLEW/include
-		${PROJECT_SOURCE_DIR}/src/nvgl/glew/include
-		DOC "The directory where GL/glew.h resides")
-	FIND_LIBRARY( GLEW_LIBRARY
-		NAMES glew GLEW glew32 glew32s
-		PATHS
-		$ENV{PROGRAMFILES}/GLEW/lib
-		${PROJECT_SOURCE_DIR}/src/nvgl/glew/bin
-		${PROJECT_SOURCE_DIR}/src/nvgl/glew/lib
-		DOC "The GLEW library")
-ELSE (WIN32)
-	FIND_PATH( GLEW_INCLUDE_PATH GL/glew.h
-		/usr/include
-		/usr/local/include
-		/sw/include
-		/opt/local/include
-		DOC "The directory where GL/glew.h resides")
-	FIND_LIBRARY( GLEW_LIBRARY
-		NAMES GLEW glew
-		PATHS
-		/usr/lib64
-		/usr/lib
-		/usr/local/lib64
-		/usr/local/lib
-		/sw/lib
-		/opt/local/lib
-		DOC "The GLEW library")
-ENDIF (WIN32)
+find_path(GLEW_INCLUDE_DIR GL/glew.h)
 
-IF (GLEW_INCLUDE_PATH)
-	SET( GLEW_FOUND 1)
-ELSE (GLEW_INCLUDE_PATH)
-	SET( GLEW_FOUND 0)
-ENDIF (GLEW_INCLUDE_PATH)
+if(NOT GLEW_LIBRARY)
+  find_library(GLEW_LIBRARY_RELEASE NAMES GLEW glew32 glew glew32s PATH_SUFFIXES lib64)
+  find_library(GLEW_LIBRARY_DEBUG NAMES GLEWd glew32d glewd PATH_SUFFIXES lib64)
 
+  include(SelectLibraryConfigurations)
+  select_library_configurations(GLEW)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLEW
+                                  REQUIRED_VARS GLEW_INCLUDE_DIR GLEW_LIBRARY)
+
+if(GLEW_FOUND)
+  set(GLEW_INCLUDE_DIRS ${GLEW_INCLUDE_DIR})
+
+  if(NOT GLEW_LIBRARIES)
+    set(GLEW_LIBRARIES ${GLEW_LIBRARY})
+  endif()
+
+  if (NOT TARGET GLEW::GLEW)
+    add_library(GLEW::GLEW UNKNOWN IMPORTED)
+    set_target_properties(GLEW::GLEW PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIRS}")
+
+    if(GLEW_LIBRARY_RELEASE)
+      set_property(TARGET GLEW::GLEW APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+      set_target_properties(GLEW::GLEW PROPERTIES IMPORTED_LOCATION_RELEASE "${GLEW_LIBRARY_RELEASE}")
+    endif()
+
+    if(GLEW_LIBRARY_DEBUG)
+      set_property(TARGET GLEW::GLEW APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+      set_target_properties(GLEW::GLEW PROPERTIES IMPORTED_LOCATION_DEBUG "${GLEW_LIBRARY_DEBUG}")
+    endif()
+
+    if(NOT GLEW_LIBRARY_RELEASE AND NOT GLEW_LIBRARY_DEBUG)
+      set_property(TARGET GLEW::GLEW APPEND PROPERTY IMPORTED_LOCATION "${GLEW_LIBRARY}")
+    endif()
+  endif()
+endif()
+
+mark_as_advanced(GLEW_INCLUDE_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 find_package(FreeImage REQUIRED)
 find_package(SFML COMPONENTS ${SFML_FIND_COMPONENTS} REQUIRED)
 find_package(FTGL REQUIRED)
+find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(CURL REQUIRED)
@@ -64,14 +65,20 @@ endif()
 
 set(SLADE_SOURCES
 )
-file(GLOB_RECURSE SLADE_SOURCES *.cpp)
-set(LUA_SOURCES
-)
-file(GLOB LUA_SOURCES External/lua/*.c)
-set(DUMB_SOURCES
-)
-file(GLOB_RECURSE DUMB_SOURCES External/dumb/*.c)
-
+# Don't include external libraries here as they should be compiled separately
+file(GLOB_RECURSE SLADE_SOURCES
+	Application/*.cpp
+	Archive/*.cpp
+	Audio/*.cpp
+	Dialogs/*.cpp
+	General/*.cpp
+	Graphics/*.cpp
+	MainEditor/*.cpp
+	MapEditor/*.cpp
+	OpenGL/*.cpp
+	UI/*.cpp
+	Utility/*.cpp
+	)
 set(SLADE_HEADERS
 )
 file(GLOB_RECURSE SLADE_HEADERS *.h *.hpp)
@@ -88,6 +95,9 @@ endif(APPLE)
 # enable SSE instructions for dumb library
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_USE_SSE -msse")
 
+# External libraries are compiled separately to enable unity builds
+add_subdirectory(External)
+
 # c++14 is required to compile
 if(CMAKE_VERSION VERSION_LESS 3.1)
 	add_compile_options(-std=c++14)
@@ -97,18 +107,6 @@ else()
 endif()
 
 add_executable(slade WIN32 MACOSX_BUNDLE
-	External/lzma/C/LzmaDec.c
-	External/mus2mid/mus2mid.cpp
-	External/zreaders/files.cpp
-	External/zreaders/m_alloc.cpp
-	External/zreaders/i_music.cpp
-	External/zreaders/music_hmi_midiout.cpp
-	External/zreaders/music_midistream.cpp
-	External/zreaders/music_mus_midiout.cpp
-	External/zreaders/music_smf_midiout.cpp
-	External/zreaders/music_xmi_midiout.cpp
-	${LUA_SOURCES}
-	${DUMB_SOURCES}
 	${SLADE_SOURCES}
 	${SLADE_HEADERS}
 )
@@ -116,6 +114,7 @@ add_executable(slade WIN32 MACOSX_BUNDLE
 target_link_libraries(slade
 	${ZLIB_LIBRARY}
 	${BZIP2_LIBRARIES}
+	${EXTERNAL_LIBRARIES}
 	${wxWidgets_LIBRARIES}
 	${FREEIMAGE_LIBRARIES}
 	${SFML_LIBRARY}
@@ -156,6 +155,13 @@ else(APPLE)
 endif(APPLE)
 
 if (NOT NO_COTIRE)
-	set_target_properties(slade PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "common.h")
+	set_target_properties(slade PROPERTIES
+		COTIRE_CXX_PREFIX_HEADER_INIT "common.h"
+		# Enable multithreaded unity builds by default
+		# because otherwise probably no one would realize how
+		COTIRE_UNITY_SOURCE_MAXIMUM_NUMBER_OF_INCLUDES -j
+		# Fixes macro definition bleedout
+		COTIRE_UNITY_SOURCE_PRE_UNDEFS "Bool"
+		)
 	cotire(slade)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT NO_COTIRE)
-	include(../cmake/cotire.cmake)
+	include(cotire)
 endif()
 
 # wxWidgets version minimum 3.0
@@ -45,48 +45,22 @@ else (APPLE)
 endif (APPLE)
 
 if(NOT NO_FLUIDSYNTH)
-	include(../cmake/FindFluidSynth.cmake)
+	find_package(FluidSynth REQUIRED)
 else(NO_FLUIDSYNTH)
 	message(STATUS "Fluidsynth support is disabled.")
 endif()
 
-find_package(CURL)
-
-include(../cmake/FindFreeImage.cmake)
-include(../cmake/FindSFML.cmake)
-include(../cmake/FindFTGL.cmake)
-include(../cmake/FindGLEW.cmake)
-include(FindFreetype)
-if(NOT NO_FLUIDSYNTH)
-	if(NOT ${FLUIDSYNTH_FOUND})
-		message(SEND_ERROR "Fluidsynth required.")
-	endif()
-endif()
-if(NOT ${FREEIMAGE_FOUND})
-	message(SEND_ERROR "FreeImage required.")
-endif()
-if(NOT ${SFML_FOUND})
-	message(SEND_ERROR "SFML required.")
-endif()
-if(NOT ${FTGL_FOUND})
-	message(SEND_ERROR "FTGL required.")
-endif()
-if(NOT ${FREETYPE_FOUND})
-	message(SEND_ERROR "Freetype required.")
-endif()
-if(NOT ${GLEW_FOUND})
-	message(SEND_ERROR "GLEW required.")
-endif()
-if(NOT ${CURL_FOUND})
-	message(SEND_ERROR "CURL required.")
-endif()
-include_directories(${FREEIMAGE_INCLUDE_DIR} ${SFML_INCLUDE_DIR} ${FTGL_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS} ${GLEW_INCLUDE_PATH} ${GTK2_INCLUDE_DIRS} . ./External/dumb ./Application)
+find_package(FreeImage REQUIRED)
+find_package(SFML COMPONENTS ${SFML_FIND_COMPONENTS} REQUIRED)
+find_package(FTGL REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(Freetype REQUIRED)
+find_package(CURL REQUIRED)
+include_directories(${FREEIMAGE_INCLUDE_DIR} ${SFML_INCLUDE_DIR} ${FTGL_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS} ${GLEW_INCLUDE_PATH} ${GTK2_INCLUDE_DIRS} ${CURL_INCLUDE_DIR} . ./External/dumb ./Application)
 
 if (NOT NO_FLUIDSYNTH)
 	include_directories(${FLUIDSYNTH_INCLUDE_DIR})
 endif()
-
-	include_directories(${CURL_INCLUDE_DIR})
 
 set(SLADE_SOURCES
 )
@@ -116,10 +90,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_USE_SSE -msse")
 
 # c++14 is required to compile
 if(CMAKE_VERSION VERSION_LESS 3.1)
-    add_compile_options(-std=c++14)
+	add_compile_options(-std=c++14)
 else()
-    set(CMAKE_CXX_STANDARD 14)
-    set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+	set(CMAKE_CXX_STANDARD 14)
+	set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 endif()
 
 add_executable(slade WIN32 MACOSX_BUNDLE
@@ -145,7 +119,7 @@ target_link_libraries(slade
 	${wxWidgets_LIBRARIES}
 	${FREEIMAGE_LIBRARIES}
 	${SFML_LIBRARY}
-	${FTGL_LIBRARY}
+	${FTGL_LIBRARIES}
 	${OPENGL_LIBRARIES}
 	${FREETYPE_LIBRARIES}
 	${GLEW_LIBRARY}

--- a/src/External/CMakeLists.txt
+++ b/src/External/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Use system packages if available
+find_package(ZLIB)
+find_package(BZip2)
+
+if(NOT ZLIB_FOUND)
+	set(ZLIB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zlib)
+	add_subdirectory(zlib)
+	set(ZLIB_LIBRARY z)
+endif(NOT ZLIB_FOUND)
+
+if(NOT BZIP2_FOUND)
+	set(BZIP2_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bzip2)
+	add_subdirectory(bzip2)
+	set(BZIP2_LIBRARIES bz2)
+endif(NOT BZIP2_FOUND)
+
+# Set in parent scope
+set(ZLIB_LIBRARY ${ZLIB_LIBRARY} PARENT_SCOPE)
+set(BZIP2_LIBRARIES ${BZIP2_LIBRARIES} PARENT_SCOPE)
+
+# Roll the rest up into a big ball and compile it by itself
+set(EXTERNAL_SOURCES
+)
+file(GLOB_RECURSE EXTERNAL_SOURCES
+	*.cpp
+	*.cxx
+	dumb/*.c
+	lua/*.c
+	lzma/C/LzmaDec.c
+	${SLADE_HEADERS}
+	)
+
+add_library(external ${EXTERNAL_SOURCES})
+target_link_libraries(external ${ZLIB_LIBRARY})
+set(EXTERNAL_LIBRARIES external PARENT_SCOPE)


### PR DESCRIPTION
I've never done unity builds before, so I was pretty confused at first and thought it would be too complicated to get working, yet it turned out to be pretty easy once I actually figured it out.

External sources must be compiled as a separate step since they do things like use static declarations, which are incompatible with this technique. Other than that, all that had to be changed was to undefine a dumb macro that bled all the way over from an X11 include file.

cotire generates a target called `slade_unity` which produces and compiles the unity source file. If you just run `make`, it will do an incremental compilation instead (maybe good if you only change a few files at once during development).

The difference wasn't as noticeable during a parallel build, which is already pretty fast, but I timed two single threaded builds and got 5m30.467s for the incremental build and 2m11.218s for the unity build. I'd say I'm more sold on the unity build idea now than I was to start with.

Don't worry about the first commit; I'm going to rebase on master before this gets merged in.