### PR TITLE
ZScript language support and text editor improvements

### DIFF
--- a/build/msvc/SLADE.vcxproj
+++ b/build/msvc/SLADE.vcxproj
@@ -1030,6 +1030,7 @@
     <ClCompile Include="..\..\src\Game\SpecialPreset.cpp" />
     <ClCompile Include="..\..\src\Game\ThingType.cpp" />
     <ClCompile Include="..\..\src\Game\UDMFProperty.cpp" />
+    <ClCompile Include="..\..\src\Game\ZScript.cpp" />
     <ClCompile Include="..\..\src\General\Clipboard.cpp" />
     <ClCompile Include="..\..\src\General\ColourConfiguration.cpp" />
     <ClCompile Include="..\..\src\General\Console\Console.cpp" />
@@ -2003,6 +2004,7 @@
     <ClInclude Include="..\..\src\Game\SpecialPreset.h" />
     <ClInclude Include="..\..\src\Game\ThingType.h" />
     <ClInclude Include="..\..\src\Game\UDMFProperty.h" />
+    <ClInclude Include="..\..\src\Game\ZScript.h" />
     <ClInclude Include="..\..\src\General\Clipboard.h" />
     <ClInclude Include="..\..\src\General\ColourConfiguration.h" />
     <ClInclude Include="..\..\src\General\Console\Console.h" />

--- a/build/msvc/SLADE.vcxproj.filters
+++ b/build/msvc/SLADE.vcxproj.filters
@@ -1497,6 +1497,9 @@
     <ClCompile Include="..\..\src\Game\MapInfo.cpp">
       <Filter>Game</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\Game\ZScript.cpp">
+      <Filter>Game</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />
@@ -2616,6 +2619,9 @@
       <Filter>Text Editor\UI</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\Game\MapInfo.h">
+      <Filter>Game</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\Game\ZScript.h">
       <Filter>Game</Filter>
     </ClInclude>
   </ItemGroup>

--- a/dist/res/config/languages/zscript.txt
+++ b/dist/res/config/languages/zscript.txt
@@ -14,7 +14,7 @@ zscript
 		class, default, private, static, native, return, if, else, for, while, do, break, continue,
 		deprecated, state, null, readonly, true, false, struct, extend, clearscope, vararg, ui, play,
 		virtual, virtualscope, meta, Property, version, in, out, states, action, override, super, is,
-		let, const, replaces, protected
+		let, const, replaces, protected, self
 	}
 
 	types =

--- a/dist/res/config/languages/zscript.txt
+++ b/dist/res/config/languages/zscript.txt
@@ -14,7 +14,7 @@ zscript
 		class, default, private, static, native, return, if, else, for, while, do, break, continue,
 		deprecated, state, null, readonly, true, false, struct, extend, clearscope, vararg, ui, play,
 		virtual, virtualscope, meta, Property, version, in, out, states, action, override, super, is,
-		let
+		let, const
 	}
 
 	types =

--- a/dist/res/config/languages/zscript.txt
+++ b/dist/res/config/languages/zscript.txt
@@ -13,7 +13,8 @@ zscript
 		// General keywords
 		class, default, private, static, native, return, if, else, for, while, do, break, continue,
 		deprecated, state, null, readonly, true, false, struct, extend, clearscope, vararg, ui, play,
-		virtual, virtualscope, meta, Property, version, in, out, states, action, override, super
+		virtual, virtualscope, meta, Property, version, in, out, states, action, override, super, is,
+		let
 	}
 
 	types =

--- a/dist/res/config/languages/zscript.txt
+++ b/dist/res/config/languages/zscript.txt
@@ -14,7 +14,7 @@ zscript
 		class, default, private, static, native, return, if, else, for, while, do, break, continue,
 		deprecated, state, null, readonly, true, false, struct, extend, clearscope, vararg, ui, play,
 		virtual, virtualscope, meta, Property, version, in, out, states, action, override, super, is,
-		let, const
+		let, const, replaces
 	}
 
 	types =

--- a/dist/res/config/languages/zscript.txt
+++ b/dist/res/config/languages/zscript.txt
@@ -1,156 +1,24 @@
 
-zscript : decorate
+zscript
 {
 	name = "ZDoom ZScript";
 	keyword_link = "http://zdoom.org/wiki/Special:Search/%s";
 	constant_link = "http://zdoom.org/wiki/Special:Search/%s";
 	function_link = "http://zdoom.org/wiki/%s";
 	case_sensitive = false;
-	blocks = "class", "struct";
+	blocks = "class", "struct", "enum";
 
 	keywords =
 	{
-		//$override,
-
 		// General keywords
 		class, default, private, static, native, return, if, else, for, while, do, break, continue,
-		deprecated, state, null, readonly, true, false, struct, extend,
+		deprecated, state, null, readonly, true, false, struct, extend, clearscope, vararg, ui, play,
+		virtual, virtualscope, meta, Property, version, in, out, states, action, override, super
+	}
 
-		// Types
+	types =
+	{
 		object, vector2, vector3, name, string, color, sound, void, double, bool, int, float,
-
-		// States
-		States, Spawn, See, Melee, Missile, Pain, Death, XDeath, Burn, Ice, Disintegrate,
-		Raise, Heal, Crash, Crush, Wound, Greetings, Yes, No, Extreme, Bounce, Floor, Ceiling,
-		Wall, Creature, Loop, Stop, Wait, Fail, Goto, Ready, Deselect, Select, Fire, AltFire,
-		Hold, AltHold, Flash, AltFlash, Reload, Zoom, Pickup, Use, Drop, Bright, Fast, Slow, NoDelay,
-		CanRaise, Idle, Active, Inactive, Light, Offset, Action, Native, Const, Enum, Replaces,
-		LightDone, Super, Spray, GenericFreezeDeath, GenericCrush, User1, User2, User3, User4,
-		DeadLowered,
-
-		// Properties
-		// (if more word lists were allowed by the scintilla lexer these would not be in the 'keywords' list, but oh well)
-		Pos, Prev, SpriteAngle, SpriteRotation, VisibleStartAngle, VisibleStartPitch,
-		VisibleEndAngle, VisibleEndPitch, Angle, Pitch, Roll, Vel, Speed, FloatSpeed, Sprite,
-		FloorSector, FloorPic, FloorTerrain, CeilingSector, CeilingPic, Height, Radius,
-		ProjectilePassHeight, Tics, CurState, Damage, ProjectileKickBack, Special1, Special2,
-		SpecialF1, SpecialF2, WeaponSpecial, Health, MoveDir, VisDir, MoveCount, StrafeCount,
-		Target, Master, Tracer, LastHeard, LastEnemy, LastLookActor, ReactionTime, Threshold,
-		DefThreshold, SpawnPoint, SpawnAngle, StartHealth, WeaveIndexXY, WeaveIndexZ,
-		SkillRespawnCount, Args, Mass, Special, TID, TIDtoHate, WaterLevel, Score, Accuracy,
-		Stamina, MeleeRange, PainThreshold, Gravity, FloorClip, DamageType, DamageTypeReceived,
-		FloatBobPhase, RipperLevel, RipLevelMin, RipLevelMax, Species, Alternative, Goal,
-		MinMissileChance, LastLookPlayerNumber, SpawnFlags, MeleeThreshold, MaxTargetRange,
-		BounceFactor, WallBounceFactor, BounceCount, Friction, FastChaseStrafeCount,
-		PushFactor, LastPush, ActivationType, LastBump, DesignatedTeam, BlockingMobj,
-		PoisonDamage, PoisonDamageType, PoisonDuration, PoisonPeriod, PoisonDamageReceived,
-		PoisonDamageTypeReceived, PoisonDurationReceived, PoisonPeriodReceived, Poisoner,
-		Inv, SmokeCounter, FriendPlayer, Translation, AttackSound, DeathSound, SeeSound,
-		PainSound, ActiveSound, UseSound, BounceSound, WallBounceSound, CrushPainSound,
-		MaxDropoffHeight, MaxStepHeight, PainChance, PainType, DeathType, DamageFactor,
-		DamageMultiply, TelefogSourceType, TelefogDestType, SpawnState, SeeState, MeleeState,
-		MissileState, Scale, RenderState, Alpha, VisibleAngles, VisiblePitch
-	}
-
-	constants =
-	{
-		// EMaskRotationFlags
-		VRF_NOANGLESTART, VRF_NOANGLEEND, VRF_NOPITCHSTART, VRF_NOPITCHEND, VRF_NOANGLE, VRF_NOPITCH,
-
-		// ERenderStyle
-		STYLE_None, STYLE_Normal, STYLE_Fuzzy, STYLE_SoulTrans, STYLE_OptFuzzy, STYLE_Stencil,
-		STYLE_Translucent, STYLE_Add, STYLE_Shaded, STYLE_TranslucentStencil, STYLE_Shadow,
-		STYLE_Subtract, STYLE_AddStencil, STYLE_AddShaded,
-
-		// EStateType
-		STATE_Actor, STATE_Psprite, STATE_StateChain,
-
-		// EAimFlags
-		ALF_FORCENOSMART, ALF_CHECK3D, ALF_CHECKNONSHOOTABLE, ALF_CHECKCONVERSATION, ALF_NOFRIENDS,
-		ALF_PORTALRESTRICT,
-
-		// ELineAttackFlags
-		LAF_ISMELEEATTACK, LAF_NORANDOMPUFFZ, LAF_NOIMPACTDECAL, LAF_NOINTERACT,
-
-		// ESightFlags
-		SF_IGNOREVISIBILITY, SF_SEEPASTSHOOTABLELINES, SF_SEEPASTBLOCKEVERYTHING,
-		SF_IGNOREWATERBOUNDARY,
-
-		// EDmgFlags
-		DMG_NO_ARMOR, DMG_INFLICTOR_IS_PUFF, DMG_THRUSTLESS, DMG_FORCED, DMG_NO_FACTOR,
-		DMG_PLAYERATTACK, DMG_FOILINVUL, DMG_FOILBUDDHA, DMG_NO_PROTECT, DMG_USEANGLE,
-
-		// EReplace
-		NO_REPLACE, ALLOW_REPLACE,
-
-		// Other
-		SAWRANGE, MISSILERANGE, PLAYERMISSILERANGE, FLAG_NO_CHANGE
-	}
-
-	functions
-	{
-		bool IsPointerEqual = "int ptr_select1, int ptr_select2";
-		readonly<Actor> GetDefaultByType = "class<Actor> cls";
-		float deltaangle = "float ang1, float ang2";
-		void SetDamage = "int dmg";
-		bool isDehState = "state st";
-		void SetOrigin = "vector3 newpos, bool moving";
-		void SetXYZ = "vector3 newpos";
-		Actor GetPointer = "int aaptr";
-		Actor Spawn = "class<Actor> type, [vector3 pos], [int replace]";
-		Actor SpawnMissile = "Actor dest, class<Actor> type, [Actor owner]";
-		Actor OldSpawnMissile = "Actor dest, class<Actor> type, [Actor owner]";
-		Actor SpawnPuff = "class<Actor> pufftype, vector3 pos, float hitdir, float particledir, int updown, [int flags], [Actor vict]";
-		void TraceBleed = "int damage, Actor missile";
-		bool CheckMeleeRange;
-		int DamageMobj = "Actor inflictor, Actor source, int damage, Name mod, [int flags], [double angle]";
-		//double AimLineAttack = "double angle, double distance, [out FTranslatedLineTarget pLineTarget], [double vrange], [int flags], [Actor target], [Actor friender]";
-		//Actor, int LineAttack = "double angle, double distance, double pitch, int damage, Name damageType, class<Actor> pufftype, [int flags], [out FTranslatedLineTarget victim]";
-		bool CheckSight = "Actor target, [int flags]";
-		bool HitFriend;
-		bool SetState = "state st, [bool nofunction]";
-		void LinkToWorld;
-		void UnlinkFromWorld;
-		bool CanSeek = "Actor target";
-		double AngleTo = "Actor target, [bool absolute]";
-		void AddZ = "float zadd";
-		vector3 Vec3Offset = "float x, float y, float z, [bool absolute]";
-		vector3 Vec3Angle = "float length, float angle, [float z], [bool absolute]";
-		vector3 Vec2OffsetZ = "float x, float y, float atz, [bool absolute]";
-		void VelFromAngle = "[float speed], [float angle]";
-		bool isFriend = "Actor other";
-		void AdjustFloorClip;
-		DropItem GetDropItems;
-		void CopyFriendliness  = "Actor other, bool changeTarget, [bool resetHealth]";
-		bool LookForPlayers = "bool allaround";
-		bool TeleportMove = "Vector3 pos, bool telefrag, [bool modifyactor]";
-		double DistanceBySpeed = "Actor other, double speed";
-		name GetSpecies;
-
-		bool CheckClass = "class<Actor> checkclass, [int ptr_select], [bool match_superclass]";
-		int	CountInv = "class<Inventory> itemtype, [int ptr_select]";
-		float GetDistance = "bool checkz, [int ptr]";
-		float GetAngle = "int flags, [int ptr]";
-		float GetZAt = "[float px], [float py], [float angle], [int flags], [int pick_pointer]";
-		int GetSpawnHealth;
-		int GetGibHealth;
-		float GetCrouchFactor = "[int ptr]";
-		float GetCVar = "string cvar";
-		int GetPlayerInput = "int inputnum, [int ptr]";
-		int CountProximity = "class<Actor> classname, float distance, [int flags], [int ptr]";
-		float GetSpriteAngle = "[int ptr]";
-		float GetSpriteRotation = "[int ptr]";
-		int GetMissileDamage = "int mask, int add, [int ptr]";
-		int OverlayID;
-		float OverlayX = "[int layer]";
-		float OverlayY = "[int layer]";
-
-		void A_Face = "Actor faceto, [float max_turn], [float max_pitch], [float ang_offset], [float pitch_offset], [int flags], [float z_ofs]";
-		void A_ChangeLinkFlags = "[int blockmap], [int sector]";
-		bool A_SetInventory = "class<Inventory> itemtype, int amount, [int ptr], [bool beyondMax]";
-		void A_SetRenderStyle = "float alpha, int style";
-		void A_ChangeCountFlags = "[int kill], [int item], [int secret]";
-		bool A_SetVisibleRotation = "[float anglestart], [float angleend], [float pitchstart], [float pitchend], [int flags], [int ptr]";
-		void A_SetTranslation = "string transname";
+		uint8, uint16, uint, int8, int16, TextureID, SpriteID, Array, voidptr, short
 	}
 }

--- a/dist/res/config/languages/zscript.txt
+++ b/dist/res/config/languages/zscript.txt
@@ -14,7 +14,7 @@ zscript
 		class, default, private, static, native, return, if, else, for, while, do, break, continue,
 		deprecated, state, null, readonly, true, false, struct, extend, clearscope, vararg, ui, play,
 		virtual, virtualscope, meta, Property, version, in, out, states, action, override, super, is,
-		let, const, replaces
+		let, const, replaces, protected
 	}
 
 	types =

--- a/src/Archive/ArchiveEntry.cpp
+++ b/src/Archive/ArchiveEntry.cpp
@@ -1,35 +1,37 @@
 
-/*******************************************************************
- * SLADE - It's a Doom Editor
- * Copyright (C) 2008-2014 Simon Judd
- *
- * Email:       sirjuddington@gmail.com
- * Web:         http://slade.mancubus.net
- * Filename:    ArchiveEntry.cpp
- * Description: ArchiveEntry, a class that represents and holds
- *              information about a single 'entry', ie, a chunk of
- *              data with a name and various other properties, that
- *              is usually part of an archive (archive=wad, entry=lump)
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2017 Simon Judd
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    ArchiveEntry.cpp
+// Description: ArchiveEntry, a class that represents and holds information
+//              about a single 'entry', ie, a chunk of data with a name and
+//              various other properties, that is usually part of an archive
+//              (archive=wad, entry=lump)
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// ----------------------------------------------------------------------------
 
 
-/*******************************************************************
- * INCLUDES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Includes
+//
+// ----------------------------------------------------------------------------
 #include "Main.h"
 #include "ArchiveEntry.h"
 #include "Archive.h"
@@ -37,13 +39,18 @@
 #include "Utility/StringUtils.h"
 
 
-/*******************************************************************
- * ARCHIVEENTRY CLASS FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// ArchiveEntry Class Functions
+//
+// ----------------------------------------------------------------------------
 
-/* ArchiveEntry::ArchiveEntry
- * ArchiveEntry class constructor
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// ArchiveEntry::ArchiveEntry
+//
+// ArchiveEntry class constructor
+// ----------------------------------------------------------------------------
 ArchiveEntry::ArchiveEntry(string name, uint32_t size)
 {
 	// Initialise attributes
@@ -63,9 +70,11 @@ ArchiveEntry::ArchiveEntry(string name, uint32_t size)
 	this->index_guess = 0;
 }
 
-/* ArchiveEntry::ArchiveEntry
- * ArchiveEntry class copy constructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::ArchiveEntry
+//
+// ArchiveEntry class copy constructor
+// ----------------------------------------------------------------------------
 ArchiveEntry::ArchiveEntry(ArchiveEntry& copy)
 {
 	// Initialise (copy) attributes
@@ -99,18 +108,22 @@ ArchiveEntry::ArchiveEntry(ArchiveEntry& copy)
 	state_locked = false;
 }
 
-/* ArchiveEntry::~ArchiveEntry
- * ArchiveEntry class destructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::~ArchiveEntry
+//
+// ArchiveEntry class destructor
+// ----------------------------------------------------------------------------
 ArchiveEntry::~ArchiveEntry()
 {
 }
 
-/* ArchiveEntry::getName
- * Returns the entry name. If [cut_ext] is true and the name has an
- * extension, it will be cut from the returned name
- *******************************************************************/
-string ArchiveEntry::getName(bool cut_ext)
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getName
+//
+// Returns the entry name. If [cut_ext] is true and the name has an extension,
+// it will be cut from the returned name
+// ----------------------------------------------------------------------------
+string ArchiveEntry::getName(bool cut_ext) const
 {
 	if (!cut_ext)
 		return name;
@@ -131,18 +144,21 @@ string ArchiveEntry::getName(bool cut_ext)
 	*/
 }
 
-
-/* ArchiveEntry::getUpperName
- * Returns the entry name in uppercase
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getUpperName
+//
+// Returns the entry name in uppercase
+// ----------------------------------------------------------------------------
 string ArchiveEntry::getUpperName()
 {
 	return upper_name;
 }
 
-/* ArchiveEntry::getUpperNameNoExt
- * Returns the entry name in uppercase with no file extension
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getUpperNameNoExt
+//
+// Returns the entry name in uppercase with no file extension
+// ----------------------------------------------------------------------------
 string ArchiveEntry::getUpperNameNoExt()
 {
 	if (upper_name.Contains(StringUtils::FULLSTOP))
@@ -151,9 +167,11 @@ string ArchiveEntry::getUpperNameNoExt()
 		return Misc::lumpNameToFileName(upper_name);
 }
 
-/* ArchiveEntry::getParent
- * Returns the entry's parent archive
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getParent
+//
+// Returns the entry's parent archive
+// ----------------------------------------------------------------------------
 Archive* ArchiveEntry::getParent()
 {
 	if (parent)
@@ -162,9 +180,11 @@ Archive* ArchiveEntry::getParent()
 		return NULL;
 }
 
-/* ArchiveEntry::getParent
- * Returns the entry's top-level parent archive
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getParent
+//
+// Returns the entry's top-level parent archive
+// ----------------------------------------------------------------------------
 Archive* ArchiveEntry::getTopParent()
 {
 	if (parent)
@@ -178,10 +198,12 @@ Archive* ArchiveEntry::getTopParent()
 		return NULL;
 }
 
-/* ArchiveEntry::getPath
- * Returns the entry path in its parent archive
- *******************************************************************/
-string ArchiveEntry::getPath(bool name)
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getPath
+//
+// Returns the entry path in its parent archive
+// ----------------------------------------------------------------------------
+string ArchiveEntry::getPath(bool name) const
 {
 	// Get the entry path
 	string path = parent->getPath();
@@ -192,22 +214,25 @@ string ArchiveEntry::getPath(bool name)
 		return path;
 }
 
