### PR TITLE
Add appdata

### DIFF
--- a/net.mancubus.SLADE.appdata.xml
+++ b/net.mancubus.SLADE.appdata.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+	<id>net.mancubus.SLADE</id>
+	<name>SLADE</name>
+	<summary>It's a Doom editor</summary>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>GPL-2.0</project_license>
+	<developer_name>Simon Judd</developer_name>
+	<url type="homepage">http://slade.mancubus.net/</url>
+	<url type="bugtracker">https://github.com/sirjuddington/SLADE/issues</url>
+	<description>
+		<p>
+			SLADE3 is a modern editor for Doom-engine based games and source ports. It has the ability to view, modify, and write many different game-specific formats, and even convert between some of them, or from/to other generic formats such as PNG.
+		</p>
+		<p>
+			SLADE3 can be considered a successor to both SLumpEd and SLADE - it combines the features of both, to create an all-in-one editor. Why does it keep the name of what was previously just a map editor? Because it fits :)
+		</p>
+		<p>
+			As with SLumpEd and previous versions of SLADE, SLADE3 is fully cross-platform. It can be run on various operating systems, including Windows, Linux and Mac OS/X. So no matter your preferred OS, SLADE3 is available for you.
+		</p>
+	</description>
+	<screenshots>
+		<screenshot>
+			<image>http://slade.mancubus.net/shots/gfx_t.png</image>
+			<caption>The basic editor view</caption>
+		</screenshot>
+		<screenshot>
+			<image>http://slade.mancubus.net/shots/textures_t.png</image>
+			<caption>Texture editor - also supports ZDoom TEXTURES</caption>
+		</screenshot>
+		<screenshot>
+			<image>http://slade.mancubus.net/shots/text_t.png</image>
+			<caption>Advanced text editor</caption>
+		</screenshot>
+		<screenshot>
+			<image>http://slade.mancubus.net/shots/ansi_t.png</image>
+			<caption>ANSI screen preview</caption>
+		</screenshot>
+		<screenshot>
+			<image>http://slade.mancubus.net/shots/gfxconv_t.png</image>
+			<caption>Convert graphics between formats/palettes</caption>
+		</screenshot>
+		<screenshot>
+			<image>http://slade.mancubus.net/shots/gfxremap_t.png</image>
+			<caption>Remap colours in graphics</caption>
+		</screenshot>
+		<screenshot>
+			<image>http://slade.mancubus.net/shots/map_t.png</image>
+			<caption>The map editor</caption>
+		</screenshot>
+		<screenshot  type="default">
+			<image>http://slade.mancubus.net/shots/map3d_t.png</image>
+			<caption>Map editor 3d mode</caption>
+		</screenshot>
+		<screenshot>
+			<image>http://slade.mancubus.net/shots/mapudmf_t.png</image>
+			<caption>UDMF format support includes ZDoom extensions</caption>
+		</screenshot>
+	</screenshots>
+	<releases>
+		<release date="2017-01-18" version="3.1.1.5"/>
+		<release date="2017-09-26" version="3.1.1.4"/>
+		<release date="2016-06-25" version="3.1.1.3"/>
+	</releases>
+	<content_rating type="oars-1.1">
+		<content_attribute id="violence-cartoon">none</content_attribute>
+		<content_attribute id="violence-fantasy">none</content_attribute>
+		<content_attribute id="violence-realistic">none</content_attribute>
+		<content_attribute id="violence-bloodshed">none</content_attribute>
+		<content_attribute id="violence-sexual">none</content_attribute>
+		<content_attribute id="violence-desecration">none</content_attribute>
+		<content_attribute id="violence-slavery">none</content_attribute>
+		<content_attribute id="violence-worship">none</content_attribute>
+		<content_attribute id="drugs-alcohol">none</content_attribute>
+		<content_attribute id="drugs-narcotics">none</content_attribute>
+		<content_attribute id="drugs-tobacco">none</content_attribute>
+		<content_attribute id="sex-nudity">none</content_attribute>
+		<content_attribute id="sex-themes">none</content_attribute>
+		<content_attribute id="sex-homosexuality">none</content_attribute>
+		<content_attribute id="sex-prostitution">none</content_attribute>
+		<content_attribute id="sex-adultery">none</content_attribute>
+		<content_attribute id="sex-appearance">none</content_attribute>
+		<content_attribute id="language-profanity">none</content_attribute>
+		<content_attribute id="language-humor">none</content_attribute>
+		<content_attribute id="language-discrimination">none</content_attribute>
+		<content_attribute id="social-chat">none</content_attribute>
+		<content_attribute id="social-info">none</content_attribute>
+		<content_attribute id="social-audio">none</content_attribute>
+		<content_attribute id="social-location">none</content_attribute>
+		<content_attribute id="social-contacts">none</content_attribute>
+		<content_attribute id="money-purchasing">none</content_attribute>
+		<content_attribute id="money-gambling">none</content_attribute>
+	</content_rating>
+</component>

--- a/net.mancubus.SLADE.desktop
+++ b/net.mancubus.SLADE.desktop
@@ -4,5 +4,5 @@ Exec=slade
 Type=Application
 Categories=Development
 Comment=It's a Doom editor
-Icon=slade
+Icon=net.mancubus.SLADE
 Terminal=false

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,11 +146,15 @@ else(APPLE)
 		
 		install(FILES "${PROJECT_SOURCE_DIR}/dist/res/logo_icon.png"
 			DESTINATION share/icons/
-			RENAME slade.png
+			RENAME net.mancubus.SLADE.png
 			)
 
-		install(FILES "${PROJECT_SOURCE_DIR}/slade.desktop"
+		install(FILES "${PROJECT_SOURCE_DIR}/net.mancubus.SLADE.desktop"
 			DESTINATION share/applications/
+			)
+
+		install(FILES "${PROJECT_SOURCE_DIR}/net.mancubus.SLADE.appdata.xml"
+			DESTINATION share/appdata/
 			)
 	endif(UNIX)
 endif(APPLE)


### PR DESCRIPTION
This adds an [AppData](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps) file, which makes applications look better in Gnome Software & KDE Discover.

Also, this changes the ID of the desktop file to use the same reverse domain name notation.