### PR TITLE
Update CMakeLists.txt for quick fix of #903

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -2,7 +2,7 @@ find_program(ZIPTOOL_ZIP_EXECUTABLE zip)
 find_program(ZIPTOOL_7Z_EXECUTABLE 7z "$ENV{ProgramFiles}/7-Zip")
 
 if(ZIPTOOL_7Z_EXECUTABLE)
-	set(ZIP_COMMAND "${ZIPTOOL_7Z_EXECUTABLE}" u -tzip -mtc- -mx=9 -r "${CMAKE_BINARY_DIR}/slade.pk3" .)
+	set(ZIP_COMMAND "${ZIPTOOL_7Z_EXECUTABLE}" u -tzip -mtc- -mcu+ -mx=9 -r "${CMAKE_BINARY_DIR}/slade.pk3" .)
 elseif(ZIPTOOL_ZIP_EXECUTABLE)
 	set(ZIP_COMMAND "${ZIPTOOL_ZIP_EXECUTABLE}" -X -UN=UTF8 -9 -r "${CMAKE_BINARY_DIR}/slade.pk3" .)
 else()

--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -2,7 +2,7 @@ find_program(ZIPTOOL_ZIP_EXECUTABLE zip)
 find_program(ZIPTOOL_7Z_EXECUTABLE 7z "$ENV{ProgramFiles}/7-Zip")
 
 if(ZIPTOOL_7Z_EXECUTABLE)
-	set(ZIP_COMMAND "${ZIPTOOL_7Z_EXECUTABLE}" u -tzip -mtc- -mtu+ -mx=9 -r "${CMAKE_BINARY_DIR}/slade.pk3" .)
+	set(ZIP_COMMAND "${ZIPTOOL_7Z_EXECUTABLE}" u -tzip -mtc- -mx=9 -r "${CMAKE_BINARY_DIR}/slade.pk3" .)
 elseif(ZIPTOOL_ZIP_EXECUTABLE)
 	set(ZIP_COMMAND "${ZIPTOOL_ZIP_EXECUTABLE}" -X -UN=UTF8 -9 -r "${CMAKE_BINARY_DIR}/slade.pk3" .)
 else()


### PR DESCRIPTION
Quick fix for #903, `-mtu+` option is not recognized by 7z.