-/* ArchiveEntry::getData
- * Returns a pointer to the entry data. If no entry data exists and
- * allow_load is true, entry data will be loaded from its parent
- * archive (if it exists)
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getData
+//
+// Returns a pointer to the entry data. If no entry data exists and
+// [allow_load] is true, entry data will be loaded from its parent archive (if
+// it exists)
+// ----------------------------------------------------------------------------
 const uint8_t* ArchiveEntry::getData(bool allow_load)
 {
 	// Return entry data
 	return getMCData(allow_load).getData();
 }
 
-/* ArchiveEntry::getMCData
- * Returns the entry data MemChunk. If no entry data exists and
- * allow_load is true, entry data will be loaded from its parent
- * archive (if it exists)
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getMCData
+//
+// Returns the entry data MemChunk. If no entry data exists and [allow_load]
+// is true, entry data will be loaded from its parent archive (if it exists)
+// ----------------------------------------------------------------------------
 MemChunk& ArchiveEntry::getMCData(bool allow_load)
 {
 	// Get parent archive
@@ -223,10 +248,12 @@ MemChunk& ArchiveEntry::getMCData(bool allow_load)
 	return data;
 }
 
-/* ArchiveEntry::getShared
- * Returns the parent ArchiveTreeNode's shared pointer to this entry,
- * or nullptr if this entry has no parent
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getShared
+//
+// Returns the parent ArchiveTreeNode's shared pointer to this entry, or
+// nullptr if this entry has no parent
+// ----------------------------------------------------------------------------
 ArchiveEntry::SPtr ArchiveEntry::getShared()
 {
 	if (parent)
@@ -235,10 +262,12 @@ ArchiveEntry::SPtr ArchiveEntry::getShared()
 		return nullptr;
 }
 
-/* ArchiveEntry::setState
- * Sets the entry's state. Won't change state if the change would be
- * redundant (eg new->modified, unmodified->unmodified)
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::setState
+//
+// Sets the entry's state. Won't change state if the change would be redundant
+// (eg new->modified, unmodified->unmodified)
+// ----------------------------------------------------------------------------
 void ArchiveEntry::setState(uint8_t state)
 {
 	if (state_locked || (state == 0 && this->state == 0))
@@ -256,9 +285,11 @@ void ArchiveEntry::setState(uint8_t state)
 	stateChanged();
 }
 
-/* ArchiveEntry::unloadData
- * 'Unloads' entry data from memory
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::unloadData
+//
+// 'Unloads' entry data from memory
+// ----------------------------------------------------------------------------
 void ArchiveEntry::unloadData()
 {
 	// Check there is any data to be 'unloaded'
@@ -276,9 +307,11 @@ void ArchiveEntry::unloadData()
 	setLoaded(false);
 }
 
-/* ArchiveEntry::lock
- * Locks the entry. A locked entry cannot be modified
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::lock
+//
+// Locks the entry. A locked entry cannot be modified
+// ----------------------------------------------------------------------------
 void ArchiveEntry::lock()
 {
 	// Lock the entry
@@ -288,9 +321,11 @@ void ArchiveEntry::lock()
 	stateChanged();
 }
 
-/* ArchiveEntry::unlock
- * Unlocks the entry
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::unlock
+//
+// Unlocks the entry
+// ----------------------------------------------------------------------------
 void ArchiveEntry::unlock()
 {
 	// Unlock the entry
@@ -300,9 +335,11 @@ void ArchiveEntry::unlock()
 	stateChanged();
 }
 
-/* ArchiveEntry::rename
- * Renames the entry
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::rename
+//
+// Renames the entry
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::rename(string new_name)
 {
 	// Check if locked
@@ -320,10 +357,12 @@ bool ArchiveEntry::rename(string new_name)
 	return true;
 }
 
-/* ArchiveEntry::resize
- * Resizes the entry to [new_size]. If [preserve_data] is true, any
- * existing data is preserved
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::resize
+//
+// Resizes the entry to [new_size]. If [preserve_data] is true, any existing
+// data is preserved
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::resize(uint32_t new_size, bool preserve_data)
 {
 	// Check if locked
@@ -339,9 +378,11 @@ bool ArchiveEntry::resize(uint32_t new_size, bool preserve_data)
 	return data.reSize(new_size, preserve_data);
 }
 
-/* ArchiveEntry::clearData
- * Clears entry data and resets its size to zero
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::clearData
+//
+// Clears entry data and resets its size to zero
+// ----------------------------------------------------------------------------
 void ArchiveEntry::clearData()
 {
 	// Check if locked
@@ -359,11 +400,13 @@ void ArchiveEntry::clearData()
 	data_loaded = false;
 }
 
-/* ArchiveEntry::importMem
- * Imports a chunk of memory into the entry, resizing it and clearing
- * any currently existing data.
- * Returns false if data pointer is invalid, true otherwise
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::importMem
+//
+// Imports a chunk of memory into the entry, resizing it and clearing any
+// currently existing data.
+// Returns false if data pointer is invalid, true otherwise
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::importMem(const void* data, uint32_t size)
 {
 	// Check parameters
@@ -392,11 +435,13 @@ bool ArchiveEntry::importMem(const void* data, uint32_t size)
 	return true;
 }
 
-/* ArchiveEntry::importMemChunk
- * Imports data from a MemChunk object into the entry, resizing it
- * and clearing any currently existing data.
- * Returns false if the MemChunk has no data, or true otherwise.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::importMemChunk
+//
+// Imports data from a MemChunk object into the entry, resizing it and clearing
+// any currently existing data.
+// Returns false if the MemChunk has no data, or true otherwise.
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::importMemChunk(MemChunk& mc)
 {
 	// Check that the given MemChunk has data
@@ -409,13 +454,15 @@ bool ArchiveEntry::importMemChunk(MemChunk& mc)
 		return false;
 }
 
-/* ArchiveEntry::importFile
- * Loads a portion of a file into the entry, overwriting any existing
- * data currently in the entry. A size of 0 means load from the
- * offset to the end of the file.
- * Returns false if the file does not exist or the given offset/size
- * are out of bounds, otherwise returns true.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::importFile
+//
+// Loads a portion of a file into the entry, overwriting any existing data
+// currently in the entry. A size of 0 means load from the offset to the end of
+// the file.
+// Returns false if the file does not exist or the given offset/size are out of
+// bounds, otherwise returns true.
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::importFile(string filename, uint32_t offset, uint32_t size)
 {
 	// Check if locked
@@ -457,9 +504,11 @@ bool ArchiveEntry::importFile(string filename, uint32_t offset, uint32_t size)
 	return true;
 }
 
-/* ArchiveEntry::importFileStream
- * Imports [len] data from [file]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::importFileStream
+//
+// Imports [len] data from [file]
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::importFileStream(wxFile& file, uint32_t len)
 {
 	// Check if locked
@@ -484,11 +533,13 @@ bool ArchiveEntry::importFileStream(wxFile& file, uint32_t len)
 	return false;
 }
 
-/* ArchiveEntry::importEntry
- * Imports data from another entry into this entry, resizing it
- * and clearing any currently existing data.
- * Returns false if the entry is null, true otherwise
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::importEntry
+//
+// Imports data from another entry into this entry, resizing it and clearing
+// any currently existing data.
+// Returns false if the entry is null, true otherwise
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::importEntry(ArchiveEntry* entry)
 {
 	// Check if locked
@@ -508,10 +559,12 @@ bool ArchiveEntry::importEntry(ArchiveEntry* entry)
 	return true;
 }
 
-/* ArchiveEntry::exportFile
- * Exports entry data to a file.
- * Returns false if file cannot be written, true otherwise
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::exportFile
+//
+// Exports entry data to a file.
+// Returns false if file cannot be written, true otherwise
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::exportFile(string filename)
 {
 	// Attempt to open file
@@ -532,9 +585,11 @@ bool ArchiveEntry::exportFile(string filename)
 	return true;
 }
 
-/* ArchiveEntry::write
- * Writes data to the entry MemChunk
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::write
+//
+// Writes data to the entry MemChunk
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::write(const void* data, uint32_t size)
 {
 	// Check if locked
@@ -561,9 +616,11 @@ bool ArchiveEntry::write(const void* data, uint32_t size)
 	return false;
 }
 
-/* ArchiveEntry::read
- * Reads data from the entry MemChunk
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::read
+//
+// Reads data from the entry MemChunk
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::read(void* buf, uint32_t size)
 {
 	// Load data if it isn't already
@@ -573,18 +630,21 @@ bool ArchiveEntry::read(void* buf, uint32_t size)
 	return data.read(buf, size);
 }
 
-/* ArchiveEntry::getSizeString
- * Returns the entry's size as a string
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::getSizeString
+//
+// Returns the entry's size as a string
+// ----------------------------------------------------------------------------
 string ArchiveEntry::getSizeString()
 {
 	return Misc::sizeAsString(getSize());
 }
 
-/* ArchiveEntry::stateChanged
- * Notifies the entry's parent archive that the entry has been
- * modified
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::stateChanged
+//
+// Notifies the entry's parent archive that the entry has been modified
+// ----------------------------------------------------------------------------
 void ArchiveEntry::stateChanged()
 {
 	Archive* parent_archive = getParent();
@@ -592,10 +652,11 @@ void ArchiveEntry::stateChanged()
 		parent_archive->entryStateChanged(this);
 }
 
-/* ArchiveEntry::setExtensionByType
- * Sets the entry's name extension to the extension defined in its
- * EntryType
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::setExtensionByType
+//
+// Sets the entry's name extension to the extension defined in its EntryType
+// ----------------------------------------------------------------------------
 void ArchiveEntry::setExtensionByType()
 {
 	// Ignore if the parent archive doesn't support entry name extensions
@@ -616,10 +677,12 @@ void ArchiveEntry::setExtensionByType()
 		rename(fn.GetFullName());
 }
 
-/* ArchiveEntry::isInNamespace
- * Returns true if the entry is in the [ns] namespace within its
- * parent, false otherwise
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// ArchiveEntry::isInNamespace
+//
+// Returns true if the entry is in the [ns] namespace within its parent, false
+// otherwise
+// ----------------------------------------------------------------------------
 bool ArchiveEntry::isInNamespace(string ns)
 {
 	// Can't do this without parent archive
@@ -631,4 +694,25 @@ bool ArchiveEntry::isInNamespace(string ns)
 		ns = "global";	// Graphics namespace doesn't exist in wad files, use global instead
 
 	return getParent()->detectNamespace(this) == ns;
+}
+
+// ----------------------------------------------------------------------------
+// ArchiveEntry::relativeEntry
+//
+// Returns the entry at [path] relative to [base], or failing that, the entry
+// at absolute [path] in the archive (if [allow_absolute_path] is true)
+// ----------------------------------------------------------------------------
+ArchiveEntry* ArchiveEntry::relativeEntry(const string& path, bool allow_absolute_path) const
+{
+	if (!parent)
+		return nullptr;
+
+	// Try relative to this entry
+	auto include = parent->archive()->entryAtPath(getPath() + path);
+
+	// Try absolute path
+	if (!include && allow_absolute_path)
+		include = parent->archive()->entryAtPath(path);
+
+	return include;
 }

--- a/src/Archive/ArchiveEntry.h
+++ b/src/Archive/ArchiveEntry.h
@@ -54,7 +54,7 @@ public:
 	~ArchiveEntry();
 
 	// Accessors
-	string				getName(bool cut_ext = false);
+	string				getName(bool cut_ext = false) const;
 	string				getUpperName();
 	string				getUpperNameNoExt();
 	uint32_t			getSize()			{ if (data_loaded) return data.getSize(); else return size; }
@@ -63,7 +63,7 @@ public:
 	ArchiveTreeNode*	getParentDir()		{ return parent; }
 	Archive*			getParent();
 	Archive*			getTopParent();
-	string				getPath(bool name = false);
+	string				getPath(bool name = false) const;
 	EntryType*			getType()			{ return type; }
 	PropertyList&		exProps()			{ return ex_props; }
 	Property&			exProp(string key)	{ return ex_props[key]; }
@@ -111,12 +111,13 @@ public:
 	uint32_t	currentPos() { return data.currentPos(); }
 
 	// Misc
-	string	getSizeString();
-	string	getTypeString() { if (type) return type->getName(); else return "Unknown"; }
-	void	stateChanged();
-	void	setExtensionByType();
-	int		getTypeReliability() { return (type ? (getType()->getReliability() * reliability / 255) : 0); }
-	bool	isInNamespace(string ns);
+	string			getSizeString();
+	string			getTypeString() { if (type) return type->getName(); else return "Unknown"; }
+	void			stateChanged();
+	void			setExtensionByType();
+	int				getTypeReliability() { return (type ? (getType()->getReliability() * reliability / 255) : 0); }
+	bool			isInNamespace(string ns);
+	ArchiveEntry*	relativeEntry(const string& path, bool allow_absolute_path = true) const;
 
 	size_t	index_guess; // for speed
 };

--- a/src/Dialogs/Preferences/BaseResourceArchivesPanel.cpp
+++ b/src/Dialogs/Preferences/BaseResourceArchivesPanel.cpp
@@ -1,172 +1,144 @@
 
-/*******************************************************************
- * SLADE - It's a Doom Editor
- * Copyright (C) 2008-2014 Simon Judd
- *
- * Email:       sirjuddington@gmail.com
- * Web:         http://slade.mancubus.net
- * Filename:    BaseResourceArchivesPanel.cpp
- * Description: Panel containing controls to select from and modify
- *              saved paths to base resource archives
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2017 Simon Judd
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    BaseResourceArchivesPanel.cpp
+// Description: Panel containing controls to select from and modify saved paths
+//              to base resource archives
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// ----------------------------------------------------------------------------
 
 
-/*******************************************************************
- * INCLUDES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Includes
+//
+// ----------------------------------------------------------------------------
 #include "Main.h"
 #include "BaseResourceArchivesPanel.h"
 #include "Archive/ArchiveManager.h"
 #include "Utility/Parser.h"
+#include "Utility/SFileDialog.h"
 
 
-/*******************************************************************
- * EXTERNAL VARIABLES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// External Variables
+//
+// ----------------------------------------------------------------------------
 EXTERN_CVAR(Int, base_resource)
 EXTERN_CVAR(String, dir_last)
+EXTERN_CVAR(String, zdoom_pk3_path)
 
 
-/*******************************************************************
- * BASERESOURCEARCHIVESPANEL CLASS FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// BaseResourceArchivesPanel Class Functions
+//
+// ----------------------------------------------------------------------------
 
-/* BaseResourceArchivesPanel::BaseResourceArchivesPanel
- * BaseResourceArchivesPanel class constructor
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// BaseResourceArchivesPanel::BaseResourceArchivesPanel
+//
+// BaseResourceArchivesPanel class constructor
+// ----------------------------------------------------------------------------
 BaseResourceArchivesPanel::BaseResourceArchivesPanel(wxWindow* parent)
 	: wxPanel(parent, -1)
 {
 	// Setup sizer
-	wxBoxSizer* hbox = new wxBoxSizer(wxHORIZONTAL);
-	SetSizer(hbox);
+	auto sizer = new wxBoxSizer(wxVERTICAL);
+	SetSizer(sizer);
 
 	// Init paths list
-	//int sel_index = -1;
-	list_base_archive_paths = new wxListBox(this, -1);
+	list_base_archive_paths_ = new wxListBox(this, -1);
 	for (size_t a = 0; a < App::archiveManager().numBaseResourcePaths(); a++)
-	{
-		list_base_archive_paths->Append(App::archiveManager().getBaseResourcePath(a));
-	}
+		list_base_archive_paths_->Append(App::archiveManager().getBaseResourcePath(a));
 
 	// Select the currently open base archive if any
 	if (base_resource >= 0)
-		list_base_archive_paths->Select(base_resource);
+		list_base_archive_paths_->Select(base_resource);
 
 	// Add paths list
-	hbox->Add(list_base_archive_paths, 1, wxEXPAND|wxALL, 4);
+	auto hbox = new wxBoxSizer(wxHORIZONTAL);
+	sizer->Add(hbox, 1, wxEXPAND);
+	hbox->Add(list_base_archive_paths_, 1, wxEXPAND|wxALL, 4);
 
 	// Setup buttons
-	btn_add = new wxButton(this, -1, "Add Archive");
-	btn_remove = new wxButton(this, -1, "Remove Archive");
-	btn_detect = new wxButton(this, -1, "Detect Archives");
+	btn_add_ = new wxButton(this, -1, "Add Archive");
+	btn_remove_ = new wxButton(this, -1, "Remove Archive");
+	btn_detect_ = new wxButton(this, -1, "Detect Archives");
 
-	wxBoxSizer* vbox = new wxBoxSizer(wxVERTICAL);
-	vbox->Add(btn_add, 0, wxEXPAND|wxBOTTOM, 4);
-	vbox->Add(btn_remove, 0, wxEXPAND|wxBOTTOM, 4);
-	vbox->Add(btn_detect, 0, wxEXPAND|wxBOTTOM, 4);
+	auto vbox = new wxBoxSizer(wxVERTICAL);
+	vbox->Add(btn_add_, 0, wxEXPAND|wxBOTTOM, 4);
+	vbox->Add(btn_remove_, 0, wxEXPAND|wxBOTTOM, 4);
+	vbox->Add(btn_detect_, 0, wxEXPAND|wxBOTTOM, 4);
 	hbox->Add(vbox, 0, wxEXPAND|wxALL, 4);
 
+	// ZDoom.pk3 path
+	hbox = new wxBoxSizer(wxHORIZONTAL);
+	sizer->Add(hbox, 0, wxEXPAND | wxALL, 4);
+
+	text_zdoom_pk3_path_ = new wxTextCtrl(this, -1, zdoom_pk3_path, wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+	hbox->Add(new wxStaticText(this, -1, "ZDoom PK3 Path:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 4);
+	hbox->Add(text_zdoom_pk3_path_, 1, wxALIGN_CENTER_VERTICAL);
+
+	btn_browse_zdoom_pk3_ = new wxButton(this, -1, "Browse");
+	hbox->Add(btn_browse_zdoom_pk3_, 0, wxEXPAND | wxLEFT, 4);
+
 	// Bind events
-	btn_add->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnAdd, this);
-	btn_remove->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnRemove, this);
-	btn_detect->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnDetect, this);
+	btn_add_->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnAdd, this);
+	btn_remove_->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnRemove, this);
+	btn_detect_->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnDetect, this);
+	btn_browse_zdoom_pk3_->Bind(wxEVT_BUTTON, &BaseResourceArchivesPanel::onBtnBrowseZDoomPk3, this);
 
 	// Init layout
 	Layout();
 }
 
-/* BaseResourceArchivesPanel::~BaseResourceArchivesPanel
- * BaseResourceArchivesPanel class destructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// BaseResourceArchivesPanel::~BaseResourceArchivesPanel
+//
+// BaseResourceArchivesPanel class destructor
+// ----------------------------------------------------------------------------
 BaseResourceArchivesPanel::~BaseResourceArchivesPanel()
 {
 }
 
-/* BaseResourceArchivesPanel::getSelectedPath
- * Returns the currently selected base resource path
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// BaseResourceArchivesPanel::getSelectedPath
+//
+// Returns the currently selected base resource path
+// ----------------------------------------------------------------------------
 int BaseResourceArchivesPanel::getSelectedPath()
 {
-	return list_base_archive_paths->GetSelection();
-}
-
-
-/*******************************************************************
- * BASERESOURCEARCHIVESPANEL CLASS EVENTS
- *******************************************************************/
-
-/* BaseResourceArchivesPanel::onBtnAdd
- * Called when the 'Add Archive' button is clicked
- *******************************************************************/
-void BaseResourceArchivesPanel::onBtnAdd(wxCommandEvent& e)
-{
-	// Create extensions string
-	string extensions = App::archiveManager().getArchiveExtensionsString();
-
-	// Open a file browser dialog that allows multiple selection
-	wxFileDialog dialog_open(this, "Choose file(s) to open", dir_last, wxEmptyString, extensions, wxFD_OPEN|wxFD_MULTIPLE|wxFD_FILE_MUST_EXIST, wxDefaultPosition);
-
-	// Run the dialog & check that the user didn't cancel
-	if (dialog_open.ShowModal() == wxID_OK)
-	{
-		// Get an array of selected filenames
-		wxArrayString files;
-		dialog_open.GetPaths(files);
-
-		// Add each to the paths list
-		for (size_t a = 0; a < files.size(); a++)
-		{
-			if (App::archiveManager().addBaseResourcePath(files[a]))
-				list_base_archive_paths->Append(files[a]);
-		}
-
-		// Save 'dir_last'
-		dir_last = dialog_open.GetDirectory();
-	}
-}
-
-/* BaseResourceArchivesPanel::onBtnRemove
- * Called when the 'Remove Archive' button is clicked
- *******************************************************************/
-void BaseResourceArchivesPanel::onBtnRemove(wxCommandEvent& e)
-{
-	// Get the selected item index and remove it
-	int index = list_base_archive_paths->GetSelection();
-	list_base_archive_paths->Delete(index);
-
-	// Also remove it from the archive manager
-	App::archiveManager().removeBaseResourcePath(index);
-}
-
-/* BaseResourceArchivesPanel::onBtnDetect
- * Called when the 'Detect Archives' button is clicked
- *******************************************************************/
-void BaseResourceArchivesPanel::onBtnDetect(wxCommandEvent& e)
-{
-	autodetect();
+	return list_base_archive_paths_->GetSelection();
 }
 
 #ifdef __WXMSW__
