### PR TITLE
Fix improper parsing of RGB values in patch blends.

### DIFF
--- a/src/Graphics/CTexture/CTexture.cpp
+++ b/src/Graphics/CTexture/CTexture.cpp
@@ -312,11 +312,12 @@ bool CTPatchEx::parse(Tokenizer& tz, uint8_t type)
 					else
 					{
 						// Third value exists, must be R,G,B,A format
+						// RGB are ints in the 0-255 range; A is float in the 0.0-1.0 range
 						tz.skipToken();	// Skip ,
 						first.ToDouble(&val);
-						colour.r = val*255;
-						colour.g = second*255;
-						colour.b = tz.getDouble()*255;
+						colour.r = val;
+						colour.g = second;
+						colour.b = tz.getInteger();
 						if (tz.peekToken() != ",")
 						{
 							wxLogMessage("Invalid TEXTURES definition, expected ',', got '%s'", tz.getToken());


### PR DESCRIPTION
When values were in three separate parameters, they were read as if they were on a 0.0-1.0 scale, instead of the 0-255 scale they actually are. The operation of multiplying them by 255 and then forcing them back into a single byte inverted their values (except for 0 and 128). Fixes the actual bug of #693.