### PR TITLE
Make Run button in Run dialog the default button

### DIFF
--- a/src/Dialogs/RunDialog.cpp
+++ b/src/Dialogs/RunDialog.cpp
@@ -188,6 +188,7 @@ RunDialog::RunDialog(wxWindow* parent, Archive* archive, bool show_start_3d_cb)
 
 	// Dialog buttons
 	btn_run = new wxButton(this, wxID_OK, "Run");
+	btn_run->SetDefault();
 	hbox->Add(btn_run, 0, wxEXPAND|wxRIGHT, 4);
 
 	btn_cancel = new wxButton(this, wxID_CANCEL, "Cancel");


### PR DESCRIPTION
I think the Run dialog will be a little easier to use if the "Run" button is selected by default. This way when it pops up, pressing enter will cause the game to start.

<img width="400" alt="screen shot 2017-06-16 at 10 13 53 am" src="https://user-images.githubusercontent.com/110764/27237188-fe491edc-527c-11e7-9066-69be9dd0bc2b.png">