-/* QueryPathKey
- * Inspired by ZDoom. Automatizes some repetitive steps. Puts the
- * value of a registry key into the reference, and returns true if
- * the value actually exists and isn't an empty string.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// QueryPathKey
+//
+// Inspired by ZDoom. Automatizes some repetitive steps. Puts the value of a
+// registry key into the reference, and returns true if the value actually
+// exists and isn't an empty string.
+// ----------------------------------------------------------------------------
 static bool QueryPathKey(wxRegKey::StdKey hkey, string path, string variable, string &value)
 {
 	wxRegKey key(hkey, path);
@@ -177,9 +149,11 @@ static bool QueryPathKey(wxRegKey::StdKey hkey, string path, string variable, st
 }
 #endif
 
-/* BaseResourceArchivesPanel::autodetect
- * Automatically seek IWADs to populate the list
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// BaseResourceArchivesPanel::autodetect
+//
+// Automatically seek IWADs to populate the list
+// ----------------------------------------------------------------------------
 void BaseResourceArchivesPanel::autodetect()
 {
 	// List of known IWADs and common aliases
@@ -234,10 +208,10 @@ void BaseResourceArchivesPanel::autodetect()
 				if (wxFileExists(iwad))
 				{
 					// Verify existence before adding it to the list
-					if (list_base_archive_paths->FindString(iwad) == wxNOT_FOUND)
+					if (list_base_archive_paths_->FindString(iwad) == wxNOT_FOUND)
 					{
 						App::archiveManager().addBaseResourcePath(iwad);
-						list_base_archive_paths->Append(iwad);
+						list_base_archive_paths_->Append(iwad);
 					}
 				}
 			}
@@ -300,12 +274,91 @@ void BaseResourceArchivesPanel::autodetect()
 		if (wxFileExists(iwad))
 		{
 			// Verify existence before adding it to the list
-			if (list_base_archive_paths->FindString(iwad) == wxNOT_FOUND)
+			if (list_base_archive_paths_->FindString(iwad) == wxNOT_FOUND)
 			{
 				App::archiveManager().addBaseResourcePath(iwad);
-				list_base_archive_paths->Append(iwad);
+				list_base_archive_paths_->Append(iwad);
 			}
 		}
 	}
+}
 
+
+// ----------------------------------------------------------------------------
+//
+// BaseResourceArchivesPanel Class Events
+//
+// ----------------------------------------------------------------------------
+
+
+// ----------------------------------------------------------------------------
+// BaseResourceArchivesPanel::onBtnAdd
+//
+// Called when the 'Add Archive' button is clicked
+// ----------------------------------------------------------------------------
+void BaseResourceArchivesPanel::onBtnAdd(wxCommandEvent& e)
+{
+	// Create extensions string
+	string extensions = App::archiveManager().getArchiveExtensionsString();
+
+	// Open a file browser dialog that allows multiple selection
+	wxFileDialog dialog_open(this, "Choose file(s) to open", dir_last, wxEmptyString, extensions, wxFD_OPEN|wxFD_MULTIPLE|wxFD_FILE_MUST_EXIST, wxDefaultPosition);
+
+	// Run the dialog & check that the user didn't cancel
+	if (dialog_open.ShowModal() == wxID_OK)
+	{
+		// Get an array of selected filenames
+		wxArrayString files;
+		dialog_open.GetPaths(files);
+
+		// Add each to the paths list
+		for (size_t a = 0; a < files.size(); a++)
+		{
+			if (App::archiveManager().addBaseResourcePath(files[a]))
+				list_base_archive_paths_->Append(files[a]);
+		}
+
+		// Save 'dir_last'
+		dir_last = dialog_open.GetDirectory();
+	}
+}
+
+// ----------------------------------------------------------------------------
+// BaseResourceArchivesPanel::onBtnRemove
+//
+// Called when the 'Remove Archive' button is clicked
+// ----------------------------------------------------------------------------
+void BaseResourceArchivesPanel::onBtnRemove(wxCommandEvent& e)
+{
+	// Get the selected item index and remove it
+	int index = list_base_archive_paths_->GetSelection();
+	list_base_archive_paths_->Delete(index);
+
+	// Also remove it from the archive manager
+	App::archiveManager().removeBaseResourcePath(index);
+}
+
+// ----------------------------------------------------------------------------
+// BaseResourceArchivesPanel::onBtnDetect
+//
+// Called when the 'Detect Archives' button is clicked
+// ----------------------------------------------------------------------------
+void BaseResourceArchivesPanel::onBtnDetect(wxCommandEvent& e)
+{
+	autodetect();
+}
+
+// ----------------------------------------------------------------------------
+// BaseResourceArchivesPanel::onBtnBrowseZDoomPk3
+//
+// Called when the 'Browse' for zdoom pk3 button is clicked
+// ----------------------------------------------------------------------------
+void BaseResourceArchivesPanel::onBtnBrowseZDoomPk3(wxCommandEvent& e)
+{
+	SFileDialog::fd_info_t info;
+	if (SFileDialog::openFile(info, "Browse ZDoom PK3", "Pk3 Files (*.pk3)|*.pk3"))
+	{
+		text_zdoom_pk3_path_->SetValue(info.filenames[0]);
+		zdoom_pk3_path = info.filenames[0];
+	}
 }

--- a/src/Dialogs/Preferences/BaseResourceArchivesPanel.h
+++ b/src/Dialogs/Preferences/BaseResourceArchivesPanel.h
@@ -1,6 +1,4 @@
-
-#ifndef __BASERESOURCEARCHIVESPANEL__
-#define __BASERESOURCEARCHIVESPANEL__
+#pragma once
 
 #include "common.h"
 
@@ -8,12 +6,6 @@ class wxListBox;
 class wxButton;
 class BaseResourceArchivesPanel : public wxPanel
 {
-private:
-	wxListBox*	list_base_archive_paths;
-	wxButton*	btn_add;
-	wxButton*	btn_remove;
-	wxButton*	btn_detect;
-
 public:
 	BaseResourceArchivesPanel(wxWindow* parent);
 	~BaseResourceArchivesPanel();
@@ -21,9 +13,17 @@ public:
 	int		getSelectedPath();
 	void	autodetect();
 
+private:
+	wxListBox*	list_base_archive_paths_;
+	wxButton*	btn_add_;
+	wxButton*	btn_remove_;
+	wxButton*	btn_detect_;
+	wxTextCtrl*	text_zdoom_pk3_path_;
+	wxButton*	btn_browse_zdoom_pk3_;
+
+	// Events
 	void	onBtnAdd(wxCommandEvent& e);
 	void	onBtnRemove(wxCommandEvent& e);
 	void	onBtnDetect(wxCommandEvent& e);
+	void	onBtnBrowseZDoomPk3(wxCommandEvent& e);
 };
-
-#endif//__BASERESOURCEARCHIVESPANEL__

--- a/src/Dialogs/Preferences/TextEditorPrefsPanel.cpp
+++ b/src/Dialogs/Preferences/TextEditorPrefsPanel.cpp
@@ -1,39 +1,43 @@
 
-/*******************************************************************
- * SLADE - It's a Doom Editor
- * Copyright (C) 2008-2014 Simon Judd
- *
- * Email:       sirjuddington@gmail.com
- * Web:         http://slade.mancubus.net
- * Filename:    TextEditorPrefsPanel.cpp
- * Description: Panel containing text editor preference controls
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2017 Simon Judd
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    TextEditorPrefsPanel.cpp
+// Description: Panel containing text editor preference controls
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// ----------------------------------------------------------------------------
 
 
-/*******************************************************************
- * INCLUDES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Includes
+//
+// ----------------------------------------------------------------------------
 #include "Main.h"
 #include "TextEditorPrefsPanel.h"
 
 
-/*******************************************************************
- * EXTERNAL VARIABLES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// External Variables
+//
+// ----------------------------------------------------------------------------
 EXTERN_CVAR(Int, txed_tab_width)
 EXTERN_CVAR(Bool, txed_auto_indent)
 EXTERN_CVAR(Bool, txed_syntax_hilight)
@@ -53,176 +57,259 @@ EXTERN_CVAR(Bool, txed_fold_preprocessor)
 EXTERN_CVAR(Bool, txed_fold_lines)
 EXTERN_CVAR(Bool, txed_match_cursor_word)
 EXTERN_CVAR(Int, txed_hilight_current_line)
+EXTERN_CVAR(Int, txed_line_extra_height)
 
 
-/*******************************************************************
- * TEXTEDITORPREFSPANEL CLASS FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// TextEditorPrefsPanel Class Functions
+//
+// ----------------------------------------------------------------------------
 
-/* TextEditorPrefsPanel::TextEditorPrefsPanel
- * TextEditorPrefsPanel class constructor
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// TextEditorPrefsPanel::TextEditorPrefsPanel
+//
+// TextEditorPrefsPanel class constructor
+// ----------------------------------------------------------------------------
 TextEditorPrefsPanel::TextEditorPrefsPanel(wxWindow* parent) : PrefsPanelBase(parent)
 {
 	// Create main sizer
-	wxBoxSizer* psizer = new wxBoxSizer(wxVERTICAL);
+	auto psizer = new wxBoxSizer(wxVERTICAL);
 	SetSizer(psizer);
 
 	// Create frame+sizer
-	wxStaticBox* frame = new wxStaticBox(this, -1, "Text Editor Preferences");
-	wxStaticBoxSizer* sizer = new wxStaticBoxSizer(frame, wxVERTICAL);
+	auto frame = new wxStaticBox(this, -1, "Text Editor Preferences");
+	auto sizer = new wxStaticBoxSizer(frame, wxVERTICAL);
 	psizer->Add(sizer, 1, wxEXPAND|wxALL, 4);
 
+	// --- Whitespace/indentation ---
+	auto gb_sizer = new wxGridBagSizer(4, 4);
+	auto row = 0;
+	sizer->Add(gb_sizer, 0, wxALL | wxEXPAND, 4);
+
 	// Tab width
-	wxBoxSizer* hbox = new wxBoxSizer(wxHORIZONTAL);
-	spin_tab_width = new wxSpinCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER, 1, 100, txed_tab_width);
+	auto hbox = new wxBoxSizer(wxHORIZONTAL);
+	spin_tab_width_ = new wxSpinCtrl(
+		this,
+		-1,
+		wxEmptyString,
+		wxDefaultPosition,
+		wxDefaultSize,
+		wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER,
+		1,
+		100,
+		txed_tab_width
+	);
 	hbox->Add(new wxStaticText(this, -1, "Tab Indentation Width: "), 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 2);
-	hbox->Add(spin_tab_width, 1, wxEXPAND);
-	sizer->Add(hbox, 0, wxALL|wxEXPAND, 4);
+	hbox->Add(spin_tab_width_, 1, wxEXPAND);
+	gb_sizer->Add(hbox, { row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Auto indent
-	cb_auto_indent = new wxCheckBox(this, -1, "Enable Auto-Indent");
-	sizer->Add(cb_auto_indent, 0, wxEXPAND|wxALL, 4);
+	cb_auto_indent_ = new wxCheckBox(this, -1, "Enable Auto-Indent");
+	gb_sizer->Add(cb_auto_indent_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Trim whitespace
-	cb_trim_whitespace = new wxCheckBox(this, -1, "Trim Whitespace on Save");
-	sizer->Add(cb_trim_whitespace, 0, wxEXPAND|wxALL, 4);
+	cb_trim_whitespace_ = new wxCheckBox(this, -1, "Trim Whitespace on Save");
+	gb_sizer->Add(cb_trim_whitespace_, { row, 1 }, wxDefaultSpan, wxEXPAND);
 
 	// Separator
-	sizer->Add(new wxStaticLine(this, -1, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL), 0, wxEXPAND|wxALL, 4);
+	gb_sizer->Add(
+		new wxStaticLine(this, -1, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL),
+		{ ++row, 0 },
+		{ 1, 2 },
+		wxEXPAND | wxTOP | wxBOTTOM,
+		8
+	);
+	
+	// --- Display ---
 
 	// Right margin
 	hbox = new wxBoxSizer(wxHORIZONTAL);
-	spin_right_margin = new wxSpinCtrl(this, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS|wxTE_PROCESS_ENTER, 0, 1000, txed_edge_column);
+	spin_right_margin_ = new wxSpinCtrl(
+		this,
+		-1,
+		wxEmptyString,
+		wxDefaultPosition,
+		wxDefaultSize,
+		wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER,
+		0,
+		1000,
+		txed_edge_column
+	);
 	hbox->Add(new wxStaticText(this, -1, "Right Margin at Column: "), 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 2);
-	hbox->Add(spin_right_margin, 1, wxEXPAND);
-	sizer->Add(hbox, 0, wxALL|wxEXPAND, 4);
-
-	// Syntax Hilighting
-	cb_syntax_hilight = new wxCheckBox(this, -1, "Show Syntax Hilighting");
-	sizer->Add(cb_syntax_hilight, 0, wxEXPAND|wxALL, 4);
+	hbox->Add(spin_right_margin_, 1, wxEXPAND);
+	gb_sizer->Add(hbox, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Indentation guides
-	cb_indent_guides = new wxCheckBox(this, -1, "Show Indentation Guides");
-	sizer->Add(cb_indent_guides, 0, wxEXPAND|wxALL, 4);
+	cb_indent_guides_ = new wxCheckBox(this, -1, "Show Indentation Guides");
+	gb_sizer->Add(cb_indent_guides_, { row, 1 }, wxDefaultSpan, wxEXPAND);
+
+	// Syntax Hilighting
+	cb_syntax_hilight_ = new wxCheckBox(this, -1, "Show Syntax Hilighting");
+	gb_sizer->Add(cb_syntax_hilight_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Hilight current line
 	string choices[] = { "Off", "Background", "Background + Underline" };
 	hbox = new wxBoxSizer(wxHORIZONTAL);
-	choice_line_hilight = new wxChoice(this, -1, wxDefaultPosition, wxDefaultSize, 3, choices);
+	choice_line_hilight_ = new wxChoice(this, -1, wxDefaultPosition, wxDefaultSize, 3, choices);
 	hbox->Add(new wxStaticText(this, -1, "Current Line Hilight: "), 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 2);
-	hbox->Add(choice_line_hilight, 1, wxEXPAND);
-	sizer->Add(hbox, 0, wxALL, 4);
+	hbox->Add(choice_line_hilight_, 1, wxEXPAND);
+	gb_sizer->Add(hbox, { row, 1 }, wxDefaultSpan, wxEXPAND);
 
 	// Brace matching
-	cb_brace_match = new wxCheckBox(this, -1, "Hilight Matching Braces");
-	sizer->Add(cb_brace_match, 0, wxEXPAND|wxALL, 4);
+	cb_brace_match_ = new wxCheckBox(this, -1, "Hilight Matching Braces");
+	gb_sizer->Add(cb_brace_match_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
+
+	// TODO: line extra spacing
+	// Line extra spacing
+	hbox = new wxBoxSizer(wxHORIZONTAL);
+	spin_line_spacing_ = new wxSpinCtrl(
+		this,
+		-1,
+		wxEmptyString,
+		wxDefaultPosition,
+		wxDefaultSize,
+		wxSP_ARROW_KEYS | wxTE_PROCESS_ENTER,
+		0,
+		10,
+		txed_edge_column
+	);
+	hbox->Add(new wxStaticText(this, -1, "Extra Line Spacing: "), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 2);
+	hbox->Add(spin_line_spacing_, 1, wxEXPAND);
+	gb_sizer->Add(hbox, { row, 1 }, wxDefaultSpan, wxEXPAND);
 
 	// Word matching
-	cb_match_cursor_word = new wxCheckBox(this, -1, "Hilight Matching Words");
-	cb_match_cursor_word->SetToolTip(
+	cb_match_cursor_word_ = new wxCheckBox(this, -1, "Hilight Matching Words");
+	cb_match_cursor_word_->SetToolTip(
 		"When enabled, any words matching the word at the current cursor position or selection will be hilighted"
 	);
-	sizer->Add(cb_match_cursor_word, 0, wxEXPAND|wxALL, 4);
+	gb_sizer->Add(cb_match_cursor_word_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Separator
-	sizer->Add(new wxStaticLine(this, -1, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL), 0, wxEXPAND | wxALL, 4);
+	gb_sizer->Add(
+		new wxStaticLine(this, -1, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL),
+		{ ++row, 0 },
+		{ 1, 2 },
+		wxEXPAND | wxTOP | wxBOTTOM,
+		8
+	);
+
+	// --- Calltips ---
 
 	// Calltips on mouse hover
-	cb_calltips_mouse = new wxCheckBox(this, -1, "Show calltips on mouse hover");
-	sizer->Add(cb_calltips_mouse, 0, wxEXPAND|wxALL, 4);
-
-	// Calltips on parenthesis
-	cb_calltips_parenthesis = new wxCheckBox(this, -1, "Show calltips on opening parenthesis");
-	sizer->Add(cb_calltips_parenthesis, 0, wxEXPAND|wxALL, 4);
+	cb_calltips_mouse_ = new wxCheckBox(this, -1, "Show calltips on mouse hover");
+	gb_sizer->Add(cb_calltips_mouse_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Colourise calltips
-	cb_calltips_colourise = new wxCheckBox(this, -1, "Colourise calltip function name and parameter types");
-	sizer->Add(cb_calltips_colourise, 0, wxEXPAND | wxALL, 4);
+	cb_calltips_colourise_ = new wxCheckBox(this, -1, "Colourise calltip text");
+	gb_sizer->Add(cb_calltips_colourise_, { row, 1 }, wxDefaultSpan, wxEXPAND);
+
+	// Calltips on parenthesis
+	cb_calltips_parenthesis_ = new wxCheckBox(this, -1, "Show calltips on opening parenthesis");
+	gb_sizer->Add(cb_calltips_parenthesis_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Dim optional calltip parameters
-	cb_calltips_dim_optional = new wxCheckBox(this, -1, "Dim optional function parameters in calltips");
-	cb_calltips_dim_optional->SetToolTip("If disabled, optional parameters will be shown between [] brackets");
-	sizer->Add(cb_calltips_dim_optional, 0, wxEXPAND | wxALL, 4);
+	cb_calltips_dim_optional_ = new wxCheckBox(this, -1, "Dim optional function parameters");
+	cb_calltips_dim_optional_->SetToolTip("If disabled, optional parameters will be shown between [] brackets");
+	gb_sizer->Add(cb_calltips_dim_optional_, { row, 1 }, wxDefaultSpan, wxEXPAND);
 
 	// Use text editor font in calltips
-	cb_calltips_use_font = new wxCheckBox(this, -1, "Use the text editor font in calltips");
-	sizer->Add(cb_calltips_use_font, 0, wxEXPAND | wxALL, 4);
+	cb_calltips_use_font_ = new wxCheckBox(this, -1, "Use the text editor font in calltips");
+	gb_sizer->Add(cb_calltips_use_font_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Separator
-	sizer->Add(new wxStaticLine(this, -1, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL), 0, wxEXPAND | wxALL, 4);
+	gb_sizer->Add(
+		new wxStaticLine(this, -1, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL),
+		{ ++row, 0 },
+		{ 1, 2 },
+		wxEXPAND | wxTOP | wxBOTTOM,
+		8
+	);
+
+	// --- Folding ---
 
 	// Enable Code Folding
-	cb_fold_enable = new wxCheckBox(this, -1, "Enable Code Folding");
-	sizer->Add(cb_fold_enable, 0, wxEXPAND | wxALL, 4);
+	cb_fold_enable_ = new wxCheckBox(this, -1, "Enable Code Folding");
+	gb_sizer->Add(cb_fold_enable_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
 
 	// Fold Comments
-	cb_fold_comments = new wxCheckBox(this, -1, "Fold comment blocks");
-	sizer->Add(cb_fold_comments, 0, wxEXPAND | wxALL, 4);
-
-	// Fold Preprcessor
-	cb_fold_preprocessor = new wxCheckBox(this, -1, "Fold preprocessor regions");
-	cb_fold_preprocessor->SetToolTip("Enable folding for preprocessor regions, eg. #if/#endif, #region/#endregion");
-	sizer->Add(cb_fold_preprocessor, 0, wxEXPAND | wxALL, 4);
+	cb_fold_comments_ = new wxCheckBox(this, -1, "Fold comment blocks");
+	gb_sizer->Add(cb_fold_comments_, { row, 1 }, wxDefaultSpan, wxEXPAND);
 
 	// Fold Lines
-	cb_fold_lines = new wxCheckBox(this, -1, "Show lines at contracted code folding regions");
-	sizer->Add(cb_fold_lines, 0, wxEXPAND | wxALL, 4);
+	cb_fold_lines_ = new wxCheckBox(this, -1, "Show lines at contracted code folding regions");
+	gb_sizer->Add(cb_fold_lines_, { ++row, 0 }, wxDefaultSpan, wxEXPAND);
+
+	// Fold Preprcessor
+	cb_fold_preprocessor_ = new wxCheckBox(this, -1, "Fold preprocessor regions");
+	cb_fold_preprocessor_->SetToolTip("Enable folding for preprocessor regions, eg. #if/#endif, #region/#endregion");
+	gb_sizer->Add(cb_fold_preprocessor_, { row, 1 }, wxDefaultSpan, wxEXPAND);
+
+	gb_sizer->AddGrowableCol(1, 1);
 }
 
-/* TextEditorPrefsPanel::~TextEditorPrefsPanel
- * TextEditorPrefsPanel class destructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextEditorPrefsPanel::~TextEditorPrefsPanel
+//
+// TextEditorPrefsPanel class destructor
+// ----------------------------------------------------------------------------
 TextEditorPrefsPanel::~TextEditorPrefsPanel()
 {
 }
 
-/* TextEditorPrefsPanel::init
- * Initialises panel controls
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextEditorPrefsPanel::init
+//
+// Initialises panel controls
+// ----------------------------------------------------------------------------
 void TextEditorPrefsPanel::init()
 {
-	cb_auto_indent->SetValue(txed_auto_indent);
-	cb_trim_whitespace->SetValue(txed_trim_whitespace);
-	cb_syntax_hilight->SetValue(txed_syntax_hilight);
-	cb_indent_guides->SetValue(txed_indent_guides);
-	cb_brace_match->SetValue(txed_brace_match);
-	cb_match_cursor_word->SetValue(txed_match_cursor_word);
-	cb_calltips_mouse->SetValue(txed_calltips_mouse);
-	cb_calltips_parenthesis->SetValue(txed_calltips_parenthesis);
-	cb_calltips_colourise->SetValue(txed_calltips_colourise);
-	cb_calltips_dim_optional->SetValue(txed_calltips_dim_optional);
-	cb_calltips_use_font->SetValue(txed_calltips_use_font);
-	spin_right_margin->SetValue(txed_edge_column);
-	spin_tab_width->SetValue(txed_tab_width);
-	cb_fold_enable->SetValue(txed_fold_enable);
-	cb_fold_comments->SetValue(txed_fold_comments);
-	cb_fold_preprocessor->SetValue(txed_fold_preprocessor);
-	cb_fold_lines->SetValue(txed_fold_lines);
-	choice_line_hilight->SetSelection(txed_hilight_current_line);
+	cb_auto_indent_->SetValue(txed_auto_indent);
+	cb_trim_whitespace_->SetValue(txed_trim_whitespace);
+	cb_syntax_hilight_->SetValue(txed_syntax_hilight);
+	cb_indent_guides_->SetValue(txed_indent_guides);
+	cb_brace_match_->SetValue(txed_brace_match);
+	cb_match_cursor_word_->SetValue(txed_match_cursor_word);
+	cb_calltips_mouse_->SetValue(txed_calltips_mouse);
+	cb_calltips_parenthesis_->SetValue(txed_calltips_parenthesis);
+	cb_calltips_colourise_->SetValue(txed_calltips_colourise);
+	cb_calltips_dim_optional_->SetValue(txed_calltips_dim_optional);
+	cb_calltips_use_font_->SetValue(txed_calltips_use_font);
+	spin_right_margin_->SetValue(txed_edge_column);
+	spin_tab_width_->SetValue(txed_tab_width);
+	cb_fold_enable_->SetValue(txed_fold_enable);
+	cb_fold_comments_->SetValue(txed_fold_comments);
+	cb_fold_preprocessor_->SetValue(txed_fold_preprocessor);
+	cb_fold_lines_->SetValue(txed_fold_lines);
+	choice_line_hilight_->SetSelection(txed_hilight_current_line);
+	spin_line_spacing_->SetValue(txed_line_extra_height);
 }
 
-/* TextEditorPrefsPanel::applyPreferences
- * Applies preference values from the controls to CVARs
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextEditorPrefsPanel::applyPreferences
+//
+// Applies preference values from the controls to CVARs
+// ----------------------------------------------------------------------------
 void TextEditorPrefsPanel::applyPreferences()
 {
-	txed_auto_indent = cb_auto_indent->GetValue();
-	txed_trim_whitespace = cb_trim_whitespace->GetValue();
-	txed_syntax_hilight = cb_syntax_hilight->GetValue();
-	txed_indent_guides = cb_indent_guides->GetValue();
-	txed_brace_match = cb_brace_match->GetValue();
-	txed_match_cursor_word = cb_match_cursor_word->GetValue();
-	txed_tab_width = spin_tab_width->GetValue();
-	txed_edge_column = spin_right_margin->GetValue();
-	txed_calltips_mouse = cb_calltips_mouse->GetValue();
-	txed_calltips_parenthesis = cb_calltips_parenthesis->GetValue();
-	txed_calltips_colourise = cb_calltips_colourise->GetValue();
-	txed_calltips_dim_optional = cb_calltips_dim_optional->GetValue();
-	txed_calltips_use_font = cb_calltips_use_font->GetValue();
-	txed_fold_enable = cb_fold_enable->GetValue();
-	txed_fold_comments = cb_fold_comments->GetValue();
-	txed_fold_preprocessor = cb_fold_preprocessor->GetValue();
-	txed_fold_lines = cb_fold_lines->GetValue();
-	txed_hilight_current_line = choice_line_hilight->GetSelection();
+	txed_auto_indent = cb_auto_indent_->GetValue();
+	txed_trim_whitespace = cb_trim_whitespace_->GetValue();
+	txed_syntax_hilight = cb_syntax_hilight_->GetValue();
+	txed_indent_guides = cb_indent_guides_->GetValue();
+	txed_brace_match = cb_brace_match_->GetValue();
+	txed_match_cursor_word = cb_match_cursor_word_->GetValue();
+	txed_tab_width = spin_tab_width_->GetValue();
+	txed_edge_column = spin_right_margin_->GetValue();
+	txed_calltips_mouse = cb_calltips_mouse_->GetValue();
+	txed_calltips_parenthesis = cb_calltips_parenthesis_->GetValue();
+	txed_calltips_colourise = cb_calltips_colourise_->GetValue();
+	txed_calltips_dim_optional = cb_calltips_dim_optional_->GetValue();
+	txed_calltips_use_font = cb_calltips_use_font_->GetValue();
+	txed_fold_enable = cb_fold_enable_->GetValue();
+	txed_fold_comments = cb_fold_comments_->GetValue();
+	txed_fold_preprocessor = cb_fold_preprocessor_->GetValue();
+	txed_fold_lines = cb_fold_lines_->GetValue();
+	txed_hilight_current_line = choice_line_hilight_->GetSelection();
+	txed_line_extra_height = spin_line_spacing_->GetValue();
 }

--- a/src/Dialogs/Preferences/TextEditorPrefsPanel.h
+++ b/src/Dialogs/Preferences/TextEditorPrefsPanel.h
@@ -1,37 +1,34 @@
-
-#ifndef __TEXT_EDITOR_PREFS_PANEL_H__
-#define __TEXT_EDITOR_PREFS_PANEL_H__
+#pragma once
 
 #include "PrefsPanelBase.h"
 
 class TextEditorPrefsPanel : public PrefsPanelBase
 {
-private:
-	wxSpinCtrl*	spin_tab_width;
-	wxCheckBox*	cb_auto_indent;
-	wxCheckBox*	cb_trim_whitespace;
-	wxCheckBox*	cb_syntax_hilight;
-	wxCheckBox*	cb_brace_match;
-	wxSpinCtrl*	spin_right_margin;
-	wxCheckBox*	cb_indent_guides;
-	wxCheckBox*	cb_calltips_mouse;
-	wxCheckBox*	cb_calltips_parenthesis;
-	wxCheckBox*	cb_calltips_colourise;
-	wxCheckBox*	cb_calltips_dim_optional;
-	wxCheckBox*	cb_calltips_use_font;
-	wxCheckBox*	cb_fold_enable;
-	wxCheckBox*	cb_fold_comments;
-	wxCheckBox*	cb_fold_preprocessor;
-	wxCheckBox*	cb_fold_lines;
-	wxCheckBox*	cb_match_cursor_word;
-	wxChoice*	choice_line_hilight;
-
 public:
 	TextEditorPrefsPanel(wxWindow* parent);
 	~TextEditorPrefsPanel();
 
-	void	init();
-	void	applyPreferences();
-};
+	void	init() override;
+	void	applyPreferences() override;
 
-#endif//__TEXT_EDITOR_PREFS_PANEL_H__
+private:
+	wxSpinCtrl*	spin_tab_width_;
+	wxCheckBox*	cb_auto_indent_;
+	wxCheckBox*	cb_trim_whitespace_;
+	wxCheckBox*	cb_syntax_hilight_;
+	wxCheckBox*	cb_brace_match_;
+	wxSpinCtrl*	spin_right_margin_;
+	wxSpinCtrl*	spin_line_spacing_;
+	wxCheckBox*	cb_indent_guides_;
+	wxCheckBox*	cb_calltips_mouse_;
+	wxCheckBox*	cb_calltips_parenthesis_;
+	wxCheckBox*	cb_calltips_colourise_;
+	wxCheckBox*	cb_calltips_dim_optional_;
+	wxCheckBox*	cb_calltips_use_font_;
+	wxCheckBox*	cb_fold_enable_;
+	wxCheckBox*	cb_fold_comments_;
+	wxCheckBox*	cb_fold_preprocessor_;
+	wxCheckBox*	cb_fold_lines_;
+	wxCheckBox*	cb_match_cursor_word_;
+	wxChoice*	choice_line_hilight_;
+};

--- a/src/Dialogs/Preferences/TextEditorPrefsPanel.h
+++ b/src/Dialogs/Preferences/TextEditorPrefsPanel.h
@@ -13,6 +13,7 @@ public:
 
 private:
 	wxSpinCtrl*	spin_tab_width_;
+	wxCheckBox*	cb_tab_spaces_;
 	wxCheckBox*	cb_auto_indent_;
 	wxCheckBox*	cb_trim_whitespace_;
 	wxCheckBox*	cb_syntax_hilight_;
@@ -31,4 +32,5 @@ private:
 	wxCheckBox*	cb_fold_lines_;
 	wxCheckBox*	cb_match_cursor_word_;
 	wxChoice*	choice_line_hilight_;
+	wxChoice*	choice_show_whitespace_;
 };

--- a/src/Game/Configuration.cpp
+++ b/src/Game/Configuration.cpp
@@ -42,6 +42,7 @@
 #include "Utility/Parser.h"
 #include "Utility/StringUtils.h"
 #include "Decorate.h"
+#include "ZScript.h"
 
 using namespace Game;
 
@@ -1437,9 +1438,19 @@ void Configuration::clearDecorateDefs()
 }
 
 // ----------------------------------------------------------------------------
+// Configuration::importZScriptDefs
+//
+// Imports parsed classes from ZScript [defs] as thing types
+// ----------------------------------------------------------------------------
+void Configuration::importZScriptDefs(ZScript::Definitions& defs)
+{
+	defs.exportThingTypes(thing_types_, parsed_types_);
+}
+
+// ----------------------------------------------------------------------------
 // Configuration::parseMapInfo
 //
-// Parses all (Z/E/U)MAPINFO definitions in [archive]
+// Parses all *MAPINFO definitions in [archive]
 // ----------------------------------------------------------------------------
 bool Configuration::parseMapInfo(Archive* archive)
 {
@@ -1449,22 +1460,23 @@ bool Configuration::parseMapInfo(Archive* archive)
 // ----------------------------------------------------------------------------
 // Configuration::linkDoomEdNums
 //
-// Attempts to find editor numbers in *MAPINFO for parsed DECORATE types that
-// were not given one along with their definition
+// Attempts to find editor numbers in *MAPINFO for parsed DECORATE/ZScript
+// types that were not given one along with their definition
 // ----------------------------------------------------------------------------
 void Configuration::linkDoomEdNums()
 {
-	for (auto& i : parsed_types_)
+	for (auto& parsed : parsed_types_)
 	{
 		// Find MAPINFO editor number for parsed actor class
-		int ednum = map_info_.doomEdNumForClass(i.first);
+		int ednum = map_info_.doomEdNumForClass(parsed.className());
+		Log::debug(S_FMT("Find doomednum for class %s", CHR(parsed.className())));
 
 		if (ednum >= 0)
 		{
 			// Editor number found, copy the definition to thing types map
-			thing_types_[ednum].define(ednum, i.second.name(), i.second.group());
-			thing_types_[ednum].copy(i.second);
-			Log::info(2, S_FMT("Linked parsed DECORATE actor %s to DoomEdNum %d", CHR(i.first), ednum));
+			thing_types_[ednum].define(ednum, parsed.name(), parsed.group());
+			thing_types_[ednum].copy(parsed);
+			Log::info(2, S_FMT("Linked parsed class %s to DoomEdNum %d", CHR(parsed.className()), ednum));
 		}
 	}
 }

--- a/src/Game/Configuration.cpp
+++ b/src/Game/Configuration.cpp
@@ -1469,7 +1469,6 @@ void Configuration::linkDoomEdNums()
 	{
 		// Find MAPINFO editor number for parsed actor class
 		int ednum = map_info_.doomEdNumForClass(parsed.className());
-		Log::debug(S_FMT("Find doomednum for class %s", CHR(parsed.className())));
 
 		if (ednum >= 0)
 		{

--- a/src/Game/Configuration.h
+++ b/src/Game/Configuration.h
@@ -14,6 +14,7 @@ class Archive;
 class MapLine;
 class MapThing;
 class MapObject;
+namespace ZScript { class Definitions; }
 
 namespace Game
 {
@@ -131,6 +132,9 @@ namespace Game
 		bool	parseDecorateDefs(Archive* archive);
 		void	clearDecorateDefs();
 
+		// ZScript
+		void	importZScriptDefs(ZScript::Definitions& defs);
+
 		// MapInfo
 		bool	parseMapInfo(Archive* archive);
 		void	clearMapInfo() { map_info_.clear(); }
@@ -206,7 +210,8 @@ namespace Game
 		// Thing types
 		std::map<int, ThingType>	thing_types_;
 		std::map<string, ThingType>	tt_group_defaults_;
-		std::map<string, ThingType> parsed_types_;		// ThingTypes parsed from definitions
+		vector<ThingType>			parsed_types_;
+		//std::map<string, ThingType> parsed_types_;		// ThingTypes parsed from definitions
 														// (DECORATE, ZScript etc.)
 
 		// Flags

--- a/src/Game/Decorate.cpp
+++ b/src/Game/Decorate.cpp
@@ -40,6 +40,17 @@
 
 using namespace Game;
 
+
+// ----------------------------------------------------------------------------
+//
+// Variables
+//
+// ----------------------------------------------------------------------------
+namespace
+{
+	EntryType* etype_decorate = nullptr;
+}
+
 // ----------------------------------------------------------------------------
 //
 // Local Functions
@@ -47,19 +58,6 @@ using namespace Game;
 // ----------------------------------------------------------------------------
 namespace
 {
-
-struct DecorateState
-{
-	struct Frame
-	{
-		string	sprite_base;
-		string	sprite_frame;
-		int		duration;
-	};
-
-	string			name;
-	vector<Frame>	frames;
-};
 
 // ----------------------------------------------------------------------------
 // parseStates
@@ -627,6 +625,10 @@ void parseDecorateEntry(ArchiveEntry* entry, std::map<int, ThingType>& types, ve
 
 		tz.advIf("}");
 	}
+
+	// Set entry type
+	if (etype_decorate && entry->getType() != etype_decorate)
+		entry->setType(etype_decorate);
 }
 
 } // namespace
@@ -658,6 +660,11 @@ bool Game::readDecorateDefs(Archive* archive, std::map<int, ThingType>& types, v
 		return false;
 
 	Log::info(2, S_FMT("Parsing DECORATE entries found in archive %s", archive->filename()));
+
+	// Get DECORATE entry type (all parsed DECORATE entries will be set to this)
+	etype_decorate = EntryType::getType("decorate");
+	if (etype_decorate == EntryType::unknownType())
+		etype_decorate = nullptr;
 
 	// Parse DECORATE entries
 	for (auto entry : decorate_entries)

--- a/src/Game/Decorate.cpp
+++ b/src/Game/Decorate.cpp
@@ -51,6 +51,7 @@ namespace
 	EntryType* etype_decorate = nullptr;
 }
 
+
 // ----------------------------------------------------------------------------
 //
 // Local Functions
@@ -592,8 +593,6 @@ void parseDecorateEntry(ArchiveEntry* entry, std::map<int, ThingType>& types, ve
 	// --- Parse ---
 	while (!tz.atEnd())
 	{
-		Log::debug(2, S_FMT("token %s", CHR(tz.current().text)));
-
 		// Check for #include
 		if (tz.checkNC("#include"))
 		{

--- a/src/Game/Decorate.h
+++ b/src/Game/Decorate.h
@@ -20,6 +20,6 @@ namespace Game
 	bool readDecorateDefs(
 		Archive* archive,
 		std::map<int, ThingType>& types,
-		std::map<string, ThingType>& parsed
+		vector<ThingType>& parsed
 	);
 }

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -244,7 +244,7 @@ void Game::updateCustomDefinitions()
 
 	// Parse custom definitions in all resource archives
 	vector<Archive*> resource_archives;
-	for (unsigned a = 0; a < App::archiveManager().numArchives(); a++)
+	for (auto a = 0; a < App::archiveManager().numArchives(); a++)
 	{
 		auto archive = App::archiveManager().getArchive(a);
 		if (App::archiveManager().archiveIsResource(archive))

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -100,4 +100,7 @@ namespace Game
 
 	// Tagging
 	TagType		parseTagged(ParseTreeNode* tagged);
+
+	// Custom definitions (ZScript, DECORATE, EDF, etc.)
+	void	updateCustomDefinitions();
 }

--- a/src/Game/MapInfo.cpp
+++ b/src/Game/MapInfo.cpp
@@ -181,11 +181,10 @@ bool MapInfo::parseZMapInfo(ArchiveEntry* entry)
 		// Unknown block (skip it)
 		else if (tz.check("{"))
 		{
-			LOG_MESSAGE(
-				2,
+			Log::warning(2, S_FMT(
 				"Warning - Parsing ZMapInfo \"%s\": Skipping {} block",
 				entry->getName()
-			);
+			));
 
 			tz.adv();
 			tz.skipSection("{", "}");
@@ -213,15 +212,12 @@ bool MapInfo::parseZMapInfo(ArchiveEntry* entry)
 bool MapInfo::parseZMap(Tokenizer& tz, string type)
 {
 	// TODO: Handle adddefaultmap
-	Log::debug(2, S_FMT("Map type %s", CHR(type)));
-
 	Map map = default_map_;
 
 	// Normal map, get lump/name/etc
 	tz.adv();
 	if (type == "map")
 	{
-		Log::debug(2, "MAP TYPE");
 		// Entry name should be just after map keyword
 		map.entry_name = tz.current().text;
 
@@ -231,13 +227,11 @@ bool MapInfo::parseZMap(Tokenizer& tz, string type)
 		{
 			map.lookup_name = true;
 			map.name = tz.next().text;
-			Log::debug(2, S_FMT("map name lookup %s", CHR(map.name)));
 		}
 		else
 		{
 			map.lookup_name = false;
 			map.name = tz.current().text;
-			Log::debug(2, S_FMT("map name %s", CHR(map.name)));
 		}
 
 		tz.adv();

--- a/src/Game/ThingType.cpp
+++ b/src/Game/ThingType.cpp
@@ -57,12 +57,13 @@ ThingType ThingType::unknown_;
 //
 // ThingType class constructor
 // ----------------------------------------------------------------------------
-ThingType::ThingType(const string& name, const string& group) :
+ThingType::ThingType(const string& name, const string& group, const string& class_name) :
 	name_{ name },
 	group_{ group },
 	colour_{ 170, 170, 180, 255, 0 },
 	radius_{ 20 },
 	height_{ -1 },
+	scale_{ 1.0, 1.0 },
 	angled_{ true },
 	hanging_{ false },
 	shrink_{ false },
@@ -76,7 +77,7 @@ ThingType::ThingType(const string& name, const string& group) :
 	flags_{ 0 },
 	tagged_{ TagType::None },
 	number_{ -1 },
-	scale_{ 1.0, 1.0 }
+	class_name_{ class_name }
 {
 	// Init args
 	args_.count = 0;

--- a/src/Game/ThingType.h
+++ b/src/Game/ThingType.h
@@ -23,7 +23,7 @@ namespace Game
 			FLAG_OBSOLETE = 1 << 6,		// Thing is flagged as obsolete
 		};
 
-		ThingType(const string& name = "Unknown", const string& group = "");
+		ThingType(const string& name = "Unknown", const string& group = "", const string& class_name = "");
 		~ThingType() {}
 
 		void	copy(const ThingType& copy);
@@ -53,6 +53,7 @@ namespace Game
 		const ArgSpec&	argSpec() const { return args_; }
 		int				number() const { return number_; }
 		bool 			decorate() const { return decorate_; }
+		const string&	className() const { return class_name_; }
 
 		void	setSprite(string sprite) { this->sprite_ = sprite; }
 
@@ -92,6 +93,7 @@ namespace Game
 		int			flags_;
 		TagType		tagged_;
 		int			number_;
+		string		class_name_;
 
 		static ThingType	unknown_;
 	};

--- a/src/Game/ZScript.cpp
+++ b/src/Game/ZScript.cpp
@@ -642,7 +642,7 @@ void parseBlocks(ArchiveEntry* entry, vector<ParsedStatement>& parsed)
 	tz.enableDecorate(true);
 	tz.openMem(entry->getMCData(), "ZScript");
 
-	Log::info(2, S_FMT("Parsing ZScript entry \"%s\"", entry->getPath(true)));
+	//Log::info(2, S_FMT("Parsing ZScript entry \"%s\"", entry->getPath(true)));
 
 	while (!tz.atEnd())
 	{

--- a/src/Game/ZScript.cpp
+++ b/src/Game/ZScript.cpp
@@ -20,11 +20,19 @@ namespace ZScript
 
 string parseType(const vector<string>& tokens, unsigned& index)
 {
-	auto type = tokens[index];
+	string type;
 
-	// Check for 'out'
-	if (S_CMPNOCASE(type, "out"))
-		type = "out " + tokens[++index];
+	// Qualifiers
+	while (index < tokens.size())
+	{
+		if (S_CMPNOCASE(tokens[index], "in") ||
+			S_CMPNOCASE(tokens[index], "out"))
+			type += tokens[index++] + " ";
+		else
+			break;
+	}
+
+	type += tokens[index];
 
 	// Check for ...
 	if (index + 2 < tokens.size() && tokens[index] == "." && tokens[index + 1] == "." && tokens[index + 2] == ".")

--- a/src/Game/ZScript.cpp
+++ b/src/Game/ZScript.cpp
@@ -1,0 +1,572 @@
+
+#include "Main.h"
+#include "ZScript.h"
+#include "Archive/Archive.h"
+#include "Utility/Tokenizer.h"
+
+namespace ZScript
+{
+	bool dump_parsed_blocks = false;
+}
+
+
+using namespace ZScript;
+
+
+
+bool Enumerator::parse(ParsedStatement& statement)
+{
+	// Check valid statement
+	if (statement.block.empty())
+		return false;
+	if (statement.tokens.size() < 2)
+		return false;
+
+	// Parse name
+	name_ = statement.tokens[1];
+
+	// Parse values
+	unsigned index = 0;
+	unsigned count = statement.block[0].tokens.size();
+	while (index < count)
+	{
+		string val_name = statement.block[0].tokens[index];
+
+		// TODO: Parse value
+
+		values_.push_back({ val_name, 0 });
+
+		// Skip past next ,
+		while (index < count)
+			if (statement.block[0].tokens[++index] == ",")
+				break;
+
+		index++;
+	}
+
+	return true;
+}
+
+bool Function::parse(ParsedStatement& statement)
+{
+	unsigned index;
+	unsigned last_qualifier = 0;
+	for (index = 0; index < statement.tokens.size(); index++)
+	{
+		if (S_CMPNOCASE(statement.tokens[index], "virtual"))
+		{
+			virtual_ = true;
+			last_qualifier = index;
+		}
+		else if (S_CMPNOCASE(statement.tokens[index], "static"))
+		{
+			static_ = true;
+			last_qualifier = index;
+		}
+		else if (S_CMPNOCASE(statement.tokens[index], "native"))
+		{
+			native_ = true;
+			last_qualifier = index;
+		}
+		else if (S_CMPNOCASE(statement.tokens[index], "action"))
+		{
+			action_ = true;
+			last_qualifier = index;
+		}
+		else if (index > last_qualifier + 2 && S_CMPNOCASE(statement.tokens[index], "("))
+		{
+			name_ = statement.tokens[index - 1];
+			return_type_ = statement.tokens[index - 2];
+			break;
+		}
+	}
+
+	if (name_.empty() || return_type_.empty())
+		return false;
+
+	// TODO: Parse parameters
+
+	return true;
+}
+
+bool Function::isFunction(ParsedStatement& statement)
+{
+	// Need at least type, name, (, )
+	if (statement.tokens.size() < 4)
+		return false;
+
+	// Check for ( before =
+	bool deprecated_func = false;
+	for (unsigned a = 0; a < statement.tokens.size(); a++)
+	{
+		if (statement.tokens[a] == "=")
+			return false;
+
+		if (!deprecated_func && statement.tokens[a] == "(")
+			return true;
+
+		if (S_CMPNOCASE(statement.tokens[a], "deprecated"))
+			deprecated_func = true;
+		else if (deprecated_func && statement.tokens[a] == ")")
+			deprecated_func = false;
+	}
+
+	// No ( found
+	return false;
+}
+
+
+bool Class::parse(ParsedStatement& class_statement)
+{
+	if (class_statement.tokens.size() < 2)
+		return false;
+
+	name_ = class_statement.tokens[1];
+
+	for (unsigned a = 0; a < class_statement.tokens.size(); a++)
+	{
+		if (class_statement.tokens[a] == ":" && a < class_statement.tokens.size() - 1)
+			inherits_class_ = class_statement.tokens[a + 1];
+		else if (S_CMPNOCASE(class_statement.tokens[a], "native"))
+			native_ = true;
+		else if (S_CMPNOCASE(class_statement.tokens[a], "deprecated"))
+			deprecated_ = true;
+	}
+
+	for (auto& statement : class_statement.block)
+	{
+		if (statement.tokens.empty())
+			continue;
+
+		// Default block
+		if (S_CMPNOCASE(statement.tokens[0], "default"))
+		{
+			if (!parseDefaults(statement.block))
+				return false;
+		}
+
+		// Enum
+		else if (S_CMPNOCASE(statement.tokens[0], "enum"))
+		{
+			Enumerator e;
+			if (!e.parse(statement))
+				return false;
+
+			enumerators_.push_back(e);
+		}
+
+		// TODO: States
+		else if (S_CMPNOCASE(statement.tokens[0], "states"))
+			continue;
+
+		// DB property comment
+		else if (statement.tokens[0].StartsWith("//$"))
+		{
+			if (statement.tokens.size() > 1)
+				db_properties_.push_back({ statement.tokens[0].substr(3),  statement.tokens[1] });
+			else
+				db_properties_.push_back({ statement.tokens[0].substr(3), "true" });
+		}
+
+		// Function
+		else if (Function::isFunction(statement))
+		{
+			Function fn;
+			if (fn.parse(statement))
+				functions_.push_back(fn);
+		}
+
+		// Variable
+		else if (statement.tokens.size() >= 2 && statement.block.empty())
+			continue;
+	}
+
+	// Add DB comment props to default properties
+	for (auto& i : db_properties_)
+	{
+		// Sprite
+		if (S_CMPNOCASE(i.first, "EditorSprite") || S_CMPNOCASE(i.first, "Sprite"))
+			default_properties_["sprite"] = i.second;
+
+		// Angled
+		else if (S_CMPNOCASE(i.first, "Angled"))
+			default_properties_["angled"] = true;
+		else if (S_CMPNOCASE(i.first, "NotAngled"))
+			default_properties_["angled"] = false;
+
+		// Is Decoration
+		else if (S_CMPNOCASE(i.first, "IsDecoration"))
+			default_properties_["decoration"] = true;
+
+		// Icon
+		else if (S_CMPNOCASE(i.first, "Icon"))
+			default_properties_["icon"] = i.second;
+
+		// DB2 Color
+		else if (S_CMPNOCASE(i.first, "Color"))
+			default_properties_["color"] = i.second;
+
+		// SLADE 3 Colour (overrides DB2 color)
+		// Good thing US spelling differs from ABC (Aussie/Brit/Canuck) spelling! :p
+		else if (S_CMPNOCASE(i.first, "Colour"))
+			default_properties_["colour"] = i.second;
+
+		// Obsolete thing
+		else if (S_CMPNOCASE(i.first, "Obsolete"))
+			default_properties_["obsolete"] = true;
+	}
+
+	return true;
+}
+
+void Class::toThingType(std::map<int, Game::ThingType>& types, vector<Game::ThingType>& parsed)
+{
+	// Find existing definition
+	Game::ThingType* def = nullptr;
+
+	// Check types with ednums first
+	for (auto& type : types)
+		if (S_CMPNOCASE(name_, type.second.className()))
+		{
+			def = &type.second;
+			break;
+		}
+	if (!def)
+	{
+		// Check all parsed types
+		for (auto& type : parsed)
+			if (S_CMPNOCASE(name_, type.className()))
+			{
+				def = &type;
+				break;
+			}
+	}
+
+	// Create new type if it didn't exist
+	if (!def)
+	{
+		parsed.push_back(Game::ThingType(name_, "ZScript", name_));
+		def = &parsed.back();
+	}
+
+	// Set properties from DB comments
+	string title = name_;
+	string group = "ZScript";
+	for (auto& prop : db_properties_)
+	{
+		if (S_CMPNOCASE(prop.first, "Title"))
+			title = prop.second;
+		else if (S_CMPNOCASE(prop.first, "Group") || S_CMPNOCASE(prop.first, "Category"))
+			group = "ZScript/" + prop.second;
+	}
+	def->define(def->number(), title, group);
+
+	// Set properties from defaults section
+	def->loadProps(default_properties_);
+}
+
+bool Class::parseDefaults(vector<ParsedStatement>& defaults)
+{
+	for (auto& statement : defaults)
+	{
+		if (statement.tokens.empty())
+			continue;
+
+		// DB property comment
+		if (statement.tokens[0].StartsWith("//$"))
+		{
+			if (statement.tokens.size() > 1)
+				db_properties_.push_back({ statement.tokens[0].substr(3),  statement.tokens[1] });
+			else
+				db_properties_.push_back({ statement.tokens[0].substr(3), "true" });
+			continue;
+		}
+
+		// Flags
+		unsigned t = 0;
+		unsigned count = statement.tokens.size();
+		while (t < count)
+		{
+			if (statement.tokens[t] == "+")
+				default_properties_[statement.tokens[++t]] = true;
+			else if (statement.tokens[t] == "-")
+				default_properties_[statement.tokens[++t]] = false;
+			else
+				break;
+
+			t++;
+		}
+
+		// Name + Value
+		// For now ignore anything after the first whitespace/special character
+		// so stuff like arithmetic expressions or comma separated lists won't
+		// really work properly yet
+		if (t < count - 1)
+			default_properties_[statement.tokens[t]] = statement.tokens[t + 1];
+
+		// Name only
+		else if (t < count)
+			default_properties_[statement.tokens[t]] = true;
+	}
+
+	return true;
+}
+
+
+
+
+
+void parseBlocks(ArchiveEntry* entry, vector<ParsedStatement>& parsed)
+{
+	Tokenizer tz;
+	tz.setSpecialCharacters(Tokenizer::DEFAULT_SPECIAL_CHARACTERS + "()+-<>[].&!?");
+	tz.enableDecorate(true);
+	tz.openMem(entry->getMCData(), "ZScript");
+
+	Log::info(2, S_FMT("Parsing ZScript entry \"%s\"", entry->getPath(true)));
+
+	while (!tz.atEnd())
+	{
+		// Preprocessor
+		if (tz.current().text.StartsWith("#"))
+		{
+			if (tz.checkNC("#include"))
+			{
+				auto inc_entry = entry->relativeEntry(tz.next().text);
+
+				// Check #include path could be resolved
+				if (!inc_entry)
+				{
+					Log::warning(
+						S_FMT(
+							"Warning parsing ZScript entry %s: "
+							"Unable to find #included entry \"%s\" at line %d, skipping",
+							CHR(entry->getName()),
+							CHR(tz.current().text),
+							tz.current().line_no
+						));
+				}
+				else
+					parseBlocks(inc_entry, parsed);
+			}
+
+			tz.advToNextLine();
+			continue;
+		}
+
+		// Version
+		else if (tz.checkNC("version"))
+		{
+			tz.advToNextLine();
+			continue;
+		}
+
+		// ZScript
+		ParsedStatement block;
+		if (block.parse(tz))
+			parsed.push_back(std::move(block));
+	}
+}
+
+void Definitions::clear()
+{
+	classes_.clear();
+	enumerators_.clear();
+	variables_.clear();
+	functions_.clear();
+}
+
+bool Definitions::parseZScript(ArchiveEntry* entry)
+{
+	// Parse into tree of expressions and blocks
+	vector<ParsedStatement> parsed;
+	parseBlocks(entry, parsed);
+
+	for (auto& block : parsed)
+	{
+		if (block.tokens.empty())
+			continue;
+
+		if (dump_parsed_blocks)
+			block.dump();
+
+		if (S_CMPNOCASE(block.tokens[0], "class"))
+		{
+			Class nc(Class::Type::Class);
+
+			if (!nc.parse(block))
+				return false;
+
+			classes_.push_back(nc);
+		}
+
+		else if (S_CMPNOCASE(block.tokens[0], "struct"))
+		{
+			Class nc(Class::Type::Struct);
+
+			if (!nc.parse(block))
+				return false;
+
+			classes_.push_back(nc);
+		}
+	}
+
+	return true;
+}
+
+bool Definitions::parseZScript(Archive* archive)
+{
+	// Get base decorate file
+	Archive::SearchOptions opt;
+	opt.match_name = "zscript";
+	opt.ignore_ext = true;
+	vector<ArchiveEntry*> zscript_enries = archive->findAll(opt);
+	if (zscript_enries.empty())
+		return false;
+
+	Log::info(2, S_FMT("Parsing ZScript entries found in archive %s", archive->filename()));
+
+	// Parse DECORATE entries
+	bool ok = true;
+	for (auto entry : zscript_enries)
+		if (!parseZScript(entry))
+			ok = false;
+
+	return ok;
+}
+
+void Definitions::exportThingTypes(std::map<int, Game::ThingType>& types, vector<Game::ThingType>& parsed)
+{
+	for (auto& cdef : classes_)
+		cdef.toThingType(types, parsed);
+}
+
+
+bool ParsedStatement::parse(Tokenizer& tz, bool first_expression)
+{
+	auto start_line = tz.lineNo();
+
+	// Tokens
+	bool in_initializer = false;
+	while (true)
+	{
+		// End of statement (;)
+		if (tz.advIf(";"))
+			return true;
+
+		// DB comment
+		if (tz.current().text.StartsWith("//$"))
+		{
+			tokens.push_back(tz.current().text);
+			tokens.push_back(tz.getLine());
+			return true;
+		}
+
+		if (tz.check("}"))
+		{
+			// End of array initializer
+			if (in_initializer)
+			{
+				in_initializer = false;
+				tokens.push_back("}");
+				tz.adv();
+				continue;
+			}
+
+			// End of statement
+			//if (first_expression)
+				return true;
+		}
+
+		if (tz.atEnd())
+		{
+			Log::debug(S_FMT("Failed parsing zscript expression beginning line %d", start_line));
+			return false;
+		}
+
+		// Beginning of block
+		if (tz.advIf("{"))
+			break;
+
+		// Array initializer: ... = { ... }
+		if (tz.current().text == "=" && tz.peek().text == "{")
+		{
+			tokens.push_back("=");
+			tokens.push_back("{");
+			tz.adv(2);
+			in_initializer = true;
+			continue;
+		}
+		
+		tokens.push_back(tz.current().text);
+		tz.adv();
+	}
+
+	// Block
+	while (true)
+	{
+		if (tz.advIf("}"))
+			return true;
+
+		if (tz.atEnd())
+		{
+			Log::debug(S_FMT("Failed parsing zscript expression beginning line %d", start_line));
+			return false;
+		}
+
+		ParsedStatement expression;
+		if (!expression.parse(tz, block.empty()))
+			return false;
+		if (!expression.tokens.empty())
+			block.push_back(std::move(expression));
+	}
+}
+
+void ParsedStatement::dump(int indent)
+{
+	string line = "";
+	for (int a = 0; a < indent; a++)
+		line += "  ";
+
+	// Tokens
+	for (auto& token : tokens)
+		line += token + " ";
+	Log::debug(line);
+
+	// Blocks
+	for (auto& block : block)
+		block.dump(indent + 1);
+}
+
+
+// TEMP TESTING CONSOLE COMMANDS
+#include "MainEditor/MainEditor.h"
+#include "General/Console/Console.h"
+
+CONSOLE_COMMAND(test_parse_zscript, 0, false)
+{
+	dump_parsed_blocks = false;
+	ArchiveEntry* entry = nullptr;
+
+	for (auto& arg : args)
+	{
+		if (S_CMPNOCASE(arg, "dump"))
+			dump_parsed_blocks = true;
+		else if (!entry)
+			entry = MainEditor::currentArchive()->entryAtPath(arg);
+	}
+
+	if (!entry)
+		entry = MainEditor::currentEntry();
+
+	if (entry)
+	{
+		Definitions test;
+		if (test.parseZScript(entry))
+			Log::console("Parsed Successfully");
+		else
+			Log::console("Parsing failed");
+	}
+	else
+		Log::console("Select an entry or enter a valid entry name/path");
+}

--- a/src/Game/ZScript.h
+++ b/src/Game/ZScript.h
@@ -85,6 +85,7 @@ namespace ZScript
 		bool						isVirtual() const { return virtual_; }
 		bool						isStatic() const { return static_; }
 		bool						isAction() const { return action_; }
+		bool						isOverride() const { return override_; }
 
 		bool	parse(ParsedStatement& statement);
 		string	asString();
@@ -97,6 +98,7 @@ namespace ZScript
 		bool				virtual_	= false;
 		bool				static_		= false;
 		bool				action_		= false;
+		bool				override_	= false;
 	};
 
 	struct State
@@ -140,7 +142,10 @@ namespace ZScript
 		Class(Type type, string name = "") : Identifier{ name }, type_{ type } {}
 		virtual ~Class() {}
 
+		const vector<Function>&	functions() const { return functions_; }
+
 		bool	parse(ParsedStatement& block);
+		bool	extend(ParsedStatement& block);
 		void	toThingType(std::map<int, Game::ThingType>& types, vector<Game::ThingType>& parsed);
 
 	private:
@@ -154,7 +159,8 @@ namespace ZScript
 
 		vector<std::pair<string, string>>	db_properties_;
 
-		bool parseDefaults(vector<ParsedStatement>& defaults);
+		bool	parseClassBlock(vector<ParsedStatement>& block);
+		bool	parseDefaults(vector<ParsedStatement>& defaults);
 	};
 
 	class Definitions	// rename this also
@@ -162,6 +168,8 @@ namespace ZScript
 	public:
 		Definitions() {}
 		~Definitions() {}
+
+		const vector<Class>&	classes() const { return classes_; }
 
 		void	clear();
 		bool	parseZScript(ArchiveEntry* entry);

--- a/src/Game/ZScript.h
+++ b/src/Game/ZScript.h
@@ -40,17 +40,17 @@ namespace ZScript
 	class Identifier	// rename this
 	{
 	public:
-		Identifier(string name = "") : name_{ name }, native_{ false }, deprecated_{ false } {}
+		Identifier(string name = "") : name_{ name }, native_{ false } {}
 		virtual ~Identifier() {}
 
 		string	name() const { return name_; }
 		bool	native() const { return native_; }
-		bool	deprecated() const { return deprecated_; }
+		string	deprecated() const { return deprecated_; }
 
 	protected:
 		string	name_;
 		bool	native_		= false;
-		bool	deprecated_	= false;
+		string	deprecated_;
 	};
 
 	class Variable : public Identifier

--- a/src/Game/ZScript.h
+++ b/src/Game/ZScript.h
@@ -11,6 +11,9 @@ namespace ZScript
 {
 	struct ParsedStatement
 	{
+		ArchiveEntry*	entry = nullptr;
+		int				line;
+
 		vector<string>			tokens;
 		vector<ParsedStatement>	block;
 

--- a/src/Game/ZScript.h
+++ b/src/Game/ZScript.h
@@ -14,7 +14,7 @@ namespace ZScript
 		vector<string>			tokens;
 		vector<ParsedStatement>	block;
 
-		bool	parse(Tokenizer& tz, bool first_expression = false);
+		bool	parse(Tokenizer& tz);
 		void	dump(int indent = 0);
 	};
 
@@ -76,9 +76,18 @@ namespace ZScript
 			string type;
 			string default_value;
 			Parameter() : name{ "<unknown>" }, type{ "<unknown>" }, default_value{ "" } {}
+
+			unsigned parse(const vector<string>& tokens, unsigned start_index);
 		};
 
+		const string&				returnType() const { return return_type_; }
+		const vector<Parameter>&	parameters() const { return parameters_; }
+		bool						isVirtual() const { return virtual_; }
+		bool						isStatic() const { return static_; }
+		bool						isAction() const { return action_; }
+
 		bool	parse(ParsedStatement& statement);
+		string	asString();
 
 		static bool isFunction(ParsedStatement& block);
 
@@ -88,6 +97,35 @@ namespace ZScript
 		bool				virtual_	= false;
 		bool				static_		= false;
 		bool				action_		= false;
+	};
+
+	struct State
+	{
+		struct Frame
+		{
+			string	sprite_base;
+			string	sprite_frame;
+			int		duration;
+		};
+
+		string editorSprite();
+
+		vector<Frame>	frames;
+	};
+
+	class StateTable
+	{
+	public:
+		StateTable() {}
+
+		const string&	firstState() const { return state_first_; }
+
+		bool	parse(ParsedStatement& states);
+		string	editorSprite();
+
+	private:
+		std::map<string, State>	states_;
+		string					state_first_;
 	};
 
 	class Class : public Identifier
@@ -112,6 +150,7 @@ namespace ZScript
 		vector<Function>	functions_;
 		vector<Enumerator>	enumerators_;
 		PropertyList		default_properties_;
+		StateTable			states_;
 
 		vector<std::pair<string, string>>	db_properties_;
 

--- a/src/Game/ZScript.h
+++ b/src/Game/ZScript.h
@@ -49,11 +49,13 @@ namespace ZScript
 		string	name() const { return name_; }
 		bool	native() const { return native_; }
 		string	deprecated() const { return deprecated_; }
+		string	version() const { return version_; }
 
 	protected:
 		string	name_;
 		bool	native_		= false;
 		string	deprecated_;
+		string	version_;
 	};
 
 	class Variable : public Identifier

--- a/src/Game/ZScript.h
+++ b/src/Game/ZScript.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "Utility/PropertyList/PropertyList.h"
+#include "ThingType.h"
+
+class Archive;
+class ArchiveEntry;
+class Tokenizer;
+
+namespace ZScript
+{
+	struct ParsedStatement
+	{
+		vector<string>			tokens;
+		vector<ParsedStatement>	block;
+
+		bool	parse(Tokenizer& tz, bool first_expression = false);
+		void	dump(int indent = 0);
+	};
+
+	class Enumerator
+	{
+	public:
+		Enumerator(string name = "") : name_{ name } {}
+
+		struct Value
+		{
+			string	name;
+			int		value;
+			//Value() : name{name}, value{0} {}
+		};
+
+		bool parse(ParsedStatement& statement);
+
+	private:
+		string			name_;
+		vector<Value>	values_;
+	};
+
+	class Identifier	// rename this
+	{
+	public:
+		Identifier(string name = "") : name_{ name }, native_{ false }, deprecated_{ false } {}
+		virtual ~Identifier() {}
+
+		string	name() const { return name_; }
+		bool	native() const { return native_; }
+		bool	deprecated() const { return deprecated_; }
+
+	protected:
+		string	name_;
+		bool	native_		= false;
+		bool	deprecated_	= false;
+	};
+
+	class Variable : public Identifier
+	{
+	public:
+		Variable(string name = "") : Identifier(name), type_{ "<unknown>" } {}
+		virtual ~Variable() {}
+
+	private:
+		string	type_;
+	};
+
+	class Function : public Identifier
+	{
+	public:
+		Function(string name = "") : Identifier(name), return_type_{ "void" } {}
+		
+		virtual ~Function() {}
+
+		struct Parameter
+		{
+			string name;
+			string type;
+			string default_value;
+			Parameter() : name{ "<unknown>" }, type{ "<unknown>" }, default_value{ "" } {}
+		};
+
+		bool	parse(ParsedStatement& statement);
+
+		static bool isFunction(ParsedStatement& block);
+
+	private:
+		vector<Parameter>	parameters_;
+		string				return_type_;
+		bool				virtual_	= false;
+		bool				static_		= false;
+		bool				action_		= false;
+	};
+
+	class Class : public Identifier
+	{
+	public:
+		enum class Type
+		{
+			Class,
+			Struct
+		};
+
+		Class(Type type, string name = "") : Identifier{ name }, type_{ type } {}
+		virtual ~Class() {}
+
+		bool	parse(ParsedStatement& block);
+		void	toThingType(std::map<int, Game::ThingType>& types, vector<Game::ThingType>& parsed);
+
+	private:
+		Type				type_;
+		string				inherits_class_;
+		vector<Variable>	variables_;
+		vector<Function>	functions_;
+		vector<Enumerator>	enumerators_;
+		PropertyList		default_properties_;
+
+		vector<std::pair<string, string>>	db_properties_;
+
+		bool parseDefaults(vector<ParsedStatement>& defaults);
+	};
+
+	class Definitions	// rename this also
+	{
+	public:
+		Definitions() {}
+		~Definitions() {}
+
+		void	clear();
+		bool	parseZScript(ArchiveEntry* entry);
+		bool	parseZScript(Archive* archive);
+
+		void	exportThingTypes(std::map<int, Game::ThingType>& types, vector<Game::ThingType>& parsed);
+
+	private:
+		vector<Class>		classes_;
+		vector<Enumerator>	enumerators_;
+		vector<Variable>	variables_;
+		vector<Function>	functions_;	// needed? dunno if global functions are a thing
+	};
+}

--- a/src/MainEditor/UI/EntryPanel/TextEntryPanel.cpp
+++ b/src/MainEditor/UI/EntryPanel/TextEntryPanel.cpp
@@ -213,14 +213,10 @@ bool TextEntryPanel::saveEntry()
 	if (entry->getType() == EntryType::unknownType())
 		entry->setType(EntryType::getType("text"));
 
-	// Update DECORATE definitions if decorate
-	if (text_area_->language() && text_area_->language()->id() == "decorate")
-	{
-		Game::configuration().clearDecorateDefs();
-		Game::configuration().parseDecorateDefs(App::archiveManager().baseResourceArchive());
-		for (int i = 0; i < App::archiveManager().numArchives(); ++i)
-			Game::configuration().parseDecorateDefs(App::archiveManager().getArchive(i));
-	}
+	// Update custom definitions if decorate or zscript
+	if (text_area_->language() &&
+		(text_area_->language()->id() == "decorate" || text_area_->language()->id() == "zscript"))
+		Game::updateCustomDefinitions();
 
 	// Update variables
 	setModified(false);

--- a/src/MapEditor/UI/MapEditorWindow.cpp
+++ b/src/MapEditor/UI/MapEditorWindow.cpp
@@ -581,17 +581,8 @@ bool MapEditorWindow::openMap(Archive::MapDesc map)
 	{
 		MapEditor::editContext().mapDesc() = map;
 
-		// Read DECORATE and *MAPINFO definitions if any
-		Game::configuration().clearDecorateDefs();
-		Game::configuration().clearMapInfo();
-		Game::configuration().parseDecorateDefs(App::archiveManager().baseResourceArchive());
-		Game::configuration().parseMapInfo(App::archiveManager().baseResourceArchive());
-		for (int i = 0; i < App::archiveManager().numArchives(); ++i)
-		{
-			Game::configuration().parseDecorateDefs(App::archiveManager().getArchive(i));
-			Game::configuration().parseMapInfo(App::archiveManager().getArchive(i));
-		}
-		Game::configuration().linkDoomEdNums();
+		// Update DECORATE and *MAPINFO definitions
+		Game::updateCustomDefinitions();
 
 		// Load scripts if any
 		loadMapScripts(map);

--- a/src/TextEditor/Lexer.h
+++ b/src/TextEditor/Lexer.h
@@ -6,7 +6,7 @@ class Lexer
 {
 public:
 	Lexer();
-	~Lexer() {}
+	virtual ~Lexer() {}
 
 	enum Style
 	{
@@ -27,11 +27,11 @@ public:
 		Property		= wxSTC_C_UUID,
 	};
 
-	void	loadLanguage(TextLanguage* language);
+	virtual void	loadLanguage(TextLanguage* language);
 
-	bool	doStyling(TextEditorCtrl* editor, int start, int end);
-	void	addWord(string word, int style);
-	void	clearWords() { word_list_.clear(); }
+	virtual bool	doStyling(TextEditorCtrl* editor, int start, int end);
+	virtual void	addWord(string word, int style);
+	virtual void	clearWords() { word_list_.clear(); }
 
 	void	setWordChars(string chars);
 	void	setOperatorChars(string chars);
@@ -40,7 +40,9 @@ public:
 	void	foldComments(bool fold) { fold_comments_ = fold; }
 	void	foldPreprocessor(bool fold) { fold_preprocessor_ = fold; }
 
-private:
+	virtual bool isFunction(TextEditorCtrl* editor, int start_pos, int end_pos);
+
+protected:
 	enum class State
 	{
 		Unknown,
@@ -100,6 +102,22 @@ private:
 	bool	processOperator(LexerState& state);
 	bool	processWhitespace(LexerState& state);
 
-	void	styleWord(TextEditorCtrl* editor, string word);
-	bool	checkToken(TextEditorCtrl* editor, int pos, string& token);
+	virtual void	styleWord(LexerState& state, string word);
+	bool			checkToken(LexerState& state, int pos, string& token);
+};
+
+class ZScriptLexer : public Lexer
+{
+public:
+	ZScriptLexer() {}
+	virtual ~ZScriptLexer() {}
+
+protected:
+	void addWord(string word, int style) override;
+	void styleWord(LexerState& state, string word) override;
+	void clearWords() override;
+	bool isFunction(TextEditorCtrl* editor, int start_pos, int end_pos) override;
+
+private:
+	vector<string>	functions_;
 };

--- a/src/TextEditor/TextLanguage.cpp
+++ b/src/TextEditor/TextLanguage.cpp
@@ -129,7 +129,7 @@ void TLFunction::addContext(
 	const string& return_type,
 	const string& description)
 {
-	contexts_.push_back(Context{ context, {}, return_type, description });
+	contexts_.push_back(Context{ context, {}, return_type, description, "" });
 	auto& ctx = contexts_.back();
 
 	// Parse args
@@ -170,6 +170,11 @@ void TLFunction::addContext(const string& context, const ZScript::Function& func
 	auto& ctx = contexts_.back();
 
 	ctx.return_type = func.returnType();
+
+	if (func.isVirtual())
+		ctx.qualifiers += "virtual ";
+	if (func.native())
+		ctx.qualifiers += "native ";
 
 	for (auto& p : func.parameters())
 		ctx.params.push_back({ p.type, p.name, p.default_value, !p.default_value.empty() });

--- a/src/TextEditor/TextLanguage.cpp
+++ b/src/TextEditor/TextLanguage.cpp
@@ -1,168 +1,193 @@
 
-/*******************************************************************
- * SLADE - It's a Doom Editor
- * Copyright (C) 2008-2014 Simon Judd
- *
- * Email:       sirjuddington@gmail.com
- * Web:         http://slade.mancubus.net
- * Filename:    TextLanguage.cpp
- * Description: Defines a 'language' for use by the TextEditor for
- *              syntax hilighting/autocompletion/etc. Contains lists
- *              of keywords, constants and functions, with various
- *              utility functions for using them.
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2017 Simon Judd
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    TextLanguage.cpp
+// Description: Defines a 'language' for use by the TextEditor for syntax
+//              hilighting/autocompletion/etc. Contains lists of keywords,
+//              constants and functions, with various utility functions for
+//              using them.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// ----------------------------------------------------------------------------
 
 
-/*******************************************************************
- * INCLUDES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Includes
+//
+// ----------------------------------------------------------------------------
 #include "Main.h"
 #include "TextLanguage.h"
 #include "Utility/Tokenizer.h"
 #include "Utility/Parser.h"
 #include "Archive/ArchiveManager.h"
+#include "Game/ZScript.h"
 
 
-/*******************************************************************
- * VARIABLES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Variables
+//
+// ----------------------------------------------------------------------------
 vector<TextLanguage*>	text_languages;
 
 
-/*******************************************************************
- * TLFUNCTION CLASS FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// TLFunction Class Functions
+//
+// ----------------------------------------------------------------------------
 
-/* TLFunction::TLFunction
- * TLFunction class constructor
- *******************************************************************/
-TLFunction::TLFunction(string name, string return_type) :
-	name_{ name },
-	return_type_{ return_type }
+
+// ----------------------------------------------------------------------------
+// TLFunction::TLFunction
+//
+// TLFunction class constructor
+// ----------------------------------------------------------------------------
+TLFunction::TLFunction(string name) :
+	name_{ name }
 {
 }
 
