### PR TITLE
New comment code text editor commands.

### DIFF
--- a/src/General/KeyBind.cpp
+++ b/src/General/KeyBind.cpp
@@ -505,6 +505,8 @@ void KeyBind::initBinds()
 	addBind("ted_jumptoline", keypress_t("G", KPM_CTRL), "Jump to Line", group);
 	addBind("ted_fold_foldall", keypress_t("[", KPM_CTRL|KPM_SHIFT), "Fold All", group);
 	addBind("ted_fold_unfoldall", keypress_t("]", KPM_CTRL|KPM_SHIFT), "Fold All", group);
+	addBind("ted_line_comment", keypress_t("/", KPM_CTRL), "Line Comment", group);
+	addBind("ted_block_comment", keypress_t("/", KPM_CTRL|KPM_SHIFT), "Block Comment", group);
 
 	// Texture editor (txed*)
 	group = "Texture Editor";

--- a/src/UI/TextEditor/TextEditor.cpp
+++ b/src/UI/TextEditor/TextEditor.cpp
@@ -1229,6 +1229,76 @@ void TextEditor::updateFolding()
 	}*/
 }
 
+/* TextEditor::lineComment
+ * Comment current line of code
+ *******************************************************************/
+
+void TextEditor::lineComment()
+{
+	string comment = wxString::FromUTF8("// ");
+	string commentNoSpace = wxString::FromUTF8("//");
+	string emptyString = wxString::FromUTF8("");
+
+	int selectionStart, selectionEnd, firstLine, lastLine;
+	GetSelection(&selectionStart, &selectionEnd);
+
+	GotoPos(selectionStart);
+	firstLine = GetCurrentLine();
+
+	GotoPos(selectionEnd);
+	lastLine = GetCurrentLine();
+
+	for (int line = firstLine; line <= lastLine; ++line)
+	{
+		GotoLine(line);
+		string lineText = GetLineText(GetCurrentLine());
+		Home();
+		SetTargetStart(GetCurrentPos());
+		GotoPos(GetLineEndPosition(GetCurrentLine()));
+		SetTargetEnd(GetCurrentPos());
+
+		if (lineText.Find(comment) != wxNOT_FOUND)
+		{
+			lineText.Replace(comment, emptyString, false);
+			ReplaceTarget(lineText);
+		}
+		else if (lineText.Find(commentNoSpace) != wxNOT_FOUND)
+		{
+			lineText.Replace(commentNoSpace, emptyString, false);
+			ReplaceTarget(lineText);
+		}
+		else if (lineText.Len() != 0)
+		{
+			ReplaceTarget(lineText.Prepend(comment));
+		}
+	}
+
+	GotoLine(firstLine);
+	Home();
+	selectionStart = GetCurrentPos();
+
+	GotoLine(lastLine);
+	LineEnd();
+	selectionEnd = GetCurrentPos();
+
+	if (selectionEnd < selectionStart)
+	{
+		wxSwap(selectionStart, selectionEnd);
+	}
+
+	SetSelection(selectionStart, selectionEnd);
+
+}
+
+
+/* TextEditor::blockComment
+ * Comment current line of code
+ *******************************************************************/
+
+void TextEditor::blockComment()
+{
+
+}
 
 /*******************************************************************
  * TEXTEDITOR CLASS EVENTS
@@ -1332,6 +1402,19 @@ void TextEditor::onKeyDown(wxKeyEvent& e)
 		else if (name == "ted_jumptoline")
 		{
 			jumpToLine();
+			handled = true;
+		}
+
+		// Commenting
+		else if (name == "ted_line_comment")
+		{
+			lineComment();
+			handled = true;
+		}
+
+		else if (name == "ted_block_comment")
+		{
+			blockComment();
 			handled = true;
 		}
 	}

--- a/src/UI/TextEditor/TextEditor.cpp
+++ b/src/UI/TextEditor/TextEditor.cpp
@@ -1240,67 +1240,67 @@ void TextEditor::lineComment()
 	string empty = wxString::FromUTF8("");
 
 	int selectionStart, selectionEnd;
-    GetSelection(&selectionStart, &selectionEnd);
+	GetSelection(&selectionStart, &selectionEnd);
 
-    bool singleLine = false;
-    if (selectionStart == selectionEnd)
-        singleLine = true;
+	bool singleLine = false;
+	if (selectionStart == selectionEnd)
+		singleLine = true;
 
-    int firstLine, lastLine;
+	int firstLine, lastLine;
 	firstLine = LineFromPosition(selectionStart);
 	lastLine = LineFromPosition(selectionEnd);
 
-    size_t selectionStartOffs = 0, selectionEndOffs = 0;
+	size_t selectionStartOffs = 0, selectionEndOffs = 0;
 
-    BeginUndoAction();
+	BeginUndoAction();
 	for (int line = firstLine; line <= lastLine; ++line)
 	{
-        string lineText = GetTextRange(GetLineIndentPosition(line), GetLineEndPosition(line));
+		string lineText = GetTextRange(GetLineIndentPosition(line), GetLineEndPosition(line));
 
-        SetTargetStart(GetLineIndentPosition(line));
+		SetTargetStart(GetLineIndentPosition(line));
 		SetTargetEnd(GetLineEndPosition(line));
 
 		if (lineText.Find(comment) != wxNOT_FOUND)
 		{
-            if (line == firstLine) {
-                selectionStartOffs -= comment.Len();
-            }
-            selectionEndOffs -= comment.Len();
+			if (line == firstLine) {
+				selectionStartOffs -= comment.Len();
+			}
+			selectionEndOffs -= comment.Len();
 
-            lineText.Replace(comment, empty, false);
-            ReplaceTarget(lineText);
-        }
+			lineText.Replace(comment, empty, false);
+			ReplaceTarget(lineText);
+		}
 		else if (lineText.Find(commentNoSpace) != wxNOT_FOUND)
 		{
-            if (line == firstLine) {
-                selectionStartOffs -= commentNoSpace.Len();
-            }
-            selectionEndOffs -= commentNoSpace.Len();
+			if (line == firstLine) {
+				selectionStartOffs -= commentNoSpace.Len();
+			}
+			selectionEndOffs -= commentNoSpace.Len();
 
-            lineText.Replace(commentNoSpace, empty, false);
-            ReplaceTarget(lineText);
-        }
+			lineText.Replace(commentNoSpace, empty, false);
+			ReplaceTarget(lineText);
+		}
 		else if (lineText.Trim(true).Len() != 0)
 		{
-            if (line == firstLine) {
-                selectionStartOffs += comment.Len();
-            }
-            selectionEndOffs += comment.Len();
+			if (line == firstLine) {
+				selectionStartOffs += comment.Len();
+			}
+			selectionEndOffs += comment.Len();
 
-            ReplaceTarget(lineText.Prepend(comment));
-        }
-    }
-    EndUndoAction();
+			ReplaceTarget(lineText.Prepend(comment));
+		}
+	}
+	EndUndoAction();
 
-    if (singleLine)
-    {
-        LineDown();
-        GotoPos(GetLineIndentPosition(GetCurrentLine()));
-    }
-    else
-    {
-        SetSelection(selectionStart + selectionStartOffs, selectionEnd + selectionEndOffs);
-    }
+	if (singleLine)
+	{
+		LineDown();
+		GotoPos(GetLineIndentPosition(GetCurrentLine()));
+	}
+	else
+	{
+		SetSelection(selectionStart + selectionStartOffs, selectionEnd + selectionEndOffs);
+	}
 }
 
 
@@ -1310,42 +1310,42 @@ void TextEditor::lineComment()
 
 void TextEditor::blockComment()
 {
-    string leftComment = wxString::FromUTF8("/*");
-    string rightComment = wxString::FromUTF8("*/");
-    string space = wxString::FromUTF8(" ");
+	string leftComment = wxString::FromUTF8("/*");
+	string rightComment = wxString::FromUTF8("*/");
+	string space = wxString::FromUTF8(" ");
 
