### PR TITLE
Map Editor: Equalize status bar field widths

### DIFF
--- a/src/MapEditor/UI/MapEditorWindow.cpp
+++ b/src/MapEditor/UI/MapEditorWindow.cpp
@@ -353,7 +353,7 @@ void MapEditorWindow::setupLayout()
 
 	// Status bar
 	CreateStatusBar(4);
-	int status_widths[4] = { -1, UI::scalePx(240), UI::scalePx(200), UI::scalePx(160) };
+	int status_widths[4] = { -1, UI::scalePx(240), UI::scalePx(240), UI::scalePx(240) };
 	SetStatusWidths(4, status_widths);
 
 	// -- Console Panel --


### PR DESCRIPTION
Make the status bar fields wider so there's enough room to display large numbers.
160 pixels is not enough for the coordinates field, specially in UDMF maps due to the three decimal places.

Current widths:
![current_fields](https://user-images.githubusercontent.com/21117400/42337778-0ac79fc8-8088-11e8-8d5b-ae4fdc09b4c3.jpg)

Proposed width:
![proposed_fields](https://user-images.githubusercontent.com/21117400/42337803-175e5ca4-8088-11e8-9d28-eed7d5adbcb5.jpg)