-/* TLFunction::~TLFunction
- * TLFunction class destructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TLFunction::~TLFunction
+//
+// TLFunction class destructor
+// ----------------------------------------------------------------------------
 TLFunction::~TLFunction()
 {
 }
 
-/* TLFunction::getArgSet
- * Returns the arg set [index], or an empty string if [index] is
- * out of bounds
- *******************************************************************/
-TLFunction::ArgSet TLFunction::argSet(unsigned index) const
+// ----------------------------------------------------------------------------
+// TLFunction::getArgSet
+//
+// Returns the arg set [index], or an empty string if [index] is out of bounds
+// ----------------------------------------------------------------------------
+TLFunction::Context TLFunction::context(unsigned index) const
 {
 	// Check index
-	if (index >= arg_sets_.size())
-		return { "", "" };
+	if (index >= contexts_.size())
+		return Context();
 
-	return arg_sets_[index];
+	return contexts_[index];
 }
 
-/* TLFunction::generateCallTipString
- * Returns a string representation of arg set [arg_set] that can be
- * used directly in a scintilla calltip
- *******************************************************************/
-string TLFunction::generateCallTipString(int arg_set)
+// ----------------------------------------------------------------------------
+// TLFunction::Parameter::parse
+//
+// Parses a function parameter from a list of tokens
+// ----------------------------------------------------------------------------
+void TLFunction::Parameter::parse(vector<string>& tokens)
 {
-	// Check requested arg set exists
-	if (arg_set < 0 || (unsigned)arg_set >= arg_sets_.size())
-		return "<invalid argset index>";
+	// Optional
+	if (tokens[0] == "[")
+	{
+		optional = true;
+		tokens.erase(tokens.begin());
+		tokens.pop_back();
+	}
 
-	string calltip;
+	if (tokens.empty())
+		return;
 
-	// Add extra buttons for selection if there is more than one arg set
-	if (arg_sets_.size() > 1)
-		calltip += S_FMT("\001 %d of %lu \002 ", arg_set+1, arg_sets_.size());
-
-	// Generate scintilla-format calltip string
-	calltip += name_ + "(";
-	calltip += arg_sets_[arg_set].args;
-	calltip += ")";
-
-	return calltip;
+	// (Type) and name
+	if (tokens.size() > 1)
+	{
+		type = tokens[0];
+		name = tokens[1];
+	}
+	else
+	{
+		name = tokens[0];
+	}
 }
 