-    size_t rCommentLenght = 2, lCommentLength = 2;
+	size_t rCommentLenght = 2, lCommentLength = 2;
 
-    int selectionStart, selectionEnd;
-    GetSelection(&selectionStart, &selectionEnd);
-    SetTargetStart(selectionStart);
-    SetTargetEnd(selectionEnd);
+	int selectionStart, selectionEnd;
+	GetSelection(&selectionStart, &selectionEnd);
+	SetTargetStart(selectionStart);
+	SetTargetEnd(selectionEnd);
 
-    SetInsertionPoint(selectionStart);
+	SetInsertionPoint(selectionStart);
 
-    string textString = GetRange(selectionStart, selectionEnd);
+	string textString = GetRange(selectionStart, selectionEnd);
 
-    if (!textString.StartsWith(leftComment, NULL) && !textString.EndsWith(rightComment, NULL))
-    {
-        rCommentLenght = 3;
-        ReplaceTarget(textString.Prepend(leftComment.append(space)).append(rightComment.Prepend(space)));
-        selectionEnd += (int) rCommentLenght * 2;
-    }
-    else if (textString.StartsWith(leftComment, NULL) && textString.EndsWith(rightComment, NULL))
-    {
-        if (textString.StartsWith(leftComment.append(space), NULL))
-        {
-            lCommentLength = 3;
-        }
-        if (textString.EndsWith(rightComment.Prepend(space), NULL))
-        {
-            rCommentLenght = 3;
-        }
-        ReplaceTarget(textString.Remove(0, lCommentLength).RemoveLast(rCommentLenght));
-        selectionEnd -= (int)lCommentLength + (int)rCommentLenght;
-    }
+	if (!textString.StartsWith(leftComment, NULL) && !textString.EndsWith(rightComment, NULL))
+	{
+		rCommentLenght = 3;
+		ReplaceTarget(textString.Prepend(leftComment.append(space)).append(rightComment.Prepend(space)));
+		selectionEnd += (int) rCommentLenght * 2;
+	}
+	else if (textString.StartsWith(leftComment, NULL) && textString.EndsWith(rightComment, NULL))
+	{
+		if (textString.StartsWith(leftComment.append(space), NULL))
+		{
+			lCommentLength = 3;
+		}
+		if (textString.EndsWith(rightComment.Prepend(space), NULL))
+		{
+			rCommentLenght = 3;
+		}
+		ReplaceTarget(textString.Remove(0, lCommentLength).RemoveLast(rCommentLenght));
+		selectionEnd -= (int)lCommentLength + (int)rCommentLenght;
+	}
 
