### PR TITLE
Minor tweaks to SIFormat.cpp

### DIFF
--- a/src/Graphics/SImage/SIFormat.cpp
+++ b/src/Graphics/SImage/SIFormat.cpp
@@ -215,22 +215,22 @@ uint32_t valid_flat_size[][3] =
 	{   2,   2,	0 },	// lol Heretic F_SKY1
 	{  10,  12,	0 },	// gnum format
 	{  16,  16,	0 },	// |
-	{  32,  32,	0 },	// |
+	{  32,  32,	1 },	// |
 	{  32,  64,	0 },	// Strife startup sprite
 	{  48,  48,	0 },	// |
 	{  64,  64,	1 },	// standard flat size
 	{  64,	65,	0 },	// Heretic flat size variant
 	{  64, 128,	0 },	// Hexen flat size variant
-	{  80,  50, 	0 },	// SRB2 fade mask size 1
+	{  80,  50, 	1 },	// SRB2 fade mask size 1
 	{ 128, 128,	1 },	// |
-	{ 160, 100, 	0 },	// SRB2 fade mask size 2
-	{ 256,  34,	0 },    // SRB2 colormap
+	{ 160, 100, 	1 },	// SRB2 fade mask size 2
+	{ 256,  34,	1 },    // SRB2 colormap
 	{ 256,  66,	0 },	// Blake Stone colormap
 	{ 256, 200,	0 },	// Rise of the Triad sky
 	{ 256, 256,	1 },	// hires flat size
 	{ 320, 200,	0 },	// full screen format
 	{ 512, 512,	1 },	// hires flat size
-	{ 640, 400, 	0 },	// SRB2 fade mask size 4
+	{ 640, 400, 	1 },	// SRB2 fade mask size 4
 	{1024,1024,	1 },	// hires flat size
 	{2048,2048,	1 },	// super hires flat size (SRB2)
 	{4096,4096,	1 },	// |


### PR DESCRIPTION
Just found out what the third number does, that explains why despite the changes, I still could not convert 32x32 and other sizes of images to doom flats.