### PR TITLE
Fix gcc build errors.

### DIFF
--- a/src/MapEditor/SLADEMap/SLADEMap.cpp
+++ b/src/MapEditor/SLADEMap/SLADEMap.cpp
@@ -3053,7 +3053,7 @@ vector<fpoint2_t> SLADEMap::cutLines(double x1, double y1, double x2, double y2)
 		{
 			// Add intersection point to vector
 			intersect_points.push_back(intersection);
-			LOG_DEBUG("Intersection point", intersection, "valid with", lines[a]);
+			LOG_DEBUG("Intersection point", intersection, "valid with", lines_[a]);
 		}
 		else if (intersection != cutter.p1())
 		{

--- a/src/common.h
+++ b/src/common.h
@@ -141,6 +141,7 @@
 // C++
 #include <map>
 #include <vector>
+#include <functional>
 #include <algorithm>
 #include <set>
 #include <cmath>


### PR DESCRIPTION
Fixes #759:
There was a typo in `SLADEMap.cpp`

Fixes #758:
The `<functional>` header could not be found by the compiler while processing `SScriptDialog.cpp`
I have added it in `scr/common.h` but don't know if that's the place you want to put it.