-    SetSelection(selectionStart, selectionEnd);
+	SetSelection(selectionStart, selectionEnd);
 }
 
 /*******************************************************************

--- a/src/UI/TextEditor/TextEditor.cpp
+++ b/src/UI/TextEditor/TextEditor.cpp
@@ -1242,7 +1242,7 @@ void TextEditor::lineComment()
 		comment = language->getLineComment();
 	else
 		comment = wxString::FromUTF8("//");
-	commentSpace = comment.append(space);
+	commentSpace = comment + space;
 
 	int selectionStart, selectionEnd;
 	GetSelection(&selectionStart, &selectionEnd);
@@ -1255,7 +1255,8 @@ void TextEditor::lineComment()
 	firstLine = LineFromPosition(selectionStart);
 	lastLine = LineFromPosition(selectionEnd);
 
-	size_t selectionStartOffs = 0, selectionEndOffs = 0;
+	size_t selectionStartOffs, selectionEndOffs;
+	selectionStartOffs = selectionEndOffs = 0;
 
 	BeginUndoAction();
 	for (int line = firstLine; line <= lastLine; ++line)
@@ -1328,10 +1329,13 @@ void TextEditor::blockComment()
 		commentEnd = wxString::FromUTF8("*/");
 	}
 
-	size_t rCommentLenght = 2, lCommentLength = 2;
+	size_t commentBeginLen, commentEndLen;
+	commentBeginLen = commentBegin.Len();
+	commentEndLen = commentEnd.Len();
 
 	int selectionStart, selectionEnd;
 	GetSelection(&selectionStart, &selectionEnd);