-/* TLFunction::getArgTextExtent
- * Returns the start and end position of [arg] within [arg_set]
- *******************************************************************/
-point2_t TLFunction::getArgTextExtent(int arg, int arg_set)
+// ----------------------------------------------------------------------------
+// TLFunction::addContext
+//
+// Adds a [context] of the function
+// ----------------------------------------------------------------------------
+void TLFunction::addContext(
+	const string& context,
+	const string& args,
+	const string& return_type,
+	const string& description)
 {
-	point2_t extent(-1, -1);
+	contexts_.push_back(Context{ context, {}, return_type, description });
+	auto& ctx = contexts_.back();
 
-	// Check requested arg set exists
-	if (arg_set < 0 || (unsigned)arg_set >= arg_sets_.size())
-		return extent;
+	// Parse args
+	Tokenizer tz;
+	tz.setSpecialCharacters("[],");
+	tz.openString(args);
 
-	// Get start position of args list
-	int start_pos = name_.Length() + 1;
-	if (arg_sets_.size() > 1)
+	vector<string> arg_tokens;
+	while (true)
 	{
-		string temp = S_FMT("\001 %d of %lu \002 ", arg_set+1, arg_sets_.size());
-		start_pos += temp.Length();
-	}
-
-	// Check arg
-	string args = arg_sets_[arg_set].args;
-	if (arg < 0)
-	{
-		extent.set(start_pos, start_pos + args.Length());
-		return extent;
-	}
-
-	// Go through arg set string
-	int current_arg = 0;
-	extent.x = start_pos;
-	extent.y = start_pos + args.Length();
-	for (unsigned a = 0; a < args.Length(); a++)
-	{
-		// Check for ,
-		if (args.at(a) == ',')
+		while (!tz.check(","))
 		{
-			// ',' found, so increment current arg
-			current_arg++;
-
-			// If we're at the start of the arg we want
-			if (current_arg == arg)
-				extent.x = start_pos + a+1;
-
-			// If we've reached the end of the arg we want
-			if (current_arg > arg)
-			{
-				extent.y = start_pos + a;
+			arg_tokens.push_back(tz.current().text);
+			if (tz.atEnd())
 				break;
-			}
+			tz.adv();
 		}
-	}
 
-	return extent;
+		ctx.params.push_back({});
+		ctx.params.back().parse(arg_tokens);
+		arg_tokens.clear();
+
+		if (tz.atEnd())
+			break;
+
+		tz.adv();
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TLFunction::addContext
+//
+// Adds a [context] of the function from a parsed ZScript function [func]
+// ----------------------------------------------------------------------------
+void TLFunction::addContext(const string& context, const ZScript::Function& func)
+{
+	contexts_.push_back(Context{ context, {} });
+	auto& ctx = contexts_.back();
+
+	ctx.return_type = func.returnType();
+
+	for (auto& p : func.parameters())
+		ctx.params.push_back({ p.type, p.name, p.default_value, !p.default_value.empty() });
 }
 
 
-/*******************************************************************
- * TEXTLANGUAGE CLASS FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// TextLanguage Class Functions
+//
+// ----------------------------------------------------------------------------
 
-/* TextLanguage::TextLanguage
- * TextLanguage class constructor
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// TextLanguage::TextLanguage
+//
+// TextLanguage class constructor
+// ----------------------------------------------------------------------------
 TextLanguage::TextLanguage(string id) :
 	line_comment_{ "//" },
 	comment_begin_{ "/*" },
@@ -178,9 +203,11 @@ TextLanguage::TextLanguage(string id) :
 	text_languages.push_back(this);
 }
 
-/* TextLanguage::~TextLanguage
- * TextLanguage class destructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::~TextLanguage
+//
+// TextLanguage class destructor
+// ----------------------------------------------------------------------------
 TextLanguage::~TextLanguage()
 {
 	// Remove from languages list
@@ -192,9 +219,11 @@ TextLanguage::~TextLanguage()
 	}
 }
 
-/* TextLanguage::copyTo
- * Copies all language info to [copy]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::copyTo
+//
+// Copies all language info to [copy]
+// ----------------------------------------------------------------------------
 void TextLanguage::copyTo(TextLanguage* copy)
 {
 	// Copy general attributes
@@ -213,42 +242,21 @@ void TextLanguage::copyTo(TextLanguage* copy)
 		copy->word_lists_[a] = word_lists_[a];
 
 	// Copy functions
-	size_t functions_size = functions_.size();
-	for (unsigned a = 0; a < functions_size; a++)
-	{
-		TLFunction* f = functions_[a];
-		size_t nargsets = f->nArgSets();
-		for (unsigned b = 0; b < nargsets; b++)
-			copy->addFunction(
-				f->name(),
-				f->argSet(b).args,
-				f->description(),
-				false,
-				f->returnType()
-			);
-	}
+	copy->functions_ = functions_;
+	copy->functions_custom_ = functions_custom_;
 
 	// Copy preprocessor/word block begin/end
 	copy->pp_block_begin_ = pp_block_begin_;
 	copy->pp_block_end_ = pp_block_end_;
 	copy->word_block_begin_ = word_block_begin_;
 	copy->word_block_end_ = word_block_end_;
-
-	/*size_t pp_block_begin_size = pp_block_begin_.size();
-
-	for (unsigned a = 0; a < pp_block_begin_size; a++)
-		copy->pp_block_begin_.push_back(pp_block_begin_[a]);
-
-	size_t pp_block_end_size = pp_block_end_.size();
-
-	for (unsigned a = 0; a < pp_block_end_size; a++)
-		copy->pp_block_end_.push_back(pp_block_end_[a]);*/
 }
 
