### PR TITLE
Force inactive text colour in wxPropertyGrid

### DIFF
--- a/src/Dialogs/Preferences/AdvancedPrefsPanel.cpp
+++ b/src/Dialogs/Preferences/AdvancedPrefsPanel.cpp
@@ -52,6 +52,9 @@ AdvancedPrefsPanel::AdvancedPrefsPanel(wxWindow* parent) : PrefsPanelBase(parent
 	wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
 	SetSizer(sizer);
 
+	const wxColour& inactiveTextColour =
+		wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT);
+
 	// Add property grid
 	pg_cvars_ = new wxPropertyGrid(
 		this,
@@ -60,6 +63,8 @@ AdvancedPrefsPanel::AdvancedPrefsPanel(wxWindow* parent) : PrefsPanelBase(parent
 		wxDefaultSize,
 		wxPG_BOLD_MODIFIED | wxPG_SPLITTER_AUTO_CENTER | wxPG_TOOLTIPS | wxPG_HIDE_MARGIN
 	);
+	pg_cvars_->SetCaptionTextColour(inactiveTextColour);
+	pg_cvars_->SetCellDisabledTextColour(inactiveTextColour);
 	sizer->Add(pg_cvars_, 1, wxEXPAND);
 
 	// Init property grid

--- a/src/Dialogs/Preferences/ColourPrefsPanel.cpp
+++ b/src/Dialogs/Preferences/ColourPrefsPanel.cpp
@@ -63,6 +63,9 @@ ColourPrefsPanel::ColourPrefsPanel(wxWindow* parent) : PrefsPanelBase(parent)
 		choice_configs_->Append(cnames[a]);
 	sizer->Add(WxUtils::createLabelHBox(this, "Preset:", choice_configs_), 0, wxEXPAND | wxBOTTOM, UI::pad());
 
+	const wxColour& inactiveTextColour =
+		wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT);
+
 	// Create property grid
 	pg_colours_ = new wxPropertyGrid(
 		this,
@@ -71,6 +74,8 @@ ColourPrefsPanel::ColourPrefsPanel(wxWindow* parent) : PrefsPanelBase(parent)
 		wxDefaultSize,
 		wxPG_BOLD_MODIFIED | wxPG_SPLITTER_AUTO_CENTER | wxPG_TOOLTIPS
 	);
+	pg_colours_->SetCaptionTextColour(inactiveTextColour);
+	pg_colours_->SetCellDisabledTextColour(inactiveTextColour);
 	sizer->Add(pg_colours_, 1, wxEXPAND);
 
 	// Load colour config into grid

--- a/src/MapEditor/UI/PropsPanel/MapObjectPropsPanel.cpp
+++ b/src/MapEditor/UI/PropsPanel/MapObjectPropsPanel.cpp
@@ -79,6 +79,9 @@ MapObjectPropsPanel::MapObjectPropsPanel(wxWindow* parent, bool no_apply) :
 	stc_sections_ = STabCtrl::createControl(this);
 	sizer->Add(stc_sections_, 1, wxEXPAND|wxLEFT|wxRIGHT|wxBOTTOM, UI::pad());
 
+	const wxColour& inactiveTextColour =
+		wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT);
+
 	// Add main property grid
 	pg_properties_ = new wxPropertyGrid(
 		stc_sections_,
@@ -87,6 +90,8 @@ MapObjectPropsPanel::MapObjectPropsPanel(wxWindow* parent, bool no_apply) :
 		wxDefaultSize,
 		wxPG_TOOLTIPS|wxPG_SPLITTER_AUTO_CENTER
 	);
+	pg_properties_->SetCaptionTextColour(inactiveTextColour);
+	pg_properties_->SetCellDisabledTextColour(inactiveTextColour);
 	stc_sections_->AddPage(pg_properties_, "Properties");
 
 	// Create side property grids
@@ -97,6 +102,8 @@ MapObjectPropsPanel::MapObjectPropsPanel(wxWindow* parent, bool no_apply) :
 		wxDefaultSize,
 		wxPG_TOOLTIPS|wxPG_SPLITTER_AUTO_CENTER
 	);
+	pg_props_side1_->SetCaptionTextColour(inactiveTextColour);
+	pg_props_side1_->SetCellDisabledTextColour(inactiveTextColour);
 	pg_props_side2_ = new wxPropertyGrid(
 		stc_sections_,
 		-1,
@@ -104,6 +111,8 @@ MapObjectPropsPanel::MapObjectPropsPanel(wxWindow* parent, bool no_apply) :
 		wxDefaultSize,
 		wxPG_TOOLTIPS|wxPG_SPLITTER_AUTO_CENTER
 	);
+	pg_props_side2_->SetCaptionTextColour(inactiveTextColour);
+	pg_props_side2_->SetCellDisabledTextColour(inactiveTextColour);
 
 	// Add buttons
 	wxBoxSizer* hbox = new wxBoxSizer(wxHORIZONTAL);


### PR DESCRIPTION
By default, wxWidgets doesn't use the current theme's inactive text color for the wxPropertyGrid widget. If a dark theme is being used, inactive labels become unreadable, since they will use black text with a dark background.

None of the main branches seem to build with GTK3. Since this change is specific to GTK3's theme functionality, I made the commit in the gtk3 branch.