### PR TITLE
Fix non-const reference argument

### DIFF
--- a/src/UI/Canvas/GfxCanvas.h
+++ b/src/UI/Canvas/GfxCanvas.h
@@ -90,7 +90,7 @@ public:
 	void	allowDrag(bool allow) { allow_drag = allow; }
 	bool	allowScroll() { return allow_scroll; }
 	void	allowScroll(bool allow) { allow_scroll = allow; }
-	void	setPaintColour(rgba_t &col) { paint_colour.set(col); }
+	void	setPaintColour(const rgba_t &col) { paint_colour.set(col); }
 	void	setEditingMode(int mode) { editing_mode = mode; }
 	void	setTranslation(Translation* tr) { translation = tr; }
 	void	setBrush(uint8_t br) { brush = br < Brush::NUM_BRUSHES ? br : 0; }


### PR DESCRIPTION
After trying to compile SLADE with Clang 3.8.1, I got this compilation error:

    /src/MainEditor/UI/EntryPanel/GfxEntryPanel.cpp: In member function ‘virtual bool GfxEntryPanel::handleAction(string)’:
    /src/MainEditor/UI/EntryPanel/GfxEntryPanel.cpp:729:50: error: invalid initialization of non-const reference of type ‘rgba_t&’ from an rvalue of type ‘rgba_t’
       gfx_canvas->setPaintColour(cb_colour->getColour());
                                  ~~~~~~~~~~~~~~~~~~~~^~
    In file included from /src/MainEditor/UI/EntryPanel/GfxEntryPanel.h:6:0,
                     from /src/MainEditor/UI/EntryPanel/GfxEntryPanel.cpp:31:
    /src/./UI/Canvas/GfxCanvas.h:93:7: note:   initializing argument 1 of ‘void GfxCanvas::setPaintColour(rgba_t&)’
      void setPaintColour(rgba_t &col) { paint_colour.set(col); }
           ^~~~~~~~~~~~~~
    /src/MainEditor/UI/EntryPanel/GfxEntryPanel.cpp: In member function ‘void GfxEntryPanel::onPaintColourChanged(wxEvent&)’:
    /src/MainEditor/UI/EntryPanel/GfxEntryPanel.cpp:1106:49: error: invalid initialization of non-const reference of type ‘rgba_t&’ from an rvalue of type ‘rgba_t’
      gfx_canvas->setPaintColour(cb_colour->getColour());
                                 ~~~~~~~~~~~~~~~~~~~~^~
    In file included from /src/MainEditor/UI/EntryPanel/GfxEntryPanel.h:6:0,
                     from /src/MainEditor/UI/EntryPanel/GfxEntryPanel.cpp:31:
    /src/./UI/Canvas/GfxCanvas.h:93:7: note:   initializing argument 1 of ‘void GfxCanvas::setPaintColour(rgba_t&)’
      void setPaintColour(rgba_t &col) { paint_colour.set(col); }
           ^~~~~~~~~~~~~~

Changing the argument `col` from non-const reference to const reference fixes the issue.