-/* TextLanguage::addWord
- * Adds a new word of [type] to the language, if it doesn't exist
- * already
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::addWord
+//
+// Adds a new word of [type] to the language, if it doesn't exist already
+// ----------------------------------------------------------------------------
 void TextLanguage::addWord(WordType type, string keyword)
 {
 	// Add only if it doesn't already exist
@@ -257,11 +265,13 @@ void TextLanguage::addWord(WordType type, string keyword)
 		list.push_back(keyword);
 }
 
-/* TextLanguage::addFunction
- * Adds a function arg set to the language. If the function [name]
- * exists, [args] will be added to it as a new arg set, otherwise
- * a new function will be added
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::addFunction
+//
+// Adds a function arg set to the language. If the function [name] exists,
+// [args] will be added to it as a new arg set, otherwise a new function will
+// be added
+// ----------------------------------------------------------------------------
 void TextLanguage::addFunction(string name, string args, string desc, bool replace, string return_type)
 {
 	// Split out context from name
@@ -274,36 +284,65 @@ void TextLanguage::addFunction(string name, string args, string desc, bool repla
 	}
 
 	// Check if the function exists
-	TLFunction* func = function(name);
+	auto func = function(name);
 
 	// If it doesn't, create it
 	if (!func)
 	{
-		func = new TLFunction(name, return_type.empty() ? "void" : return_type);
-		functions_.push_back(func);
+		functions_.push_back(TLFunction(name));
+		func = &functions_.back();
 	}
 
-	// Remove/recreate the function if we're replacing it
+	// Clear the function if we're replacing it
 	else if (replace)
-	{
-		VECTOR_REMOVE(functions_, func);
-		delete func;
-		func = new TLFunction(name, return_type.empty() ? "void" : return_type);
-		functions_.push_back(func);
-	}
+		func->clear();
 
-	// Add the arg set
-	func->addArgSet(args, context);
-
-	// Set description
-	func->setDescription(desc);
+	// Add the context
+	func->addContext(context, args, desc);
 }
 
-/* TextLanguage::getWordList
- * Returns a string of all words of [type] in the language, separated
- * by spaces, which can be sent directly to scintilla for syntax
- * hilighting
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::loadZScript
+//
+// Loads types (classes) and functions from parsed ZScript definitions [defs]
+// ----------------------------------------------------------------------------
+void TextLanguage::loadZScript(ZScript::Definitions& defs)
+{
+	// Classes
+	for (auto& c : defs.classes())
+	{
+		// Add class as type
+		addWord(Type, c.name());
+
+		// Add class functions
+		for (auto& f : c.functions())
+		{
+			// Ignore overriding functions
+			if (f.isOverride())
+				continue;
+
+			// Check if the function exists
+			auto func = function(f.name());
+
+			// If it doesn't, create it
+			if (!func)
+			{
+				functions_.push_back(TLFunction(f.name()));
+				func = &functions_.back();
+			}
+
+			// Add the context
+			func->addContext(c.name(), f);
+		}
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TextLanguage::getWordList
+//
+// Returns a string of all words of [type] in the language, separated by
+// spaces, which can be sent directly to scintilla for syntax hilighting
+// ----------------------------------------------------------------------------
 string TextLanguage::wordList(WordType type)
 {
 	// Init return string
@@ -317,27 +356,32 @@ string TextLanguage::wordList(WordType type)
 	return ret;
 }
 
-/* TextLanguage::getFunctionsList
- * Returns a string of all functions in the language, separated by
- * spaces, which can be sent directly to scintilla for syntax
- * hilighting
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getFunctionsList
+//
+// Returns a string of all functions in the language, separated by spaces,
+// which can be sent directly to scintilla for syntax hilighting
+// ----------------------------------------------------------------------------
 string TextLanguage::functionsList()
 {
 	// Init return string
 	string ret = "";
 
 	// Add each function name to return string (separated by spaces)
-	for (unsigned a = 0; a < functions_.size(); a++)
-		ret += functions_[a]->name() + " ";
+	for (auto& func : functions_)
+		ret += func.name() + " ";
+	for (auto& func : functions_custom_)
+		ret += func.name() + " ";
 
 	return ret;
 }
 
-/* TextLanguage::getAutocompletionList
- * Returns a string containing all words and functions that can be
- * used directly in scintilla for an autocompletion list
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getAutocompletionList
+//
+// Returns a string containing all words and functions that can be used
+// directly in scintilla for an autocompletion list
+// ----------------------------------------------------------------------------
 string TextLanguage::autocompletionList(string start)
 {
 	// Firstly, add all functions and word lists to a wxArrayString
@@ -351,11 +395,12 @@ string TextLanguage::autocompletionList(string start)
 				list.Add(word_lists_[type].list[a] + S_FMT("?%d", type + 1));
 
 	// Add functions
-	for (unsigned a = 0; a < functions_.size(); a++)
-	{
-		if (functions_[a]->name().Lower().StartsWith(start))
-			list.Add(functions_[a]->name() + "?3");
-	}
+	for (auto& func : functions_)
+		if (func.name().Lower().StartsWith(start))
+			list.Add(func.name() + "?3");
+	for (auto& func : functions_custom_)
+		if (func.name().Lower().StartsWith(start))
+			list.Add(func.name() + "?3");
 
 	// Sort the list
 	list.Sort();
@@ -368,10 +413,11 @@ string TextLanguage::autocompletionList(string start)
 	return ret;
 }
 
-/* TextLanguage::getWordListSorted
- * Returns a sorted wxArrayString of all words of [type] in the
- * language
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getWordListSorted
+//
+// Returns a sorted wxArrayString of all words of [type] in the language
+// ----------------------------------------------------------------------------
 wxArrayString TextLanguage::wordListSorted(WordType type)
 {
 	// Get list
@@ -385,15 +431,19 @@ wxArrayString TextLanguage::wordListSorted(WordType type)
 	return list;
 }
 
-/* TextLanguage::getFunctionsSorted
- * Returns a sorted wxArrayString of all functions in the language
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getFunctionsSorted
+//
+// Returns a sorted wxArrayString of all functions in the language
+// ----------------------------------------------------------------------------
 wxArrayString TextLanguage::functionsSorted()
 {
 	// Get list
 	wxArrayString list;
-	for (unsigned a = 0; a < functions_.size(); a++)
-		list.Add(functions_[a]->name());
+	for (auto& func : functions_)
+		list.Add(func.name());
+	for (auto& func : functions_custom_)
+		list.Add(func.name());
 
 	// Sort
 	list.Sort();
@@ -401,75 +451,74 @@ wxArrayString TextLanguage::functionsSorted()
 	return list;
 }
 
-/* TextLanguage::isWord
- * Returns true if [word] is a [type] word in this language, false
- * otherwise
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::isWord
+//
+// Returns true if [word] is a [type] word in this language, false otherwise
+// ----------------------------------------------------------------------------
 bool TextLanguage::isWord(WordType type, string word)
 {
-	vector<string>& list = word_lists_[type].list;
-	for (unsigned a = 0; a < list.size(); a++)
-	{
-		if (list[a] == word)
+	for (auto& w : word_lists_[type].list)
+		if (w == word)
 			return true;
-	}
 
 	return false;
 }
 
-/* TextLanguage::isFunction
- * Returns true if [word] is a function in this language, false
- * otherwise
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::isFunction
+//
+// Returns true if [word] is a function in this language, false otherwise
+// ----------------------------------------------------------------------------
 bool TextLanguage::isFunction(string word)
 {
-	for (unsigned a = 0; a < functions_.size(); a++)
-	{
-		if (functions_[a]->name() == word)
+	for (auto& func : functions_)
+		if (func.name() == word)
 			return true;
-	}
 
 	return false;
 }
 
-/* TextLanguage::getFunction
- * Returns the function definition matching [name], or NULL if no
- * matching function exists
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getFunction
+//
+// Returns the function definition matching [name], or NULL if no matching
+// function exists
+// ----------------------------------------------------------------------------
 TLFunction* TextLanguage::function(string name)
 {
 	// Find function matching [name]
-	size_t functions_size = functions_.size();
 	if (case_sensitive_)
 	{
-		for (unsigned a = 0; a < functions_size; a++)
-		{
-			if (functions_[a]->name() == name)
-				return functions_[a];
-		}
+		for (auto& func : functions_)
+			if (func.name() == name)
+				return &func;
 	}
 	else
 	{
-		for (unsigned a = 0; a < functions_size; a++)
-		{
-			if (S_CMPNOCASE(functions_[a]->name(), name))
-				return functions_[a];
-		}
+		for (auto& func : functions_)
+			if (S_CMPNOCASE(func.name(), name))
+				return &func;
 	}
 
 	// Not found
-	return NULL;
+	return nullptr;
 }
 
 
-/*******************************************************************
- * TEXTLANGUAGE STATIC FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// TextLanguage Static Functions
+//
+// ----------------------------------------------------------------------------
 
-/* TextLanguage::readLanguageDefinition
- * Reads in a text definition of a language. See slade.pk3 for
- * formatting examples
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// TextLanguage::readLanguageDefinition
+//
+// Reads in a text definition of a language. See slade.pk3 for
+// formatting examples
+// ----------------------------------------------------------------------------
 bool TextLanguage::readLanguageDefinition(MemChunk& mc, string source)
 {
 	Tokenizer tz;
@@ -734,9 +783,11 @@ bool TextLanguage::readLanguageDefinition(MemChunk& mc, string source)
 	return true;
 }
 
-/* TextLanguage::loadLanguages
- * Loads all text language definitions from slade.pk3
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::loadLanguages
+//
+// Loads all text language definitions from slade.pk3
+// ----------------------------------------------------------------------------
 bool TextLanguage::loadLanguages()
 {
 	// Get slade resource archive
@@ -755,16 +806,20 @@ bool TextLanguage::loadLanguages()
 				readLanguageDefinition(dir->entryAt(a)->getMCData(), dir->entryAt(a)->getName());
 		}
 		else
-			LOG_MESSAGE(1, "Warning: 'config/languages' not found in slade.pk3, no builtin text language definitions loaded");
+			Log::warning(
+				1,
+				"Warning: 'config/languages' not found in slade.pk3, no builtin text language definitions loaded"
+			);
 	}
 
 	return true;
 }
 
-/* TextLanguage::getLanguage
- * Returns the language definition matching [id], or NULL if no
- * match found
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getLanguage
+//
+// Returns the language definition matching [id], or NULL if no match found
+// ----------------------------------------------------------------------------
 TextLanguage* TextLanguage::fromId(string id)
 {
 	// Find text language matching [id]
@@ -775,26 +830,29 @@ TextLanguage* TextLanguage::fromId(string id)
 	}
 
 	// Not found
-	return NULL;
+	return nullptr;
 }
 
-/* TextLanguage::getLanguage
- * Returns the language definition at [index], or NULL if [index] is
- * out of bounds
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getLanguage
+//
+// Returns the language definition at [index], or NULL if [index] is out of
+// bounds
+// ----------------------------------------------------------------------------
 TextLanguage* TextLanguage::fromIndex(unsigned index)
 {
 	// Check index
 	if (index >= text_languages.size())
-		return NULL;
+		return nullptr;
 
 	return text_languages[index];
 }
 
-/* TextLanguage::getLanguageByName
- * Returns the language definition matching [name], or NULL if no
- * match found
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getLanguageByName
+//
+// Returns the language definition matching [name], or NULL if no match found
+// ----------------------------------------------------------------------------
 TextLanguage* TextLanguage::fromName(string name)
 {
 	// Find text language matching [name]
@@ -805,12 +863,14 @@ TextLanguage* TextLanguage::fromName(string name)
 	}
 
 	// Not found
-	return NULL;
+	return nullptr;
 }
 
-/* TextLanguage::getLanguageNames
- * Returns a list of all language names
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextLanguage::getLanguageNames
+//
+// Returns a list of all language names
+// ----------------------------------------------------------------------------
 wxArrayString TextLanguage::languageNames()
 {
 	wxArrayString ret;

--- a/src/TextEditor/TextLanguage.cpp
+++ b/src/TextEditor/TextLanguage.cpp
@@ -170,6 +170,7 @@ void TLFunction::addContext(const string& context, const ZScript::Function& func
 	auto& ctx = contexts_.back();
 
 	ctx.return_type = func.returnType();
+	ctx.deprecated = func.deprecated();
 
 	if (func.isVirtual())
 		ctx.qualifiers += "virtual ";

--- a/src/TextEditor/TextLanguage.h
+++ b/src/TextEditor/TextLanguage.h
@@ -1,35 +1,48 @@
 #pragma once
 
+namespace ZScript { class Function; class Definitions; }
+
 class TLFunction
 {
 public:
-	struct ArgSet
+	struct Parameter
 	{
-		string	args;
-		string	context;
+		string	type;
+		string	name;
+		string	default_value;
+		bool	optional;
+
+		void	parse(vector<string>& tokens);
 	};
 
-	TLFunction(string name = "", string return_type = "void");
+	struct Context
+	{
+		string				context;
+		vector<Parameter>	params;
+		string				return_type;
+		string				description;
+	};
+
+	TLFunction(string name = "");
 	~TLFunction();
 
-	const string&	name() const { return name_; }
-	ArgSet			argSet(unsigned index) const;
-	const string&	description() const { return description_; }
-	const string&	returnType() const { return return_type_; }
-	unsigned		nArgSets() const { return arg_sets_.size(); }
+	const string&			name() const { return name_; }
+	const vector<Context>&	contexts() const { return contexts_; }
+	Context					context(unsigned index) const;
 
 	void	setName(string name) { this->name_ = name; }
-	void	addArgSet(string args, string context = "") { arg_sets_.push_back({ args, context }); }
-	void	setDescription(string desc) { description_ = desc; }
-
-	string		generateCallTipString(int arg_set = 0);
-	point2_t	getArgTextExtent(int arg, int arg_set = 0);
+	void	addContext(
+				const string& context,
+				const string& args,
+				const string& return_type = "void",
+				const string& description = ""
+			);
+	void	addContext(const string& context, const ZScript::Function& func);
+	void	clear() { name_.clear(); contexts_.clear(); }
 
 private:
 	string			name_;
-	vector<ArgSet>	arg_sets_;
-	string			description_;
-	string			return_type_;
+	vector<Context>	contexts_;
 };
 
 class TextLanguage
@@ -87,6 +100,7 @@ public:
 		bool replace = false,
 		string return_type = ""
 	);
+	void	loadZScript(ZScript::Definitions& defs);
 
 	string	wordList(WordType type);
 	string	functionsList();
@@ -105,6 +119,7 @@ public:
 
 	void	clearWordList(WordType type) { word_lists_[type].list.clear(); }
 	void	clearFunctions() { functions_.clear(); }
+	void	clearCustomFunctions() { functions_custom_.clear(); }
 
 	// Static functions
 	static bool				readLanguageDefinition(MemChunk& mc, string source);
@@ -144,7 +159,8 @@ private:
 	WordList	word_lists_[4];
 
 	// Functions
-	vector<TLFunction*>	functions_;
+	vector<TLFunction>	functions_;
+	vector<TLFunction>	functions_custom_;
 	bool				f_upper_;
 	bool				f_lower_;
 	bool				f_caps_;

--- a/src/TextEditor/TextLanguage.h
+++ b/src/TextEditor/TextLanguage.h
@@ -22,6 +22,7 @@ public:
 		string				return_type;
 		string				description;
 		string				qualifiers;
+		string				deprecated;
 	};
 
 	TLFunction(string name = "");

--- a/src/TextEditor/TextLanguage.h
+++ b/src/TextEditor/TextLanguage.h
@@ -21,6 +21,7 @@ public:
 		vector<Parameter>	params;
 		string				return_type;
 		string				description;
+		string				qualifiers;
 	};
 
 	TLFunction(string name = "");

--- a/src/TextEditor/TextLanguage.h
+++ b/src/TextEditor/TextLanguage.h
@@ -23,6 +23,7 @@ public:
 		string				description;
 		string				qualifiers;
 		string				deprecated;
+		bool				custom;
 	};
 
 	TLFunction(string name = "");
@@ -39,8 +40,12 @@ public:
 				const string& return_type = "void",
 				const string& description = ""
 			);
-	void	addContext(const string& context, const ZScript::Function& func);
+	void	addContext(const string& context, const ZScript::Function& func, bool custom);
+
 	void	clear() { name_.clear(); contexts_.clear(); }
+	void	clearCustomContexts();
+
+	bool	hasContext(const string& name);
 
 private:
 	string			name_;
@@ -94,7 +99,7 @@ public:
 	void	setPreprocessor(string token) { preprocessor_ = token; }
 	void	setDocComment(string token) { doc_comment_ = token; }
 	void	setCaseSensitive(bool cs) { case_sensitive_ = cs; }
-	void	addWord(WordType type, string word);
+	void	addWord(WordType type, string word, bool custom = false);
 	void	addFunction(
 		string name,
 		string args,
@@ -102,13 +107,13 @@ public:
 		bool replace = false,
 		string return_type = ""
 	);
-	void	loadZScript(ZScript::Definitions& defs);
+	void	loadZScript(ZScript::Definitions& defs, bool custom = false);
 
-	string	wordList(WordType type);
+	string	wordList(WordType type, bool include_custom = true);
 	string	functionsList();
-	string	autocompletionList(string start = "");
+	string	autocompletionList(string start = "", bool include_custom = true);
 
-	wxArrayString	wordListSorted(WordType type);
+	wxArrayString	wordListSorted(WordType type, bool include_custom = true);
 	wxArrayString	functionsSorted();
 
 	string	wordLink(WordType type) const { return word_lists_[type].lookup_url; }
@@ -121,7 +126,7 @@ public:
 
 	void	clearWordList(WordType type) { word_lists_[type].list.clear(); }
 	void	clearFunctions() { functions_.clear(); }
-	void	clearCustomFunctions() { functions_custom_.clear(); }
+	void	clearCustomDefs();
 
 	// Static functions
 	static bool				readLanguageDefinition(MemChunk& mc, string source);
@@ -159,10 +164,10 @@ private:
 		string			lookup_url;
 	};
 	WordList	word_lists_[4];
+	WordList	word_lists_custom_[4];
 
 	// Functions
 	vector<TLFunction>	functions_;
-	vector<TLFunction>	functions_custom_;
 	bool				f_upper_;
 	bool				f_lower_;
 	bool				f_caps_;

--- a/src/TextEditor/TextStyle.cpp
+++ b/src/TextEditor/TextStyle.cpp
@@ -477,6 +477,7 @@ void StyleSet::applyTo(TextEditorCtrl* stc)
 	stc->IndicatorSetForeground(8, WXCOL(getStyleForeground("wordmatch")));
 
 	// Set current line colour
+	stc->SetCaretLineBackground(WXCOL(getStyleBackground("current_line")));
 	stc->MarkerDefine(
 		1,
 		wxSTC_MARK_BACKGROUND,

--- a/src/TextEditor/TextStyle.cpp
+++ b/src/TextEditor/TextStyle.cpp
@@ -1,37 +1,38 @@
 
-/*******************************************************************
- * SLADE - It's a Doom Editor
- * Copyright (C) 2008-2014 Simon Judd
- *
- * Email:       sirjuddington@gmail.com
- * Web:         http://slade.mancubus.net
- * Filename:    TextStyle.cpp
- * Description: Classes which handle font and colour settings for
- *              the text editor. TextStyle contains the actual font
- *              and colour settings for a particular 'style' (eg.
- *              keywords, comments, etc). StyleSet is just a set
- *              of these styles that can be loaded to the scintilla
- *              'styles' in the text editor
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2017 Simon Judd
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    TextStyle.cpp
+// Description: Classes which handle font and colour settings for the text
+//              editor. TextStyle contains the actual font and colour settings
+//              for a particular 'style' (eg. keywords, comments, etc).
+//              StyleSet is just a set of these styles that can be loaded to
+//              the scintilla 'styles' in the text editor
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// ----------------------------------------------------------------------------
 
 
-/*******************************************************************
- * INCLUDES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Includes
+//
+// ----------------------------------------------------------------------------
 #include "Main.h"
 #include "App.h"
 #include "UI/TextEditorCtrl.h"
@@ -42,23 +43,30 @@
 #include "Utility/Tokenizer.h"
 
 
-/*******************************************************************
- * VARIABLES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Variables
+//
+// ----------------------------------------------------------------------------
 CVAR(String, txed_override_font, "", CVAR_SAVE)
 CVAR(Int, txed_override_font_size, 0, CVAR_SAVE)
-vector<StyleSet*>	style_sets;
-StyleSet*			ss_current = NULL;
+vector<StyleSet*>		style_sets;
+StyleSet*				ss_current = nullptr;
 vector<TextEditorCtrl*>	StyleSet::editors;
 
 
-/*******************************************************************
- * TEXTSTYLE CLASS FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// TextStyle Class Functions
+//
+// ----------------------------------------------------------------------------
 
-/* TextStyle::TextStyle
- * TextStyle class constructor
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// TextStyle::TextStyle
+//
+// TextStyle class constructor
+// ----------------------------------------------------------------------------
 TextStyle::TextStyle(string name, string description, int style_id)
 {
 	// Init variables
@@ -77,25 +85,31 @@ TextStyle::TextStyle(string name, string description, int style_id)
 	underlined = -1;
 }
 
-/* TextStyle::~TextStyle
- * TextStyle class destructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextStyle::~TextStyle
+//
+// TextStyle class destructor
+// ----------------------------------------------------------------------------
 TextStyle::~TextStyle()
 {
 }
 
-/* TextStyle::addWxStyleId
- * Adds a wxSTC style id to the list (used for applying style to the
- * wxStyledTextCtrl, in case this style replaces multiple)
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextStyle::addWxStyleId
+//
+// Adds a wxSTC style id to the list (used for applying style to the
+// wxStyledTextCtrl, in case this style replaces multiple)
+// ----------------------------------------------------------------------------
 void TextStyle::addWxStyleId(int style)
 {
 	wx_styles.push_back(style);
 }
 
-/* TextStyle::parse
- * Reads text style information from a parse tree
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextStyle::parse
+//
+// Reads text style information from a parse tree
+// ----------------------------------------------------------------------------
 bool TextStyle::parse(ParseTreeNode* node)
 {
 	// Check any info was given
@@ -146,9 +160,11 @@ bool TextStyle::parse(ParseTreeNode* node)
 	return true;
 }
 
-/* TextStyle::applyTo
- * Applies the style settings to the scintilla text control [stc]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextStyle::applyTo
+//
+// Applies the style settings to the scintilla text control [stc]
+// ----------------------------------------------------------------------------
 void TextStyle::applyTo(TextEditorCtrl* stc)
 {
 	for (unsigned a = 0; a < wx_styles.size(); a++)
@@ -193,9 +209,11 @@ void TextStyle::applyTo(TextEditorCtrl* stc)
 	}
 }
 
-/* TextStyle::copyStyle
- * Copies style info from [copy]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextStyle::copyStyle
+//
+// Copies style info from [copy]
+// ----------------------------------------------------------------------------
 bool TextStyle::copyStyle(TextStyle* copy)
 {
 	if (!copy)
@@ -215,9 +233,11 @@ bool TextStyle::copyStyle(TextStyle* copy)
 	return true;
 }
 
-/* TextStyle::getDefinition
- * Returns a formatted string defining this style
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// TextStyle::getDefinition
+//
+// Returns a formatted string defining this style
+// ----------------------------------------------------------------------------
 string TextStyle::getDefinition(unsigned tabs)
 {
 	string ret = "";
@@ -275,13 +295,18 @@ string TextStyle::getDefinition(unsigned tabs)
 }
 
 
-/*******************************************************************
- * STYLESET CLASS FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// StyleSet Class Functions
+//
+// ----------------------------------------------------------------------------
 
-/* StyleSet::StyleSet
- * StyleSet class constructor
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// StyleSet::StyleSet
+//
+// StyleSet class constructor
+// ----------------------------------------------------------------------------
 StyleSet::StyleSet(string name) : ts_default("default", "Default", wxSTC_STYLE_DEFAULT), ts_selection("selection", "Selected Text")
 {
 	// Init default style
@@ -326,18 +351,22 @@ StyleSet::StyleSet(string name) : ts_default("default", "Default", wxSTC_STYLE_D
 	styles.push_back(new TextStyle("current_line",	"Current Line"));
 }
 
-/* StyleSet::~StyleSet
- * StyleSet class destructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::~StyleSet
+//
+// StyleSet class destructor
+// ----------------------------------------------------------------------------
 StyleSet::~StyleSet()
 {
 	for (unsigned a = 0; a < styles.size(); a++)
 		delete styles[a];
 }
 
-/* StyleSet::parseSet
- * Reads style set info from a parse tree
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::parseSet
+//
+// Reads style set info from a parse tree
+// ----------------------------------------------------------------------------
 bool StyleSet::parseSet(ParseTreeNode* root)
 {
 	if (!root)
@@ -402,10 +431,12 @@ bool StyleSet::parseSet(ParseTreeNode* root)
 	return true;
 }
 
-/* StyleSet::applyTo
- * Applies all the styles in this set to the text styles in scintilla
- * text control [stc]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::applyTo
+//
+// Applies all the styles in this set to the text styles in scintilla text
+// control [stc]
+// ----------------------------------------------------------------------------
 void StyleSet::applyTo(TextEditorCtrl* stc)
 {
 	// Set default style
@@ -460,9 +491,11 @@ void StyleSet::applyTo(TextEditorCtrl* stc)
 	);
 }
 
-/* StyleSet::copySet
- * Copies all styles in [copy] to this set
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::copySet
+//
+// Copies all styles in [copy] to this set
+// ----------------------------------------------------------------------------
 bool StyleSet::copySet(StyleSet* copy)
 {
 	if (!copy)
@@ -477,10 +510,12 @@ bool StyleSet::copySet(StyleSet* copy)
 	return true;
 }
 
-/* StyleSet::getStyle
- * Returns the text style associated with [name] (these are hard
- * coded), or NULL if [name] was invalid
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::getStyle
+//
+// Returns the text style associated with [name] (these are hard coded), or
+// nullptr if [name] was invalid
+// ----------------------------------------------------------------------------
 TextStyle* StyleSet::getStyle(string name)
 {
 	// Return style matching name given
@@ -498,23 +533,27 @@ TextStyle* StyleSet::getStyle(string name)
 	}
 
 	// Not a valid style
-	return NULL;
+	return nullptr;
 }
 
-/* StyleSet::getStyle
- * Returns the extra text style at [index]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::getStyle
+//
+// Returns the extra text style at [index]
+// ----------------------------------------------------------------------------
 TextStyle* StyleSet::getStyle(unsigned index)
 {
 	if (index < styles.size())
 		return styles[index];
 	else
-		return NULL;
+		return nullptr;
 }
 
-/* StyleSet::writeFile
- * Writes this style set as a text definition to a file [filename]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::writeFile
+//
+// Writes this style set as a text definition to a file [filename]
+// ----------------------------------------------------------------------------
 bool StyleSet::writeFile(string filename)
 {
 	// Open file for writing
@@ -556,10 +595,12 @@ bool StyleSet::writeFile(string filename)
 	return true;
 }
 
-/* StyleSet::getStyleForeground
- * Returns the foreground colour of [style], or the default style's
- * foreground colour if it is not set
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::getStyleForeground
+//
+// Returns the foreground colour of [style], or the default style's foreground
+// colour if it is not set
+// ----------------------------------------------------------------------------
 rgba_t StyleSet::getStyleForeground(string style)
 {
 	TextStyle* s = getStyle(style);
@@ -569,10 +610,12 @@ rgba_t StyleSet::getStyleForeground(string style)
 		return ts_default.getForeground();
 }
 
-/* StyleSet::getStyleBackground
- * Returns the background colour of [style], or the default style's
- * background colour if it is not set
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::getStyleBackground
+//
+// Returns the background colour of [style], or the default style's background
+// colour if it is not set
+// ----------------------------------------------------------------------------
 rgba_t StyleSet::getStyleBackground(string style)
 {
 	TextStyle* s = getStyle(style);
@@ -582,9 +625,11 @@ rgba_t StyleSet::getStyleBackground(string style)
 		return ts_default.getBackground();
 }
 
-/* StyleSet::getDefaultFontFace
- * Returns the default style font face
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::getDefaultFontFace
+//
+// Returns the default style font face
+// ----------------------------------------------------------------------------
 string StyleSet::getDefaultFontFace()
 {
 	if (txed_override_font != "")
@@ -593,9 +638,11 @@ string StyleSet::getDefaultFontFace()
 		return getStyle("default")->getFontFace();
 }
 
-/* StyleSet::getDefaultFontSize
- * Returns the default style font size
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::getDefaultFontSize
+//
+// Returns the default style font size
+// ----------------------------------------------------------------------------
 int StyleSet::getDefaultFontSize()
 {
 	if (txed_override_font != "" && txed_override_font_size > 0)
@@ -605,15 +652,19 @@ int StyleSet::getDefaultFontSize()
 }
 
 
-/*******************************************************************
- * STYLESET STATIC FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// StyleSet Class Static Functions
+//
+// ----------------------------------------------------------------------------
 
-/* StyleSet::initCurrent
- * Initialises the 'current' style set from the previously saved
- * 'current.sss' file, or uses the default set if the file does not
- * exist
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// StyleSet::initCurrent
+//
+// Initialises the 'current' style set from the previously saved 'current.sss'
+// file, or uses the default set if the file does not exist
+// ----------------------------------------------------------------------------
 void StyleSet::initCurrent()
 {
 	// Create 'current' styleset
@@ -648,9 +699,11 @@ void StyleSet::initCurrent()
 		ss_current->copySet(style_sets[0]);
 }
 
-/* StyleSet::saveCurrent
- * Writes the current style set to the 'current.sss' file
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::saveCurrent
+//
+// Writes the current style set to the 'current.sss' file
+// ----------------------------------------------------------------------------
 void StyleSet::saveCurrent()
 {
 	if (!ss_current)
@@ -659,9 +712,11 @@ void StyleSet::saveCurrent()
 	ss_current->writeFile(App::path("current.sss", App::Dir::User));
 }
 
-/* StyleSet::currentSet
- * Returns the current style set
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::currentSet
+//
+// Returns the current style set
+// ----------------------------------------------------------------------------
 StyleSet* StyleSet::currentSet()
 {
 	if (!ss_current)
@@ -670,10 +725,12 @@ StyleSet* StyleSet::currentSet()
 	return ss_current;
 }
 
-/* StyleSet::loadSet
- * Loads the style set matching [name] to the current style set.
- * Returns false if no match was found, true otherwise
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::loadSet
+//
+// Loads the style set matching [name] to the current style set.
+// Returns false if no match was found, true otherwise
+// ----------------------------------------------------------------------------
 bool StyleSet::loadSet(string name)
 {
 	// Search for set matching name
@@ -689,10 +746,12 @@ bool StyleSet::loadSet(string name)
 	return false;
 }
 
-/* StyleSet::loadSet
- * Loads the style set at [index] to the current style set. Returns
- * false if [index] was out of bounds, true otherwise
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::loadSet
+//
+// Loads the style set at [index] to the current style set.
+// Returns false if [index] was out of bounds, true otherwise
+// ----------------------------------------------------------------------------
 bool StyleSet::loadSet(unsigned index)
 {
 	// Check index
@@ -704,18 +763,22 @@ bool StyleSet::loadSet(unsigned index)
 	return true;
 }
 
-/* StyleSet::applyCurrent
- * Applies the current style set to the scintilla text control [stc]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::applyCurrent
+//
+// Applies the current style set to the scintilla text control [stc]
+// ----------------------------------------------------------------------------
 void StyleSet::applyCurrent(TextEditorCtrl* stc)
 {
 	currentSet()->applyTo(stc);
 }
 
-/* StyleSet::getName
- * Returns the name of the style set at [index], or an empty string
- * if [index] is out of bounds
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::getName
+//
+// Returns the name of the style set at [index], or an empty string if [index]
+// is out of bounds
+// ----------------------------------------------------------------------------
 string StyleSet::getName(unsigned index)
 {
 	// Check index
@@ -725,54 +788,66 @@ string StyleSet::getName(unsigned index)
 	return style_sets[index]->name;
 }
 
-/* StyleSet::numSets
- * Returns the number of loaded style sets
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::numSets
+//
+// Returns the number of loaded style sets
+// ----------------------------------------------------------------------------
 unsigned StyleSet::numSets()
 {
 	return style_sets.size();
 }
 
-/* StyleSet::getSet
- * Returns the style set at [index], or NULL if [index] is out of bounds
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::getSet
+//
+// Returns the style set at [index], or nullptr if [index] is out of bounds
+// ----------------------------------------------------------------------------
 StyleSet* StyleSet::getSet(unsigned index)
 {
 	// Check index
 	if (index >= style_sets.size())
-		return NULL;
+		return nullptr;
 
 	return style_sets[index];
 }
 
-/* StyleSet::addEditor
- * Adds [stc] to the current list of text editors
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::addEditor
+//
+// Adds [stc] to the current list of text editors
+// ----------------------------------------------------------------------------
 void StyleSet::addEditor(TextEditorCtrl* stc)
 {
 	editors.push_back(stc);
 }
 
-/* StyleSet::removeEditor
- * Removes [stc] from the current list of text editors
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::removeEditor
+//
+// Removes [stc] from the current list of text editors
+// ----------------------------------------------------------------------------
 void StyleSet::removeEditor(TextEditorCtrl* stc)
 {
 	VECTOR_REMOVE(editors, stc);
 }
 
-/* StyleSet::applyCurrentToAll
- * Applies the current style set to all text editors in the list
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::applyCurrentToAll
+//
+// Applies the current style set to all text editors in the list
+// ----------------------------------------------------------------------------
 void StyleSet::applyCurrentToAll()
 {
 	for (unsigned a = 0; a < editors.size(); a++)
 		applyCurrent(editors[a]);
 }
 
-/* StyleSet::loadResourceStyles
- * Loads all text styles from the slade resource archive (slade.pk3)
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::loadResourceStyles
+//
+// Loads all text styles from the slade resource archive (slade.pk3)
+// ----------------------------------------------------------------------------
 bool StyleSet::loadResourceStyles()
 {
 	// Get 'config/text_styles' directory in slade.pk3
@@ -843,9 +918,11 @@ bool StyleSet::loadResourceStyles()
 	return true;
 }
 
-/* StyleSet::loadCustomStyles
- * Loads all text styles from the user text style directory
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// StyleSet::loadCustomStyles
+//
+// Loads all text styles from the user text style directory
+// ----------------------------------------------------------------------------
 bool StyleSet::loadCustomStyles()
 {
 	// If the custom stylesets directory doesn't exist, create it

--- a/src/TextEditor/UI/SCallTip.cpp
+++ b/src/TextEditor/UI/SCallTip.cpp
@@ -261,11 +261,19 @@ wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 			rect_btn_down_.Offset(12, 8);
 		}
 
+		wxRect rect;
+
+		// Draw function qualifiers
+		if (!context_.qualifiers.empty())
+		{
+			dc.SetTextForeground(WXCOL(col_keyword_));
+			dc.DrawLabel(context_.qualifiers, wxNullBitmap, wxRect(left, yoff, 900, 900), 0, -1, &rect);
+		}
+
 		// Draw function return type
 		string ftype = context_.return_type + " ";
-		wxRect rect;
 		dc.SetTextForeground(wxcol_type);
-		dc.DrawLabel(ftype, wxNullBitmap, wxRect(left, yoff, 900, 900), 0, -1, &rect);
+		drawText(dc, ftype, rect.GetRight() + 1, rect.GetTop(), &rect);
 
 		// Draw function context (if any)
 		if (!context_.context.empty())

--- a/src/TextEditor/UI/SCallTip.cpp
+++ b/src/TextEditor/UI/SCallTip.cpp
@@ -527,6 +527,13 @@ wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 		// Normal calltip - show (potentially) multiple contexts
 		else
 		{
+			// Determine separator colour
+			wxColour col_sep;
+			if (col_bg_.greyscale().r < 128)
+				col_sep = WXCOL(col_bg_.amp(30, 30, 30, 0));
+			else
+				col_sep = WXCOL(col_bg_.amp(-30, -30, -30, 0));
+
 			bool first = true;
 			auto num = std::min<unsigned>(function_->contexts().size(), 12u);
 			for (auto a = 0u; a < num; a++)
@@ -535,7 +542,7 @@ wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 
 				if (!first)
 				{
-					dc.SetPen(wxPen(wxcol_faded));
+					dc.SetPen(wxPen(col_sep));
 					dc.DrawLine(xoff, bottom + 5, 2000, bottom + 5);
 				}
 

--- a/src/TextEditor/UI/SCallTip.cpp
+++ b/src/TextEditor/UI/SCallTip.cpp
@@ -1,40 +1,44 @@
 
-/*******************************************************************
- * SLADE - It's a Doom Editor
- * Copyright (C) 2008-2014 Simon Judd
- *
- * Email:       sirjuddington@gmail.com
- * Web:         http://slade.mancubus.net
- * Filename:    SCallTip.cpp
- * Description: Custom calltip implementation for the text editor
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2017 Simon Judd
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    SCallTip.cpp
+// Description: Custom calltip implementation for the text editor
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// ----------------------------------------------------------------------------
 
 
-/*******************************************************************
- * INCLUDES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Includes
+//
+// ----------------------------------------------------------------------------
 #include "Main.h"
 #include "SCallTip.h"
 #include "TextEditor/TextLanguage.h"
 
 
-/*******************************************************************
- * VARIABLES
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// Variables
+//
+// ----------------------------------------------------------------------------
 namespace
 {
 	wxColour wxcol_fg;
@@ -44,13 +48,18 @@ namespace
 CVAR(Bool, txed_calltips_dim_optional, true, CVAR_SAVE)
 
 
-/*******************************************************************
- * SCALLTIP CLASS FUNCTIONS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// SCallTip Class Functions
+//
+// ----------------------------------------------------------------------------
 
-/* SCallTip::SCallTip
- * SCallTip class constructor
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// SCallTip::SCallTip
+//
+// SCallTip class constructor
+// ----------------------------------------------------------------------------
 SCallTip::SCallTip(wxWindow* parent) :
 	wxPopupWindow(parent),
 	function_(nullptr),
@@ -78,16 +87,20 @@ SCallTip::SCallTip(wxWindow* parent) :
 	Bind(wxEVT_SHOW, &SCallTip::onShow, this);
 }
 
-/* SCallTip::~SCallTip
- * SCallTip class destructor
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::~SCallTip
+//
+// SCallTip class destructor
+// ----------------------------------------------------------------------------
 SCallTip::~SCallTip()
 {
 }
 
-/* SCallTip::setFont
- * Sets the font [face] and [size]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::setFont
+//
+// Sets the font [face] and [size]
+// ----------------------------------------------------------------------------
 void SCallTip::setFont(string face, int size)
 {
 	if (face == "")
@@ -102,9 +115,11 @@ void SCallTip::setFont(string face, int size)
 	}
 }
 
-/* SCallTip::loadArgSet
- * Opens and displays the context [index] from the current function
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::loadArgSet
+//
+// Opens and displays the context [index] from the current function
+// ----------------------------------------------------------------------------
 void SCallTip::loadContext(int index)
 {
 	context_ = function_->context(index);
@@ -115,9 +130,11 @@ void SCallTip::loadContext(int index)
 	Refresh();
 }
 
-/* SCallTip::openFunction
- * Opens [function] in the call tip, with [arg] highlighted
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::openFunction
+//
+// Opens [function] in the call tip, with [arg] highlighted
+// ----------------------------------------------------------------------------
 void SCallTip::openFunction(TLFunction* function, int arg)
 {
 	// Set current function
@@ -131,9 +148,11 @@ void SCallTip::openFunction(TLFunction* function, int arg)
 	loadContext(context_current_);
 }
 
-/* SCallTip::nextArgSet
- * Open the next (cyclic) arg set in the current function
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::nextArgSet
+//
+// Open the next (cyclic) arg set in the current function
+// ----------------------------------------------------------------------------
 void SCallTip::nextArgSet()
 {
 	context_current_++;
@@ -142,9 +161,11 @@ void SCallTip::nextArgSet()
 	loadContext(context_current_);
 }
 
-/* SCallTip::prevArgSet
- * Open the previous (cyclic) arg set in the current function
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::prevArgSet
+//
+// Open the previous (cyclic) arg set in the current function
+// ----------------------------------------------------------------------------
 void SCallTip::prevArgSet()
 {
 	context_current_--;
@@ -153,9 +174,11 @@ void SCallTip::prevArgSet()
 	loadContext(context_current_);
 }
 
-/* SCallTip::updateSize
- * Recalculates the calltip text and size
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::updateSize
+//
+// Recalculates the calltip text and size
+// ----------------------------------------------------------------------------
 void SCallTip::updateSize()
 {
 	updateBuffer();
@@ -179,16 +202,24 @@ void SCallTip::updateSize()
 	Refresh();
 }
 
-/* SCallTip::drawText
- * Using [dc], draw [text] at [left,top], writing the bounds of the
- * drawn text to [bounds]
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::drawText
+//
+// Using [dc], draw [text] at [left,top], writing the bounds of the drawn text
+// to [bounds]
+// ----------------------------------------------------------------------------
 int SCallTip::drawText(wxDC& dc, string text, int left, int top, wxRect* bounds)
 {
 	dc.DrawLabel(text, wxNullBitmap, wxRect(left, top, 900, 900), 0, -1, bounds);
 	return bounds->GetRight() + 1;
 }
 
+// ----------------------------------------------------------------------------
+// SCallTip::drawFunctionSpec
+//
+// Draws function 'spec' text for [context] at [left,top].
+// Returns a rect of the bounds of the drawn text
+// ----------------------------------------------------------------------------
 wxRect SCallTip::drawFunctionSpec(wxDC& dc, const TLFunction::Context& context, int left, int top)
 {
 	wxRect rect{ left, top, 0, 0 };
@@ -232,6 +263,12 @@ wxRect SCallTip::drawFunctionSpec(wxDC& dc, const TLFunction::Context& context, 
 	return { { rect_left, top }, rect.GetBottomRight() };
 }
 
+// ----------------------------------------------------------------------------
+// SCallTip::drawArgs
+//
+// Draws function args text for [context] at [left,top].
+// Returns a rect of the bounds of the drawn text
+// ----------------------------------------------------------------------------
 wxRect SCallTip::drawArgs(
 	wxDC& dc,
 	const TLFunction::Context& context,
@@ -304,6 +341,12 @@ wxRect SCallTip::drawArgs(
 	return { args_left, args_top, max_right - args_left, rect.GetBottom() - args_top };
 }
 
+// ----------------------------------------------------------------------------
+// SCallTip::drawFunctionContext
+//
+// Draws function text (spec+args) for [context] at [left,top].
+// Returns a rect of the bounds of the drawn text
+// ----------------------------------------------------------------------------
 wxRect SCallTip::drawFunctionContext(
 	wxDC& dc,
 	const TLFunction::Context& context,
@@ -324,6 +367,12 @@ wxRect SCallTip::drawFunctionContext(
 	};
 }
 
+// ----------------------------------------------------------------------------
+// SCallTip::drawFunctionDescription
+//
+// Draws function description text [desc] at [left,top].
+// Returns a rect of the bounds of the drawn text
+// ----------------------------------------------------------------------------
 wxRect SCallTip::drawFunctionDescription(wxDC& dc, string desc, int left, int top, int max_width)
 {
 	wxFont italic = font_.Italic();
@@ -378,10 +427,12 @@ wxRect SCallTip::drawFunctionDescription(wxDC& dc, string desc, int left, int to
 	return { left, top, max_right - left, rect.GetBottom() - top };
 }
 
-/* SCallTip::drawCallTip
- * Using [dc], draw the calltip contents at [xoff,yoff]. Returns the
- * dimensions of the drawn calltip text
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::drawCallTip
+//
+// Using [dc], draw the calltip contents at [xoff,yoff].
+// Returns the dimensions of the drawn calltip text
+// ----------------------------------------------------------------------------
 wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 {
 	wxSize ct_size;
@@ -414,10 +465,11 @@ wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 		dc.SetFont(font_);
 		dc.SetTextForeground(wxcol_fg);
 
-		// Draw arg set switching stuff
 		int left = xoff;
 		int max_right = 0;
 		int bottom = yoff;
+
+		// Context switching calltip
 		if (switch_contexts_)
 		{
 			// up-filled	\xE2\x96\xB2
@@ -471,10 +523,12 @@ wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 				bottom = rect_desc.GetBottom();
 			}
 		}
+
+		// Normal calltip - show (potentially) multiple contexts
 		else
 		{
 			bool first = true;
-			auto num = std::min(function_->contexts().size(), 12u);
+			auto num = std::min<unsigned>(function_->contexts().size(), 12u);
 			for (auto a = 0u; a < num; a++)
 			{
 				auto& context = function_->contexts()[a];
@@ -507,80 +561,6 @@ wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 		// Size buffer bitmap to fit
 		ct_size.SetWidth(max_right + 1);
 		ct_size.SetHeight(bottom + 1);
-
-		//// Draw function
-		//auto rect = drawFunctionContext(dc, context_, left, yoff, wxcol_faded, bold);
-
-		//// Draw overloads number
-		//if (function_->contexts().size() > 1 && !switch_contexts_)
-		//	dc.DrawLabel(
-		//		S_FMT(" (+%d)", function_->contexts().size() - 1),
-		//		wxNullBitmap,
-		//		wxRect(args_rect.GetRight(), args_rect.GetTop(), 900, 900),
-		//		0,
-		//		-1,
-		//		&rect);
-
-		//// Update max width
-		//int max_right = rect.GetRight();
-		//if (rect.GetRight() > max_right)
-		//	max_right = rect.GetRight();
-
-		//// Description
-		//string desc = context_.description;
-		//if (!desc.IsEmpty())
-		//{
-		//	wxFont italic = font_.Italic();
-		//	dc.SetFont(italic);
-		//	if (dc.GetTextExtent(desc).x > SCALLTIP_MAX_WIDTH)
-		//	{
-		//		// Description is too long, split into multiple lines
-		//		vector<string> desc_lines;
-		//		string line = desc;
-		//		wxArrayInt extents;
-		//		while (true)
-		//		{
-		//			dc.GetPartialTextExtents(line, extents);
-		//			bool split = false;
-		//			for (unsigned a = 0; a < extents.size(); a++)
-		//			{
-		//				if (extents[a] > SCALLTIP_MAX_WIDTH)
-		//				{
-		//					int eol = line.SubString(0, a).Last(' ');
-		//					desc_lines.push_back(line.SubString(0, eol));
-		//					line = line.SubString(eol + 1, line.Length());
-		//					split = true;
-		//					break;
-		//				}
-		//			}
-
-		//			if (!split)
-		//			{
-		//				desc_lines.push_back(line);
-		//				break;
-		//			}
-		//		}
-
-		//		int bottom = rect.GetBottom() + 8;
-		//		for (unsigned a = 0; a < desc_lines.size(); a++)
-		//		{
-		//			drawText(dc, desc_lines[a], 0, bottom, &rect);
-		//			bottom = rect.GetBottom();
-		//			if (rect.GetRight() > max_right)
-		//				max_right = rect.GetRight();
-		//		}
-		//	}
-		//	else
-		//	{
-		//		drawText(dc, desc, 0, rect.GetBottom() + 8, &rect);
-		//		if (rect.GetRight() > max_right)
-		//			max_right = rect.GetRight();
-		//	}
-		//}
-
-		//// Size buffer bitmap to fit
-		//ct_size.SetWidth(max_right + 1);
-		//ct_size.SetHeight(rect.GetBottom() + 1);
 	}
 	else
 	{
@@ -592,10 +572,12 @@ wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 	return ct_size;
 }
 
-/* SCallTip::updateBuffer
- * Redraws the calltip text to the buffer image, setting the buffer
- * image size to the exact dimensions of the text
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::updateBuffer
+//
+// Redraws the calltip text to the buffer image, setting the buffer image size
+// to the exact dimensions of the text
+// ----------------------------------------------------------------------------
 void SCallTip::updateBuffer()
 {
 	buffer_.SetWidth(1000);
@@ -608,13 +590,18 @@ void SCallTip::updateBuffer()
 }
 
 
-/*******************************************************************
- * SCALLTIP CLASS EVENTS
- *******************************************************************/
+// ----------------------------------------------------------------------------
+//
+// SCallTip Class Events
+//
+// ----------------------------------------------------------------------------
 
