### PR TITLE
Text editor commands to comment/uncomment code.

### DIFF
--- a/src/General/KeyBind.cpp
+++ b/src/General/KeyBind.cpp
@@ -505,6 +505,8 @@ void KeyBind::initBinds()
 	addBind("ted_jumptoline", keypress_t("G", KPM_CTRL), "Jump to Line", group);
 	addBind("ted_fold_foldall", keypress_t("[", KPM_CTRL|KPM_SHIFT), "Fold All", group);
 	addBind("ted_fold_unfoldall", keypress_t("]", KPM_CTRL|KPM_SHIFT), "Fold All", group);
+	addBind("ted_line_comment", keypress_t("/", KPM_CTRL), "Line Comment", group);
+	addBind("ted_block_comment", keypress_t("/", KPM_CTRL|KPM_SHIFT), "Block Comment", group);
 
 	// Texture editor (txed*)
 	group = "Texture Editor";

--- a/src/UI/TextEditor/TextEditor.h
+++ b/src/UI/TextEditor/TextEditor.h
@@ -132,6 +132,10 @@ public:
 	void	setupFolding();
 	void	updateFolding();
 
+	// Comments
+	void	lineComment();
+	void 	blockComment();
+
 	// Events
 	void	onKeyDown(wxKeyEvent& e);
 	void	onKeyUp(wxKeyEvent& e);

--- a/src/UI/TextEditor/TextLanguage.cpp
+++ b/src/UI/TextEditor/TextLanguage.cpp
@@ -719,7 +719,7 @@ bool TextLanguage::loadLanguages()
 	// Read language definitions from resource archive
 	if (res_archive)
 	{
-		// Get 'config/languages' directlry
+		// Get 'config/languages' directly
 		ArchiveTreeNode* dir = res_archive->getDir("config/languages");
 
 		if (dir)


### PR DESCRIPTION
**Supersedes #753**
I have squashed the commits and I have made the pull request from a proper branch this time.
Sorry for this mess.

**Original comment:**

I finally ended up working in my own request #746

There are two new commands for the text editor:

· Line Comment
Default bind = Ctrl + /
If there's no selection a simple line comment // is added to the line the caret is on. If there's a comment in the current line, it's cleared. Then the caret jumps to the next line.
If there's a block of text selected the command will act upon all the lines that have a character selected.

· Block Comment
Default bind = Ctrl + Shift + /'
It wraps the selected text on block comments /* text */
If the selection begins with /*, and ends with */, the comment will be cleared.

Let me know if there's something I must improve or change.