### PR TITLE
Fixed “modeids” typo

### DIFF
--- a/dist/res/config/ports/include/props_zdoom.cfg
+++ b/dist/res/config/ports/include/props_zdoom.cfg
@@ -544,7 +544,7 @@ udmf_properties
 				default = "";
 			}
 
-			property modeids
+			property moreids
 			{
 				name = "Additional Sector Tags";
 				type = "string";


### PR DESCRIPTION
Fixed a typo where the “moreids” property was actually called “modeids"