### PR TITLE
Fix minor compiler warnings

### DIFF
--- a/src/Application/SLADEWxApp.h
+++ b/src/Application/SLADEWxApp.h
@@ -16,7 +16,7 @@ public:
 	void OnFatalException() override;
 
 #ifdef __APPLE__
-	virtual void MacOpenFile(const wxString &fileName);
+	virtual void MacOpenFile(const wxString &fileName) override;
 #endif // __APPLE__
 
 	bool	singleInstanceCheck();

--- a/src/Audio/AudioTags.cpp
+++ b/src/Audio/AudioTags.cpp
@@ -408,7 +408,7 @@ string ParseID3v2Tag(MemChunk& mc, size_t start)
 		// Process only text frames that aren't empty
 		// Also skip flags, not gonna bother with encryption or compression
 		if ((mc[s] == 'T' || (mc[s] == 'C' && mc[s+1] == 'O' && mc[s+2] == 'M'))
-			&& tsize > 0 && (v22 || mc[s+8] == 0 && mc[s+9] == 0))
+			&& tsize > 0 && (v22 || (mc[s+8] == 0 && mc[s+9] == 0)))
 		{
 			string content;
 

--- a/src/External/zreaders/files.cpp
+++ b/src/External/zreaders/files.cpp
@@ -45,18 +45,18 @@
 //==========================================================================
 
 FileReader::FileReader ()
-: File(NULL), Length(0), StartPos(0), CloseOnDestruct(false), Status(0), Message("OK")
+: Status(0), Message("OK"), File(NULL), Length(0), StartPos(0), CloseOnDestruct(false)
 {
 }
 
 FileReader::FileReader (const FileReader &other, long length)
-: File(other.File), Length(length), CloseOnDestruct(false), Status(other.Status), Message(other.Message)
+: Status(other.Status), Message(other.Message), File(other.File), Length(length), CloseOnDestruct(false)
 {
 	FilePos = StartPos = ftell (other.File);
 }
 
 FileReader::FileReader (const char *filename)
-: File(NULL), Length(0), StartPos(0), FilePos(0), CloseOnDestruct(false), Status(0), Message("OK")
+: Status(0), Message("OK"), File(NULL), Length(0), StartPos(0), FilePos(0), CloseOnDestruct(false)
 {
 	if (!Open(filename))
 	{
@@ -66,13 +66,13 @@ FileReader::FileReader (const char *filename)
 }
 
 FileReader::FileReader (FILE *file)
-: File(file), Length(0), StartPos(0), FilePos(0), CloseOnDestruct(false), Status(0), Message("OK")
+: Status(0), Message("OK"), File(file), Length(0), StartPos(0), FilePos(0), CloseOnDestruct(false)
 {
 	Length = CalcFileLen();
 }
 
 FileReader::FileReader (FILE *file, long length)
-: File(file), Length(length), CloseOnDestruct(true), Status(0), Message("OK")
+: Status(0), Message("OK"), File(file), Length(length), CloseOnDestruct(true)
 {
 	FilePos = StartPos = ftell (file);
 }

--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -598,7 +598,7 @@ bool EntryOperations::modifyalPhChunk(ArchiveEntry* entry, bool value)
 
 		// Create new alPh chunk
 		uint32_t csize = wxUINT32_SWAP_ON_LE(0);
-		alph_chunk_t gc = { 'a', 'l', 'P', 'h' };
+        alph_chunk_t gc = { {'a', 'l', 'P', 'h'} };
 		uint32_t dcrc = wxUINT32_SWAP_ON_LE(Misc::crc((uint8_t*)&gc, 4));
 
 		// Create alPh chunk
@@ -721,7 +721,7 @@ bool EntryOperations::modifytRNSChunk(ArchiveEntry* entry, bool value)
 
 		// Create new tRNS chunk
 		uint32_t csize = wxUINT32_SWAP_ON_LE(1);
-		trans_chunk_t gc = { 't', 'R', 'N', 'S', '\0' };
+        trans_chunk_t gc = { {'t', 'R', 'N', 'S', '\0'} };
 		uint32_t dcrc = wxUINT32_SWAP_ON_LE(Misc::crc((uint8_t*)&gc, 5));
 
 		// Write tRNS chunk

--- a/src/MainEditor/ExternalEditManager.cpp
+++ b/src/MainEditor/ExternalEditManager.cpp
@@ -56,8 +56,8 @@ class ExternalEditFileMonitor : public FileMonitor, Listener
 public:
 	ExternalEditFileMonitor(ArchiveEntry* entry, ExternalEditManager* manager)
 		: FileMonitor("", false),
-		manager(manager),
-		entry(entry)
+		entry(entry),
+		manager(manager)
 	{
 		// Listen to entry parent archive
 		listenTo(entry->getParent());

--- a/src/MainEditor/UI/ArchivePanel.h
+++ b/src/MainEditor/UI/ArchivePanel.h
@@ -168,9 +168,9 @@ class EntryDataUS : public UndoStep
 {
 public:
 	EntryDataUS(ArchiveEntry* entry) :
-		archive_{ entry->getParent() },
 		path_{ entry->getPath() },
-		index_{ (unsigned)entry->getParentDir()->entryIndex(entry) }
+		index_{ (unsigned)entry->getParentDir()->entryIndex(entry) },
+		archive_{ entry->getParent() }
 	{
 		data_.importMem(entry->getData(), entry->getSize());
 	}

--- a/src/MainEditor/UI/EntryPanel/AudioEntryPanel.cpp
+++ b/src/MainEditor/UI/EntryPanel/AudioEntryPanel.cpp
@@ -573,6 +573,8 @@ void AudioEntryPanel::startStream()
 		theMIDIPlayer->play(); break;
 	case Media:
 		if (media_ctrl_) media_ctrl_->Play(); break;
+	default:
+		break;
 	}
 }
 
@@ -595,6 +597,8 @@ void AudioEntryPanel::stopStream()
 		theMIDIPlayer->pause();	break;
 	case Media:
 		if (media_ctrl_) media_ctrl_->Pause(); break;
+	default:
+		break;
 	}
 }
 
