### PR TITLE
Make txed_{export,extract} texts match their functions

### DIFF
--- a/dist/res/actions/txed.cfg
+++ b/dist/res/actions/txed.cfg
@@ -47,14 +47,14 @@ action txed_rename_each
 
 action txed_export
 {
-	text		= "Export Texture";
+	text		= "Patch";
 	icon		= "tex_export";
 	help_text	= "Create standalone images from the selected texture(s)";
 }
 
 action txed_extract
 {
-	text		= "Extract Texture";
+	text		= "PNG File";
 	icon		= "tex_extract";
 	help_text	= "Export the selected texture(s) as PNG files";
 }


### PR DESCRIPTION
"Export Texture" really converts a composite texture to a single patch, and "Extract Texture" exports composite textures to PNG files. I also used "Patch" and "PNG file" because these menu items were on a submenu titled "Export To".

This pull request is on master rather than stable, and changes a config file rather than the code.