-/* SCallTip::onPaint
- * Called when the control is to be (re)painted
- *******************************************************************/
+
+// ----------------------------------------------------------------------------
+// SCallTip::onPaint
+//
+// Called when the control is to be (re)painted
+// ----------------------------------------------------------------------------
 void SCallTip::onPaint(wxPaintEvent& e)
 {
 	// Create device context
@@ -663,17 +650,21 @@ void SCallTip::onPaint(wxPaintEvent& e)
 #endif
 }
 
-/* SCallTip::onEraseBackground
- * Erase background - overridden to do nothing, to avoid flickering
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::onEraseBackground
+//
+// Erase background - overridden to do nothing, to avoid flickering
+// ----------------------------------------------------------------------------
 void SCallTip::onEraseBackground(wxEraseEvent& e)
 {
 	// Do nothing
 }
 
-/* SCallTip::onMouseMove
- * Called when the mouse pointer is moved within the control
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::onMouseMove
+//
+// Called when the mouse pointer is moved within the control
+// ----------------------------------------------------------------------------
 void SCallTip::onMouseMove(wxMouseEvent& e)
 {
 	if (rect_btn_down_.Contains(e.GetPosition()))
@@ -707,9 +698,11 @@ void SCallTip::onMouseMove(wxMouseEvent& e)
 	}
 }
 
-/* SCallTip::onMouseDown
- * Called when a mouse button is clicked within the control
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::onMouseDown
+//
+// Called when a mouse button is clicked within the control
+// ----------------------------------------------------------------------------
 void SCallTip::onMouseDown(wxMouseEvent& e)
 {
 	if (e.Button(wxMOUSE_BTN_LEFT))
@@ -721,9 +714,11 @@ void SCallTip::onMouseDown(wxMouseEvent& e)
 	}
 }
 
-/* SCallTip::onShow
- * Called when the control is shown
- *******************************************************************/
+// ----------------------------------------------------------------------------
+// SCallTip::onShow
+//
+// Called when the control is shown
+// ----------------------------------------------------------------------------
 void SCallTip::onShow(wxShowEvent& e)
 {
 	if (e.IsShown())

--- a/src/TextEditor/UI/SCallTip.h
+++ b/src/TextEditor/UI/SCallTip.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "common.h"
+#include "TextEditor/TextLanguage.h"
 
 #define SCALLTIP_MAX_WIDTH 800
 
-class TLFunction;
 class SCallTip : public wxPopupWindow
 {
 public:
@@ -24,22 +24,23 @@ public:
 	void	nextArgSet();
 	void	prevArgSet();
 
-	struct arg_t
+	/*struct arg_t
 	{
 		string	type;
 		string	name;
 		bool	optional;
 		arg_t() : optional(false) {}
-	};
+	};*/
 
 private:
+	TLFunction*			function;
+	TLFunction::Context	context;
+
 	rgba_t			col_bg;
 	rgba_t			col_fg;
 	rgba_t			col_fg_hl;
 	rgba_t			col_func;
 	rgba_t			col_type;
-	TLFunction*		function;
-	vector<arg_t>	args;
 	int				arg_current;
 	bool			switch_args;
 	int				arg_set_current;
@@ -48,7 +49,6 @@ private:
 	int				btn_mouse_over;
 	wxBitmap		buffer;
 	wxFont			font;
-	string			context;
 
 	void	addArg(vector<string>& tokens);
 	void	loadArgSet(int set);

--- a/src/TextEditor/UI/SCallTip.h
+++ b/src/TextEditor/UI/SCallTip.h
@@ -12,10 +12,11 @@ public:
 	~SCallTip();
 
 	void	setBackgroundColour(rgba_t col) { col_bg_ = col; }
-	void	setTextColour(rgba_t col) { col_fg_ = col_func_ = col_type_ = col; }
+	void	setTextColour(rgba_t col) { col_fg_ = col_func_ = col_type_ = col_keyword_ = col; }
 	void	setTextHighlightColour(rgba_t col) { col_fg_hl = col; }
 	void	setFunctionColour(rgba_t col) { col_func_ = col; }
 	void	setTypeColour(rgba_t col) { col_type_ = col; }
+	void	setKeywordColour(rgba_t col) { col_keyword_ = col; }
 	void	setCurrentArg(int arg) { arg_current_ = arg; updateSize(); }
 	void	enableArgSwitch(bool enable) { switch_contexts_ = enable; }
 	void	setFont(string face, int size);
@@ -33,6 +34,7 @@ private:
 	rgba_t			col_fg_hl;
 	rgba_t			col_func_;
 	rgba_t			col_type_;
+	rgba_t			col_keyword_;
 	int				arg_current_;
 	bool			switch_contexts_;
 	int				context_current_;

--- a/src/TextEditor/UI/SCallTip.h
+++ b/src/TextEditor/UI/SCallTip.h
@@ -48,6 +48,17 @@ private:
 	void	updateSize();
 
 	int		drawText(wxDC& dc, string text, int left, int top, wxRect* bounds);
+	wxRect	drawFunctionSpec(wxDC& dc, const TLFunction::Context& context, int left, int top);
+	wxRect	drawArgs(wxDC& dc, const TLFunction::Context& context, int left, int top, wxColour& col_faded, wxFont& bold);
+	wxRect	drawFunctionContext(
+				wxDC& dc,
+				const TLFunction::Context& context,
+				int left,
+				int top,
+				wxColour& col_faded,
+				wxFont& bold
+			);
+	wxRect	drawFunctionDescription(wxDC& dc, string desc, int left, int top, int max_width);
 	wxSize	drawCallTip(wxDC& dc, int xoff = 0, int yoff = 0);
 	void	updateBuffer();
 

--- a/src/TextEditor/UI/SCallTip.h
+++ b/src/TextEditor/UI/SCallTip.h
@@ -11,47 +11,38 @@ public:
 	SCallTip(wxWindow* parent);
 	~SCallTip();
 
-	void	setBackgroundColour(rgba_t col) { col_bg = col; }
-	void	setTextColour(rgba_t col) { col_fg = col_func = col_type = col; }
+	void	setBackgroundColour(rgba_t col) { col_bg_ = col; }
+	void	setTextColour(rgba_t col) { col_fg_ = col_func_ = col_type_ = col; }
 	void	setTextHighlightColour(rgba_t col) { col_fg_hl = col; }
-	void	setFunctionColour(rgba_t col) { col_func = col; }
-	void	setTypeColour(rgba_t col) { col_type = col; }
-	void	setCurrentArg(int arg) { arg_current = arg; updateSize(); }
-	void	enableArgSwitch(bool enable) { switch_args = enable; }
+	void	setFunctionColour(rgba_t col) { col_func_ = col; }
+	void	setTypeColour(rgba_t col) { col_type_ = col; }
+	void	setCurrentArg(int arg) { arg_current_ = arg; updateSize(); }
+	void	enableArgSwitch(bool enable) { switch_contexts_ = enable; }
 	void	setFont(string face, int size);
 
 	void	openFunction(TLFunction* function, int arg = -1);
 	void	nextArgSet();
 	void	prevArgSet();
 
-	/*struct arg_t
-	{
-		string	type;
-		string	name;
-		bool	optional;
-		arg_t() : optional(false) {}
-	};*/
-
 private:
-	TLFunction*			function;
-	TLFunction::Context	context;
+	TLFunction*			function_;
+	TLFunction::Context	context_;
 
-	rgba_t			col_bg;
-	rgba_t			col_fg;
+	rgba_t			col_bg_;
+	rgba_t			col_fg_;
 	rgba_t			col_fg_hl;
-	rgba_t			col_func;
-	rgba_t			col_type;
-	int				arg_current;
-	bool			switch_args;
-	int				arg_set_current;
-	wxRect			rect_btn_up;
-	wxRect			rect_btn_down;
-	int				btn_mouse_over;
-	wxBitmap		buffer;
-	wxFont			font;
+	rgba_t			col_func_;
+	rgba_t			col_type_;
+	int				arg_current_;
+	bool			switch_contexts_;
+	int				context_current_;
+	wxRect			rect_btn_up_;
+	wxRect			rect_btn_down_;
+	int				btn_mouse_over_;
+	wxBitmap		buffer_;
+	wxFont			font_;
 
-	void	addArg(vector<string>& tokens);
-	void	loadArgSet(int set);
+	void	loadContext(int index);
 	void	updateSize();
 
 	int		drawText(wxDC& dc, string text, int left, int top, wxRect* bounds);

--- a/src/TextEditor/UI/TextEditorCtrl.cpp
+++ b/src/TextEditor/UI/TextEditorCtrl.cpp
@@ -806,9 +806,9 @@ bool TextEditorCtrl::openCalltip(int pos, int arg, bool dwell)
 	TLFunction* func = language_->function(word);
 
 	// Show calltip if it's a function
-	if (func && func->nArgSets() > 0)
+	if (func && func->contexts().size() > 0)
 	{
-		call_tip_->enableArgSwitch(!dwell && func->nArgSets() > 1);
+		call_tip_->enableArgSwitch(!dwell && func->contexts().size() > 1);
 		call_tip_->openFunction(func, arg);
 		showCalltip(dwell ? pos : end + 1);
 
@@ -1315,7 +1315,7 @@ void TextEditorCtrl::onKeyDown(wxKeyEvent& e)
 	}
 
 	// Check for up/down keys while calltip with multiple arg sets is open
-	if (call_tip_->IsShown() && ct_function_ && ct_function_->nArgSets() > 1 && !ct_dwell_)
+	if (call_tip_->IsShown() && ct_function_ && ct_function_->contexts().size() > 1 && !ct_dwell_)
 	{
 		if (e.GetKeyCode() == WXK_UP)
 		{
@@ -1537,7 +1537,7 @@ void TextEditorCtrl::onCalltipClicked(wxStyledTextEvent& e)
 	// Argset down
 	if (e.GetPosition() == 2)
 	{
-		if ((unsigned)ct_argset_ < ct_function_->nArgSets() - 1)
+		if ((unsigned)ct_argset_ < ct_function_->contexts().size() - 1)
 		{
 			ct_argset_++;
 			updateCalltip();

--- a/src/TextEditor/UI/TextEditorCtrl.cpp
+++ b/src/TextEditor/UI/TextEditorCtrl.cpp
@@ -762,6 +762,7 @@ void TextEditorCtrl::showCalltip(int position)
 	{
 		call_tip_->setFunctionColour(ss_current->getStyle("function")->getForeground());
 		call_tip_->setTypeColour(ss_current->getStyle("type")->getForeground());
+		call_tip_->setKeywordColour(ss_current->getStyle("keyword")->getForeground());
 	}
 	if (txed_calltips_use_font)
 		call_tip_->setFont(ss_current->getDefaultFontFace(), ss_current->getDefaultFontSize());

--- a/src/TextEditor/UI/TextEditorCtrl.cpp
+++ b/src/TextEditor/UI/TextEditorCtrl.cpp
@@ -765,7 +765,7 @@ void TextEditorCtrl::showCalltip(int position)
 		call_tip_->setKeywordColour(ss_current->getStyle("keyword")->getForeground());
 	}
 	if (txed_calltips_use_font)
-		call_tip_->setFont(ss_current->getDefaultFontFace(), ss_current->getDefaultFontSize());
+		call_tip_->setFont(ss_current->getDefaultFontFace(), ss_current->getDefaultFontSize() * 0.9);
 	else
 		call_tip_->setFont("", 0);
 

--- a/src/TextEditor/UI/TextEditorCtrl.cpp
+++ b/src/TextEditor/UI/TextEditorCtrl.cpp
@@ -166,8 +166,8 @@ wxThread::ExitCode JumpToCalculator::Entry()
 //
 // TextEditorCtrl class constructor
 // ----------------------------------------------------------------------------
-TextEditorCtrl::TextEditorCtrl(wxWindow* parent, int id)
-	: wxStyledTextCtrl(parent, id), timer_update_(this)
+TextEditorCtrl::TextEditorCtrl(wxWindow* parent, int id) :
+wxStyledTextCtrl(parent, id), timer_update_(this)
 {
 	// Init variables
 	language_ = nullptr;
@@ -176,6 +176,7 @@ TextEditorCtrl::TextEditorCtrl(wxWindow* parent, int id)
 	ct_start_ = 0;
 	prev_cursor_pos_ = -1;
 	prev_text_length_ = -1;
+	prev_brace_match_ = -1;
 	panel_fr_ = nullptr;
 	call_tip_ = new SCallTip(this);
 	choice_jump_to_ = nullptr;
@@ -724,11 +725,12 @@ void TextEditorCtrl::checkBraceMatch()
 	if (bracematch != wxSTC_INVALID_POSITION)
 	{
 		BraceHighlight(GetCurrentPos(), bracematch);
-		if (refresh)
+		if (refresh && prev_brace_match_ != bracematch)
 		{
 			Refresh();
 			Update();
 		}
+		prev_brace_match_ = bracematch;
 		return;
 	}
 
@@ -737,21 +739,24 @@ void TextEditorCtrl::checkBraceMatch()
 	if (bracematch != wxSTC_INVALID_POSITION)
 	{
 		BraceHighlight(GetCurrentPos() - 1, bracematch);
-		if (refresh)
+		if (refresh && prev_brace_match_ != bracematch)
 		{
 			Refresh();
 			Update();
 		}
+		prev_brace_match_ = bracematch;
 		return;
 	}
 
 	// No match at all, clear any previous brace match
 	BraceHighlight(-1, -1);
-	if (refresh)
+	if (refresh && prev_brace_match_ != -1)
 	{
 		Refresh();
 		Update();
 	}
+
+	prev_brace_match_ = -1;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/TextEditor/UI/TextEditorCtrl.h
+++ b/src/TextEditor/UI/TextEditorCtrl.h
@@ -85,16 +85,16 @@ public:
 	void 	blockComment();
 
 private:
-	TextLanguage*		language_;
-	FindReplacePanel*	panel_fr_;
-	SCallTip*			call_tip_;
-	wxChoice*			choice_jump_to_;
-	JumpToCalculator*	jump_to_calculator_;
-	Lexer				lexer_;
-	string				prev_word_match_;
-	string				autocomp_list_;
-	vector<int>			jump_to_lines_;
-	long				last_modified_;
+	TextLanguage*			language_;
+	FindReplacePanel*		panel_fr_;
+	SCallTip*				call_tip_;
+	wxChoice*				choice_jump_to_;
+	JumpToCalculator*		jump_to_calculator_;
+	std::unique_ptr<Lexer>	lexer_;
+	string					prev_word_match_;
+	string					autocomp_list_;
+	vector<int>				jump_to_lines_;
+	long					last_modified_;
 
 	// State tracking for updates
 	int	prev_cursor_pos_;

--- a/src/TextEditor/UI/TextEditorCtrl.h
+++ b/src/TextEditor/UI/TextEditorCtrl.h
@@ -79,7 +79,6 @@ public:
 	// Folding
 	void	foldAll(bool fold = true);
 	void	setupFolding();
-	void	updateFolding();
 
 	// Comments
 	void	lineComment();

--- a/src/TextEditor/UI/TextEditorCtrl.h
+++ b/src/TextEditor/UI/TextEditorCtrl.h
@@ -99,6 +99,7 @@ private:
 	// State tracking for updates
 	int	prev_cursor_pos_;
 	int	prev_text_length_;
+	int prev_brace_match_;
 
 	// Timed update stuff
 	wxTimer	timer_update_;

--- a/src/Utility/StringUtils.h
+++ b/src/Utility/StringUtils.h
@@ -16,6 +16,8 @@ namespace StringUtils
 	static string	CARET = "^";
 	static string	ESCAPED_QUOTE_DOUBLE = "\\\"";
 	static string	ESCAPED_SLASH_BACK = "\\\\";
+	static string	CURLYBRACE_OPEN = "{";
+	static string	CURLYBRACE_CLOSE = "}";
 
 	string	escapedString(const string& str, bool swap_backslash = false);
 

--- a/src/Utility/Tokenizer.cpp
+++ b/src/Utility/Tokenizer.cpp
@@ -212,6 +212,26 @@ bool Tokenizer::advIf(const char* check, int inc)
 
 	return false;
 }
+bool Tokenizer::advIf(const string& check, int inc)
+{
+	if (token_current_ == check)
+	{
+		adv(inc);
+		return true;
+	}
+
+	return false;
+}
+bool Tokenizer::advIf(char check, int inc)
+{
+	if (token_current_[0] == check)
+	{
+		adv(inc);
+		return true;
+	}
+
+	return false;
+}
 
 // ----------------------------------------------------------------------------
 // Tokenizer::advIfNC
@@ -219,6 +239,16 @@ bool Tokenizer::advIf(const char* check, int inc)
 // Advances [inc] tokens if the current token matches [check] (Case-Insensitive)
 // ----------------------------------------------------------------------------
 bool Tokenizer::advIfNC(const char* check, int inc)
+{
+	if (S_CMPNOCASE(token_current_.text, check))
+	{
+		adv(inc);
+		return true;
+	}
+
+	return false;
+}
+bool Tokenizer::advIfNC(const string& check, int inc)
 {
 	if (S_CMPNOCASE(token_current_.text, check))
 	{

--- a/src/Utility/Tokenizer.cpp
+++ b/src/Utility/Tokenizer.cpp
@@ -143,7 +143,7 @@ void Tokenizer::Token::toBool(bool& val) const
 //
 // Tokenizer class constructor
 // ----------------------------------------------------------------------------
-Tokenizer::Tokenizer(CommentTypes comments, const string& special_characters) :
+Tokenizer::Tokenizer(int comments, const string& special_characters) :
 	comment_types_{ comments },
 	special_characters_{special_characters.begin(), special_characters.end()},
 	decorate_{ false },

--- a/src/Utility/Tokenizer.h
+++ b/src/Utility/Tokenizer.h
@@ -66,7 +66,7 @@ public:
 
 	// Constructors
 	Tokenizer(
-		CommentTypes comments = CommentTypes::Default,
+		int comments = CommentTypes::Default,
 		const string& special_characters = DEFAULT_SPECIAL_CHARACTERS
 	);
 
@@ -78,7 +78,7 @@ public:
 	const Token&	peek() const;
 
 	// Modifiers
-	void	setCommentTypes(CommentTypes types) { comment_types_ = types; }
+	void	setCommentTypes(int types) { comment_types_ = types; }
 	void 	setSpecialCharacters(const char* characters)
 			{ special_characters_.assign(characters, characters + strlen(characters)); }
 	void	setSource(const string& source) { source_ = source; }
@@ -153,7 +153,7 @@ private:
 	TokenizeState	state_;
 
 	// Configuration
-	CommentTypes	comment_types_;			// Types of comments to skip
+	int				comment_types_;			// Types of comments to skip
 	vector<char>	special_characters_;	// These will always be read as separate tokens
 	string			source_;				// What file/entry/chunk is being tokenized
 	bool			decorate_;				// Special handling for //$ comments

--- a/src/Utility/Tokenizer.h
+++ b/src/Utility/Tokenizer.h
@@ -26,9 +26,9 @@ public:
 		explicit	operator	const string() const { return text; }
 		explicit	operator	const char*() const { return CHR(text); }
 		bool		operator	==(const string& cmp) const { return text == cmp; }
-		bool		operator	==(const char* cmp) const { return text == cmp; }
+		bool		operator	==(const char* cmp) const { return text.Cmp(cmp) == 0; }
 		bool		operator	!=(const string& cmp) const { return text != cmp; }
-		bool		operator	!=(const char* cmp) const { return text != cmp; }
+		bool		operator	!=(const char* cmp) const { return text.Cmp(cmp) != 0; }
 		char		operator	[](unsigned index) const { return text[index]; }
 
 		bool	isInteger(bool allow_hex = false) const;
@@ -90,7 +90,10 @@ public:
 	const Token&	next();
 	void			adv(int inc = 1);
 	bool			advIf(const char* check, int inc = 1);
+	bool			advIf(const string& check, int inc = 1);
+	bool			advIf(char check, int inc = 1);
 	bool			advIfNC(const char* check, int inc = 1);
+	bool			advIfNC(const string& check, int inc = 1);
 	bool			advIfNext(const char* check, int inc = 1);
 	bool			advIfNextNC(const char* check, int inc = 1);
 	void			advToNextLine();
@@ -103,6 +106,8 @@ public:
 
 	// Token Checking
 	bool	check(const char* check) const { return token_current_ == check; }
+	bool	check(const string& check) const { return token_current_ == check; }
+	bool	check(char check) const { return token_current_[0] == check; }
 	bool	checkOrEnd(const char* check) const;
 	bool	checkNC(const char* check) const { return S_CMPNOCASE(token_current_.text, check); }
 	bool	checkOrEndNC(const char* check) const;


### PR DESCRIPTION
* ZScript is now parsed from a configured (g)zdoom.pk3 file on startup and imported to the 'ZScript' text language
  * Added controls to browse for the pk3 on the base resource configuration panel
* ZScript in open archives is parsed:
  * Used for thing type definitions in the map editor (same as `DECORATE`)
  * Imported to the ZScript text editor language (functions and class names only for now)
* Various improvements to the text editor:
  * Call tip improvements:
    * Show default parameter values
    * Show (some) function qualifiers
    * Show all function contexts in hover call tips (instead of just the first and a '(+#)' indicator)
    * Show if the function is deprecated (and the deprecated version)
  * Added more text editor customisation options:
    * 'Extra Line Height' setting to increase line height
    * 'Indent With Spaces' option
    * 'Show Whitespace' option
  * Fixed slowness with brace matching enabled in windows
  * Improved lexer for ZScript that won't highlight function names if they aren't followed by `(`