@@ -618,6 +622,8 @@ void AudioEntryPanel::resetStream()
 		theMIDIPlayer->stop(); break;
 	case Media:
 		if (media_ctrl_) media_ctrl_->Stop(); break;
+	default:
+		break;
 	}
 }
 
@@ -693,6 +699,8 @@ bool AudioEntryPanel::updateInfo()
 		}
 		info += theOPLPlayer->getInfo();
 		break;*/
+	default:
+		break;
 	}
 	txt_info_->SetValue(info);
 	if (info.length())
@@ -817,6 +825,8 @@ void AudioEntryPanel::onTimer(wxTimerEvent& e)
 		pos = theMIDIPlayer->getPosition(); break;
 	case Media:
 		if (media_ctrl_) pos = media_ctrl_->Tell(); break;
+	default:
+		break;
 	}
 
 	// Set slider
@@ -855,6 +865,8 @@ void AudioEntryPanel::onSliderSeekChanged(wxCommandEvent& e)
 		theMIDIPlayer->setPosition(slider_seek_->GetValue()); break;
 	case Media:
 		if (media_ctrl_) media_ctrl_->Seek(slider_seek_->GetValue()); break;
+	default:
+		break;
 	}
 }
 
@@ -879,5 +891,7 @@ void AudioEntryPanel::onSliderVolumeChanged(wxCommandEvent& e)
 		if (media_ctrl_) media_ctrl_->SetVolume(snd_volume*0.01); break;
 	case Mod:
 		mod_->setVolume(snd_volume); break;
+	default:
+		break;
 	}
 }

--- a/src/MapEditor/MapEditContext.cpp
+++ b/src/MapEditor/MapEditContext.cpp
@@ -720,6 +720,8 @@ void MapEditContext::updateTagged()
 				case TagType::Interpolation:
 					if (tid) map_.getThingsById(tid, tagged_things_, 0, 9075);
 					break;
+				default:
+					break;
 				}
 			}
 		}

--- a/src/MapEditor/SLADEMap/SLADEMap.cpp
+++ b/src/MapEditor/SLADEMap/SLADEMap.cpp
@@ -3544,11 +3544,15 @@ void SLADEMap::getTaggingThingsById(int id, int type, vector<MapThing*>& list, i
 			case TagType::Patrol:
 				path_type = 9047;
 			case TagType::Interpolation:
+			{
 				path_type = 9075;
 
 				tid = things_[a]->intProperty("id");
 				auto& tt = Game::configuration().thingType(things_[a]->getType());
 				fits = ((path_type == ttype) && (IDEQ(tid)) && (tt.needsTag() == needs_tag));
+			}
+				break;
+			default:
 				break;
 			}
 			if (fits) list.push_back(things_[a]);

--- a/src/TextEditor/UI/TextEditorCtrl.cpp
+++ b/src/TextEditor/UI/TextEditorCtrl.cpp
@@ -168,8 +168,8 @@ wxThread::ExitCode JumpToCalculator::Entry()
 // ----------------------------------------------------------------------------
 TextEditorCtrl::TextEditorCtrl(wxWindow* parent, int id) :
 	wxStyledTextCtrl(parent, id),
-	timer_update_(this),
-	lexer_{ std::make_unique<Lexer>() }
+	lexer_{ std::make_unique<Lexer>() },
+	timer_update_(this)
 {
 	// Init variables
 	language_ = nullptr;


### PR DESCRIPTION
There are several warnings detected by Clang on macOS. The ones trivial to fix are solved in this pull request. The others (such as unused variables – lots of them – or deprecated OpenGL calls) seem the result of deliberate coding, so I didn't touch them.