+
 	SetTargetStart(selectionStart);
 	SetTargetEnd(selectionEnd);
 
@@ -1341,22 +1345,21 @@ void TextEditor::blockComment()
 
 	if (!textString.StartsWith(commentBegin, NULL) && !textString.EndsWith(commentEnd, NULL))
 	{
-		rCommentLenght = 3;
-		ReplaceTarget(textString.Prepend(commentBegin.append(space)).append(commentEnd.Prepend(space)));
-		selectionEnd += (int) rCommentLenght * 2;
+		commentBegin = commentBegin.append(space);
+		commentEnd = commentEnd.Prepend(space);
+
+		ReplaceTarget(textString.Prepend(commentBegin).append(commentEnd));
+		selectionEnd += (int)(commentBegin.Len() + commentEnd.Len());
 	}
 	else if (textString.StartsWith(commentBegin, NULL) && textString.EndsWith(commentEnd, NULL))
 	{
 		if (textString.StartsWith(commentBegin.append(space), NULL))
-		{
-			lCommentLength = 3;
-		}
+			commentBeginLen = commentBegin.Len();
 		if (textString.EndsWith(commentEnd.Prepend(space), NULL))
-		{
-			rCommentLenght = 3;
-		}
-		ReplaceTarget(textString.Remove(0, lCommentLength).RemoveLast(rCommentLenght));
-		selectionEnd -= (int)lCommentLength + (int)rCommentLenght;
+			commentEndLen = commentEnd.Len();
+
+		ReplaceTarget(textString.Remove(0, commentBeginLen).RemoveLast(commentEndLen));
+		selectionEnd -= (int)(commentBeginLen + commentEndLen);
 	}
 
 	SetSelection(selectionStart, selectionEnd);

--- a/src/UI/TextEditor/TextEditor.h
+++ b/src/UI/TextEditor/TextEditor.h
@@ -132,6 +132,10 @@ public:
 	void	setupFolding();
 	void	updateFolding();
 
+	// Comments
+	void	lineComment();
+	void 	blockComment();
+
 	// Events
 	void	onKeyDown(wxKeyEvent& e);
 	void	onKeyUp(wxKeyEvent& e);

--- a/src/UI/TextEditor/TextLanguage.cpp
+++ b/src/UI/TextEditor/TextLanguage.cpp
@@ -719,7 +719,7 @@ bool TextLanguage::loadLanguages()
 	// Read language definitions from resource archive
 	if (res_archive)
 	{
-		// Get 'config/languages' directlry
+		// Get 'config/languages' directly
 		ArchiveTreeNode* dir = res_archive->getDir("config/languages");
 
 		if (dir)


### PR DESCRIPTION
I finally ended up working in my own request #746 

There are two new commands for the text editor:

- Line Comment
default bind = `Ctrl + /`
If there's no selection a simple line comment `//` is added to the line the caret is on. If there's a comment in the current line, it's cleared. Then the caret jumps to the next line.
If there's a block of text selected the command will act upon all the lines that have a character selected.

- Block Comment
default bind = `Ctrl + Shift + /'`
It wraps the selected text on block comments `/* text */`
If the selection begins with `/*`, and ends with `*/`, the comment will be cleared.

Let me know if there's something I must improve or change.