### PR TITLE
Add full path texture support to the map editor

### DIFF
--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -554,7 +554,7 @@ void MapTextureManager::buildTexInfoList()
 			{
 				// Determine texture path if it's in a pk3
 				string path = patches[a]->getPath();
-				string extn = patches[a]->getType()->extension();
+				string extn = patches[a]->getName(false).AfterLast('.');
 				/*
 				if (path.StartsWith("/textures/"))
 					path.Remove(0, 9);

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -554,14 +554,17 @@ void MapTextureManager::buildTexInfoList()
 			{
 				// Determine texture path if it's in a pk3
 				string path = patches[a]->getPath();
+				string extn = patches[a]->getType()->extension();
+				/*
 				if (path.StartsWith("/textures/"))
 					path.Remove(0, 9);
 				else if (path.StartsWith("/hires/"))
 					path.Remove(0, 6);
 				else
 					path = "";
+				*/
 
-				tex_info.push_back(map_texinfo_t(patches[a]->getName(true), TC_TX, patches[a]->getParent(), path));
+				tex_info.push_back(map_texinfo_t(patches[a]->getName(true), TC_TX, patches[a]->getParent(), path, 0, extn));
 			}
 		}
 	}
@@ -575,12 +578,15 @@ void MapTextureManager::buildTexInfoList()
 
 		// Determine flat path if it's in a pk3
 		string path = entry->getPath();
+		string extn = entry->getType()->extension();
+		/*
 		if (path.StartsWith("/flats/") || path.StartsWith("/hires/"))
 			path.Remove(0, 6);
 		else
 			path = "";
+		*/
 
-		flat_info.push_back(map_texinfo_t(entry->getName(true), TC_NONE, flats[a]->getParent(), path));
+		flat_info.push_back(map_texinfo_t(entry->getName(true), TC_NONE, flats[a]->getParent(), path, 0, extn));
 	}
 }
 

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -530,22 +530,22 @@ void MapTextureManager::buildTexInfoList()
 		CTexture * tex = &textures[a]->tex;
 		Archive* parent = textures[a]->parent;
 
-		string shortName = tex->getName().Truncate(8);
+		//string shortName = tex->getName().Truncate(8);
 		string longName = tex->getName();
 		string path = longName.BeforeLast('/');
 
 		if (tex->isExtended())
 		{
 			if (S_CMPNOCASE(tex->getType(), "texture") || S_CMPNOCASE(tex->getType(), "walltexture"))
-				tex_info.push_back(map_texinfo_t(shortName, TC_TEXTURES, parent, path, tex->getIndex(), longName));
+				tex_info.push_back(map_texinfo_t(longName, TC_TEXTURES, parent, path, tex->getIndex(), longName));
 			else if (S_CMPNOCASE(tex->getType(), "define"))
-				tex_info.push_back(map_texinfo_t(shortName, TC_HIRES, parent, path, tex->getIndex(), longName));
+				tex_info.push_back(map_texinfo_t(longName, TC_HIRES, parent, path, tex->getIndex(), longName));
 			else if (S_CMPNOCASE(tex->getType(), "flat"))
-				flat_info.push_back(map_texinfo_t(shortName, TC_TEXTURES, parent, path, tex->getIndex(), longName));
+				flat_info.push_back(map_texinfo_t(longName, TC_TEXTURES, parent, path, tex->getIndex(), longName));
 			// Ignore graphics, patches and sprites
 		}
 		else
