### PR TITLE
Fixed compilation with Clang

### DIFF
--- a/src/Game/ZScript.cpp
+++ b/src/Game/ZScript.cpp
@@ -618,7 +618,7 @@ bool StateTable::parse(ParsedStatement& states)
 				statement.tokens[index + 2].ToLong(&duration);
 
 			for (auto& state : current_states)
-				states_[state].frames.push_back({ statement.tokens[index], statement.tokens[index + 1], duration });
+				states_[state].frames.push_back({ statement.tokens[index], statement.tokens[index + 1], static_cast<int>(duration) });
 		}
 	}
 


### PR DESCRIPTION
64-bit target has 4 bytes int and 8 bytes long types which cause the following compilation error:

```src/Game/ZScript.cpp:621:93: error: non-constant-expression cannot be narrowed from type 'long' to 'int' in initializer list [-Wc++11-narrowing]```