### PR TITLE
Fixed UI scaling on macOS

### DIFF
--- a/src/Application/SLADEWxApp.cpp
+++ b/src/Application/SLADEWxApp.cpp
@@ -574,9 +574,14 @@ bool SLADEWxApp::OnInit()
 	// Load image handlers
 	wxInitAllImageHandlers();
 
+#ifdef __APPLE__
+	// Should be constant, wxWidgets Cocoa backend scales everything under the hood
+	const double ui_scale = 1.0;
+#else // !__APPLE__
 	// Calculate scaling factor (from system ppi)
 	wxMemoryDC dc;
 	double ui_scale = (double)(dc.GetPPI().x) / 96.0;
+#endif // __APPLE__
 
 	// Get Windows version
 #ifdef __WXMSW__


### PR DESCRIPTION
wxMemoryDC::GetPPI().x from wxWidgets 3.1 is equal to 72 which led to weird 75% scaling on macOS