-			tex_info.push_back(map_texinfo_t(shortName, TC_TEXTUREX, parent, path, tex->getIndex() + 1, longName));
+			tex_info.push_back(map_texinfo_t(longName, TC_TEXTUREX, parent, path, tex->getIndex() + 1, longName));
 	}
 
 	// Texture namespace patches (TX_)

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -529,18 +529,23 @@ void MapTextureManager::buildTexInfoList()
 	{
 		CTexture * tex = &textures[a]->tex;
 		Archive* parent = textures[a]->parent;
+
+		string shortName = tex->getName().Truncate(8);
+		string longName = tex->getName();
+		string path = longName.BeforeLast('/');
+
 		if (tex->isExtended())
 		{
 			if (S_CMPNOCASE(tex->getType(), "texture") || S_CMPNOCASE(tex->getType(), "walltexture"))
-				tex_info.push_back(map_texinfo_t(tex->getName(), TC_TEXTURES, parent));
+				tex_info.push_back(map_texinfo_t(shortName, TC_TEXTURES, parent, path, tex->getIndex(), longName));
 			else if (S_CMPNOCASE(tex->getType(), "define"))
-				tex_info.push_back(map_texinfo_t(tex->getName(), TC_HIRES, parent));
+				tex_info.push_back(map_texinfo_t(shortName, TC_HIRES, parent, path, tex->getIndex(), longName));
 			else if (S_CMPNOCASE(tex->getType(), "flat"))
-				flat_info.push_back(map_texinfo_t(tex->getName(), TC_TEXTURES, parent));
+				flat_info.push_back(map_texinfo_t(shortName, TC_TEXTURES, parent, path, tex->getIndex(), longName));
 			// Ignore graphics, patches and sprites
 		}
 		else
-			tex_info.push_back(map_texinfo_t(tex->getName(), TC_TEXTUREX, parent, "", tex->getIndex() + 1));
+			tex_info.push_back(map_texinfo_t(shortName, TC_TEXTUREX, parent, path, tex->getIndex() + 1, longName));
 	}
 
 	// Texture namespace patches (TX_)
@@ -553,8 +558,9 @@ void MapTextureManager::buildTexInfoList()
 			if (patches[a]->isInNamespace("textures") || patches[a]->isInNamespace("hires"))
 			{
 				// Determine texture path if it's in a pk3
-				string path = patches[a]->getPath();
-				string extn = patches[a]->getName(false).AfterLast('.');
+				string longName = patches[a]->getPath(true).Remove(0, 1);
+				string shortName = patches[a]->getName(true).Truncate(8);
+				string path = patches[a]->getPath(false);
 				/*
 				if (path.StartsWith("/textures/"))
 					path.Remove(0, 9);
@@ -564,7 +570,7 @@ void MapTextureManager::buildTexInfoList()
 					path = "";
 				*/
 
-				tex_info.push_back(map_texinfo_t(patches[a]->getName(true), TC_TX, patches[a]->getParent(), path, 0, extn));
+				tex_info.push_back(map_texinfo_t(shortName, TC_TX, patches[a]->getParent(), path, 0, longName));
 			}
 		}
 	}
@@ -577,8 +583,9 @@ void MapTextureManager::buildTexInfoList()
 		ArchiveEntry* entry = flats[a];
 
 		// Determine flat path if it's in a pk3
-		string path = entry->getPath();
-		string extn = entry->getType()->extension();
+		string longName = entry->getPath(true).Remove(0, 1);
+		string shortName = entry->getName(true).Truncate(8);
+		string path = entry->getPath(false);
 		/*
 		if (path.StartsWith("/flats/") || path.StartsWith("/hires/"))
 			path.Remove(0, 6);
@@ -586,7 +593,7 @@ void MapTextureManager::buildTexInfoList()
 			path = "";
 		*/
 
-		flat_info.push_back(map_texinfo_t(entry->getName(true), TC_NONE, flats[a]->getParent(), path, 0, extn));
+		flat_info.push_back(map_texinfo_t(shortName, TC_NONE, flats[a]->getParent(), path, 0, longName));
 	}
 }
 

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -559,7 +559,7 @@ void MapTextureManager::buildTexInfoList()
 			{
 				// Determine texture path if it's in a pk3
 				string longName = patches[a]->getPath(true).Remove(0, 1);
-				string shortName = patches[a]->getName(true).Truncate(8);
+				string shortName = patches[a]->getName(true).Truncate(8).Upper();
 				string path = patches[a]->getPath(false);
 				/*
 				if (path.StartsWith("/textures/"))
@@ -584,7 +584,7 @@ void MapTextureManager::buildTexInfoList()
 
 		// Determine flat path if it's in a pk3
 		string longName = entry->getPath(true).Remove(0, 1);
-		string shortName = entry->getName(true).Truncate(8);
+		string shortName = entry->getName(true).Truncate(8).Upper();
 		string path = entry->getPath(false);
 		/*
 		if (path.StartsWith("/flats/") || path.StartsWith("/hires/"))

--- a/src/MapEditor/MapTextureManager.h
+++ b/src/MapEditor/MapTextureManager.h
@@ -21,14 +21,16 @@ struct map_texinfo_t
 	string			path;
 	unsigned		index;
 	Archive*		archive;
+	string			extension;
 
-	map_texinfo_t(string name, uint8_t category, Archive* archive, string path = "", unsigned index = 0)
+	map_texinfo_t(string name, uint8_t category, Archive* archive, string path = "", unsigned index = 0, string extension = "")
 	{
 		this->name = name;
 		this->category = category;
 		this->archive = archive;
 		this->path = path;
 		this->index = index;
+		this->extension = extension;
 	}
 };
 
@@ -73,7 +75,7 @@ public:
 	GLTexture*		getSprite(string name, string translation = "", string palette = "");
 	GLTexture*		getEditorImage(string name);
 	int				getVerticalOffset(string name);
-	
+
 	vector<map_texinfo_t>&	getAllTexturesInfo() { return tex_info; }
 	vector<map_texinfo_t>&	getAllFlatsInfo() { return flat_info; }
 

--- a/src/MapEditor/MapTextureManager.h
+++ b/src/MapEditor/MapTextureManager.h
@@ -16,21 +16,16 @@ struct map_tex_t
 class Archive;
 struct map_texinfo_t
 {
-	string			name;
+	string			shortName;
 	uint8_t			category;
+	Archive*		archive;
 	string			path;
 	unsigned		index;
-	Archive*		archive;
-	string			extension;
+	string			longName;
 
-	map_texinfo_t(string name, uint8_t category, Archive* archive, string path = "", unsigned index = 0, string extension = "")
+	map_texinfo_t(string shortName, uint8_t category, Archive* archive, string path, unsigned index = 0, string longName = "")
+	: shortName(shortName), category(category), archive(archive), path(path), index(index), longName(longName)
 	{
-		this->name = name;
-		this->category = category;
-		this->archive = archive;
-		this->path = path;
-		this->index = index;
-		this->extension = extension;
 	}
 };
 

--- a/src/MapEditor/Renderer/Overlays/QuickTextureOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/QuickTextureOverlay3d.cpp
@@ -108,7 +108,8 @@ QuickTextureOverlay3d::QuickTextureOverlay3d(MapEditContext* editor)
 			vector<map_texinfo_t>& ti = MapEditor::textureManager().getAllTexturesInfo();
 			for (unsigned a = 0; a < ti.size(); a++) {
 				tex_names.push_back(ti[a].shortName);
-				if (Game::configuration().featureSupported(Game::Feature::LongNames)) {
+				if (Game::configuration().featureSupported(Game::Feature::LongNames) &&
+						ti[a].shortName.CmpNoCase(ti[a].longName) != 0) {
 					tex_names.push_back(ti[a].longName);
 				}
 			}
@@ -118,7 +119,8 @@ QuickTextureOverlay3d::QuickTextureOverlay3d(MapEditContext* editor)
 			vector<map_texinfo_t>& ti = MapEditor::textureManager().getAllFlatsInfo();
 			for (unsigned a = 0; a < ti.size(); a++) {
 				tex_names.push_back(ti[a].shortName);
-				if (Game::configuration().featureSupported(Game::Feature::LongNames)) {
+				if (Game::configuration().featureSupported(Game::Feature::LongNames) &&
+						ti[a].shortName.CmpNoCase(ti[a].longName) != 0) {
 					tex_names.push_back(ti[a].longName);
 				}
 			}

--- a/src/MapEditor/Renderer/Overlays/QuickTextureOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/QuickTextureOverlay3d.cpp
@@ -106,14 +106,22 @@ QuickTextureOverlay3d::QuickTextureOverlay3d(MapEditContext* editor)
 		if (sel_type > 0)
 		{
 			vector<map_texinfo_t>& ti = MapEditor::textureManager().getAllTexturesInfo();
-			for (unsigned a = 0; a < ti.size(); a++)
-				tex_names.push_back(ti[a].name);
+			for (unsigned a = 0; a < ti.size(); a++) {
+				tex_names.push_back(ti[a].shortName);
+				if (Game::configuration().featureSupported(Game::Feature::LongNames)) {
+					tex_names.push_back(ti[a].longName);
+				}
+			}
 		}
 		if (sel_type == 0 || sel_type == 2)
 		{
 			vector<map_texinfo_t>& ti = MapEditor::textureManager().getAllFlatsInfo();
-			for (unsigned a = 0; a < ti.size(); a++)
-				tex_names.push_back(ti[a].name);
+			for (unsigned a = 0; a < ti.size(); a++) {
+				tex_names.push_back(ti[a].shortName);
+				if (Game::configuration().featureSupported(Game::Feature::LongNames)) {
+					tex_names.push_back(ti[a].longName);
+				}
+			}
 		}
 		std::sort(tex_names.begin(), tex_names.end());
 

--- a/src/MapEditor/Renderer/Overlays/QuickTextureOverlay3d.cpp
+++ b/src/MapEditor/Renderer/Overlays/QuickTextureOverlay3d.cpp
@@ -101,15 +101,21 @@ QuickTextureOverlay3d::QuickTextureOverlay3d(MapEditContext* editor)
 		else if (sel[initial].type == MapEditor::ItemType::WallBottom)
 			tex_init = editor->map().getSide(sel[initial].index)->stringProperty("texturebottom");
 
+		int mapFormat = editor->map().currentFormat();
+
 		// Get all available texture names (sorted alphabetically)
 		vector<string> tex_names;
 		if (sel_type > 0)
 		{
 			vector<map_texinfo_t>& ti = MapEditor::textureManager().getAllTexturesInfo();
 			for (unsigned a = 0; a < ti.size(); a++) {
-				tex_names.push_back(ti[a].shortName);
-				if (Game::configuration().featureSupported(Game::Feature::LongNames) &&
-						ti[a].shortName.CmpNoCase(ti[a].longName) != 0) {
+				if (mapFormat == MAP_UDMF || ti[a].shortName.Len() <= 8)
+				{
+					tex_names.push_back(ti[a].shortName);
+				}
+
+				if (mapFormat == MAP_UDMF && ti[a].shortName.CmpNoCase(ti[a].longName) != 0)
+				{
 					tex_names.push_back(ti[a].longName);
 				}
 			}
@@ -118,9 +124,13 @@ QuickTextureOverlay3d::QuickTextureOverlay3d(MapEditContext* editor)
 		{
 			vector<map_texinfo_t>& ti = MapEditor::textureManager().getAllFlatsInfo();
 			for (unsigned a = 0; a < ti.size(); a++) {
-				tex_names.push_back(ti[a].shortName);
-				if (Game::configuration().featureSupported(Game::Feature::LongNames) &&
-						ti[a].shortName.CmpNoCase(ti[a].longName) != 0) {
+				if (mapFormat == MAP_UDMF || ti[a].shortName.Len() <= 8)
+				{
+					tex_names.push_back(ti[a].shortName);
+				}
+
+				if (mapFormat == MAP_UDMF && ti[a].shortName.CmpNoCase(ti[a].longName) != 0)
+				{
 					tex_names.push_back(ti[a].longName);
 				}
 			}

--- a/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
+++ b/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
@@ -204,7 +204,7 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 				// Add browser item
 				string fpName = fpFlats[a].path + fpFlats[a].name + "." + fpFlats[a].extension;
 				fpName.Remove(0, 1); // Remove leading slash
-				addItem(new MapTexBrowserItem(fpName, 0, fpFlats[a].index),
+				addItem(new MapTexBrowserItem(fpName, 1, fpFlats[a].index),
 					determineTexturePath(fpFlats[a].archive, fpFlats[a].category, "Textures (Full Path)", fpFlats[a].path));
 			}
 		}

--- a/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
+++ b/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
@@ -187,7 +187,9 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		vector<map_texinfo_t>& fpTextures = MapEditor::textureManager().getAllTexturesInfo();
 		for (unsigned a = 0; a < fpTextures.size(); a++)
 		{
-			if (!fpTextures[a].path.IsEmpty() && fpTextures[a].path.Cmp("/") != 0) {
+			if (fpTextures[a].category != MapTextureManager::TC_TEXTURES &&
+					fpTextures[a].category != MapTextureManager::TC_HIRES &&
+					!fpTextures[a].path.IsEmpty() && fpTextures[a].path.Cmp("/") != 0) {
 				// Add browser item
 				addItem(new MapTexBrowserItem(fpTextures[a].longName, 0, fpTextures[a].index),
 					determineTexturePath(fpTextures[a].archive, fpTextures[a].category, "Textures (Full Path)", fpTextures[a].path));

--- a/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
+++ b/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
@@ -158,7 +158,7 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		for (unsigned a = 0; a < textures.size(); a++)
 		{
 			// Add browser item
-			addItem(new MapTexBrowserItem(textures[a].name, 0, textures[a].index),
+			addItem(new MapTexBrowserItem(textures[a].shortName, 0, textures[a].index),
 				determineTexturePath(textures[a].archive, textures[a].category, "Textures", textures[a].path));
 		}
 	}
@@ -174,9 +174,9 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 
 			// Add browser item
 			if (flats[a].category == MapTextureManager::TC_TEXTURES)
-				addItem(new MapTexBrowserItem(flats[a].name, 0, flats[a].index), path);
+				addItem(new MapTexBrowserItem(flats[a].shortName, 0, flats[a].index), path);
 			else
-				addItem(new MapTexBrowserItem(flats[a].name, 1, flats[a].index), path);
+				addItem(new MapTexBrowserItem(flats[a].shortName, 1, flats[a].index), path);
 		}
 	}
 
@@ -189,9 +189,7 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		{
 			if (!fpTextures[a].path.IsEmpty() && fpTextures[a].path.Cmp("/") != 0) {
 				// Add browser item
-				string fpName = fpTextures[a].path + fpTextures[a].name + "." + fpTextures[a].extension;
-				fpName.Remove(0, 1); // Remove leading slash
-				addItem(new MapTexBrowserItem(fpName, 0, fpTextures[a].index),
+				addItem(new MapTexBrowserItem(fpTextures[a].longName, 0, fpTextures[a].index),
 					determineTexturePath(fpTextures[a].archive, fpTextures[a].category, "Textures (Full Path)", fpTextures[a].path));
 			}
 		}
@@ -202,9 +200,8 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		{
 			if (!fpFlats[a].path.IsEmpty() && fpFlats[a].path.Cmp("/") != 0) {
 				// Add browser item
-				string fpName = fpFlats[a].path + fpFlats[a].name + "." + fpFlats[a].extension;
-				fpName.Remove(0, 1); // Remove leading slash
-				addItem(new MapTexBrowserItem(fpName, 1, fpFlats[a].index),
+				//fpName.Remove(0, 1); // Remove leading slash
+				addItem(new MapTexBrowserItem(fpFlats[a].longName, 1, fpFlats[a].index),
 					determineTexturePath(fpFlats[a].archive, fpFlats[a].category, "Textures (Full Path)", fpFlats[a].path));
 			}
 		}

--- a/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
+++ b/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
@@ -187,7 +187,7 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		vector<map_texinfo_t>& fpTextures = MapEditor::textureManager().getAllTexturesInfo();
 		for (unsigned a = 0; a < fpTextures.size(); a++)
 		{
-			if (fpTextures[a].path.Length() > 0) {
+			if (!fpTextures[a].path.IsEmpty() && fpTextures[a].path.Cmp("/") != 0) {
 				// Add browser item
 				string fpName = fpTextures[a].path + fpTextures[a].name + "." + fpTextures[a].extension;
 				fpName.Remove(0, 1); // Remove leading slash
@@ -200,7 +200,7 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		vector<map_texinfo_t>& fpFlats = MapEditor::textureManager().getAllFlatsInfo();
 		for (unsigned a = 0; a < fpFlats.size(); a++)
 		{
-			if (fpFlats[a].path.Length() > 0) {
+			if (!fpFlats[a].path.IsEmpty() && fpFlats[a].path.Cmp("/") != 0) {
 				// Add browser item
 				string fpName = fpFlats[a].path + fpFlats[a].name + "." + fpFlats[a].extension;
 				fpName.Remove(0, 1); // Remove leading slash

--- a/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
+++ b/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
@@ -180,6 +180,36 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		}
 	}
 
+	// Full path textures
+	if (Game::configuration().featureSupported(Game::Feature::LongNames))
+	{
+		// Textures
+		vector<map_texinfo_t>& fpTextures = MapEditor::textureManager().getAllTexturesInfo();
+		for (unsigned a = 0; a < fpTextures.size(); a++)
+		{
+			if (fpTextures[a].path.Length() > 0) {
+				// Add browser item
+				string fpName = fpTextures[a].path + fpTextures[a].name + "." + fpTextures[a].extension;
+				fpName.Remove(0, 1); // Remove leading slash
+				addItem(new MapTexBrowserItem(fpName, 0, fpTextures[a].index),
+					determineTexturePath(fpTextures[a].archive, fpTextures[a].category, "Textures (Full Path)", fpTextures[a].path));
+			}
+		}
+
+		// Flats
+		vector<map_texinfo_t>& fpFlats = MapEditor::textureManager().getAllFlatsInfo();
+		for (unsigned a = 0; a < fpFlats.size(); a++)
+		{
+			if (fpFlats[a].path.Length() > 0) {
+				// Add browser item
+				string fpName = fpFlats[a].path + fpFlats[a].name + "." + fpFlats[a].extension;
+				fpName.Remove(0, 1); // Remove leading slash
+				addItem(new MapTexBrowserItem(fpName, 0, fpFlats[a].index),
+					determineTexturePath(fpFlats[a].archive, fpFlats[a].category, "Textures (Full Path)", fpFlats[a].path));
+			}
+		}
+	}
+
 	populateItemTree(false);
 
 	// Select initial texture (if any)

--- a/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
+++ b/src/MapEditor/UI/Dialogs/MapTextureBrowser.cpp
@@ -149,6 +149,8 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 	// Set window title
 	SetTitle("Browse Map Textures");
 
+	int mapFormat = map->currentFormat();
+
 	// Textures
 	if (type == 0 || Game::configuration().featureSupported(Game::Feature::MixTexFlats))
 	{
@@ -157,6 +159,11 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		vector<map_texinfo_t>& textures = MapEditor::textureManager().getAllTexturesInfo();
 		for (unsigned a = 0; a < textures.size(); a++)
 		{
+			if (textures[a].shortName.Len() > 8 && mapFormat != MAP_UDMF)
+			{
+				// Only UDMF supports texture/flat names longer than 8 characters
+				continue;
+			}
 			// Add browser item
 			addItem(new MapTexBrowserItem(textures[a].shortName, 0, textures[a].index),
 				determineTexturePath(textures[a].archive, textures[a].category, "Textures", textures[a].path));
@@ -169,6 +176,11 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 		vector<map_texinfo_t>& flats = MapEditor::textureManager().getAllFlatsInfo();
 		for (unsigned a = 0; a < flats.size(); a++)
 		{
+			if (flats[a].shortName.Len() > 8 && mapFormat != MAP_UDMF)
+			{
+				// Only UDMF supports texture/flat names longer than 8 characters
+				continue;
+			}
 			// Determine tree path
 			string path = determineTexturePath(flats[a].archive, flats[a].category, "Flats", flats[a].path);
 
@@ -181,7 +193,7 @@ MapTextureBrowser::MapTextureBrowser(wxWindow* parent, int type, string texture,
 	}
 
 	// Full path textures
-	if (Game::configuration().featureSupported(Game::Feature::LongNames))
+	if (mapFormat == MAP_UDMF)
 	{
 		// Textures
 		vector<map_texinfo_t>& fpTextures = MapEditor::textureManager().getAllTexturesInfo();

--- a/src/MapEditor/UI/PropsPanel/SectorPropsPanel.cpp
+++ b/src/MapEditor/UI/PropsPanel/SectorPropsPanel.cpp
@@ -14,7 +14,7 @@
 // any later version.
 //
 // This program is distributed in the hope that it will be useful, but WITHOUT
-// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 // FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
 // more details.
 //
@@ -177,15 +177,24 @@ void FlatComboBox::onDropDown(wxCommandEvent& e)
 {
 	// Get current value
 	string text = GetValue().Upper();
-	
+
 	// Populate dropdown with matching flat names
 	vector<map_texinfo_t>& textures = MapEditor::textureManager().getAllFlatsInfo();
 	wxArrayString list;
 	list.Add("-");
 	for (unsigned a = 0; a < textures.size(); a++)
 	{
-		if (textures[a].name.StartsWith(text))
-			list.Add(textures[a].name);
+		if (textures[a].shortName.StartsWith(text))
+		{
+			list.Add(textures[a].shortName);
+		}
+		if (Game::configuration().featureSupported(Game::Feature::LongNames))
+		{
+			if (textures[a].longName.StartsWith(text))
+			{
+				list.Add(textures[a].longName);
+			}
+		}
 	}
 	Set(list);	// Why does this clear the text box also?
 	SetValue(text);
@@ -249,7 +258,7 @@ SectorPropsPanel::SectorPropsPanel(wxWindow* parent) : PropsPanelBase(parent)
 	stc_tabs_->AddPage(setupSpecialPanel(), "Special");
 
 	// Other Properties tab
-	
+
 	if (MapEditor::editContext().mapDesc().format == MAP_UDMF)
 	{
 		mopp_all_props_ = new MapObjectPropsPanel(stc_tabs_, true);
@@ -419,7 +428,7 @@ void SectorPropsPanel::openObjects(vector<MapObject*>& objects)
 	// Floor height
 	if (MapObject::multiIntProperty(objects, "heightfloor", ival))
 		text_height_floor_->SetValue(S_FMT("%d", ival));
-	
+
 	// Ceiling height
 	if (MapObject::multiIntProperty(objects, "heightceiling", ival))
 		text_height_ceiling_->SetValue(S_FMT("%d", ival));

--- a/src/MapEditor/UI/PropsPanel/SidePropsPanel.cpp
+++ b/src/MapEditor/UI/PropsPanel/SidePropsPanel.cpp
@@ -14,7 +14,7 @@
 // any later version.
 //
 // This program is distributed in the hope that it will be useful, but WITHOUT
-// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 // FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
 // more details.
 //
@@ -177,15 +177,24 @@ void TextureComboBox::onDropDown(wxCommandEvent& e)
 	string text = GetValue().Upper();
 	if (text == "-")
 		text = "";
-	
+
 	// Populate dropdown with matching texture names
 	vector<map_texinfo_t>& textures = MapEditor::textureManager().getAllTexturesInfo();
 	wxArrayString list;
 	list.Add("-");
 	for (unsigned a = 0; a < textures.size(); a++)
 	{
-		if (textures[a].name.StartsWith(text))
-			list.Add(textures[a].name);
+		if (textures[a].shortName.StartsWith(text))
+		{
+			list.Add(textures[a].shortName);
+		}
+		if (Game::configuration().featureSupported(Game::Feature::LongNames))
+		{
+			if (textures[a].longName.StartsWith(text))
+			{
+				list.Add(textures[a].longName);
+			}
+		}
 	}
 	Set(list);	// Why does this clear the text box also?
 	SetValue(text);
@@ -243,7 +252,7 @@ SidePropsPanel::SidePropsPanel(wxWindow* parent) : wxPanel(parent, -1)
 	// --- Textures ---
 	wxStaticBoxSizer* sizer_tex = new wxStaticBoxSizer(wxVERTICAL, this, "Textures");
 	sizer->Add(sizer_tex, 0, wxEXPAND);
-	
+
 	wxGridBagSizer* gb_sizer = new wxGridBagSizer(UI::pad(), UI::pad());
 	sizer_tex->Add(gb_sizer, 1, wxEXPAND|wxLEFT|wxRIGHT|wxBOTTOM, UI::pad());
 
@@ -348,7 +357,7 @@ void SidePropsPanel::openSides(vector<MapSide*>& sides)
 
 
 	// --- Offsets ---
-	
+
 	// X
 	bool multi = false;
 	int ofs = sides[0]->getOffsetX();


### PR DESCRIPTION
This adds another section to the texture browser "Textures (Full Path)" when editing a map for a game that supports full path textures, and an archive with full path textures is open.