### PR TITLE
Don't redraw map editor when application is idle

### DIFF
--- a/src/MapEditor/Edit/Input.cpp
+++ b/src/MapEditor/Edit/Input.cpp
@@ -77,6 +77,7 @@ Input::Input(MapEditContext& context) : context_{ context }
  *******************************************************************/
 bool Input::mouseMove(int new_x, int new_y)
 {
+	context_.forceRefreshRenderer();
 	// Check if a full screen overlay is active
 	if (context_.overlayActive())
 	{
@@ -192,6 +193,7 @@ bool Input::mouseMove(int new_x, int new_y)
  *******************************************************************/
 bool Input::mouseDown(MouseButton button, bool double_click)
 {
+	context_.forceRefreshRenderer();
 	// Update hilight
 	if (mouse_state_ == MouseState::Normal)
 		context_.selection().updateHilight(mouse_pos_map_, context_.renderer().view().scale());
@@ -371,6 +373,7 @@ bool Input::mouseUp(MouseButton button)
 	if (context_.overlayActive())
 		return false;
 
+	context_.forceRefreshRenderer();
 	// Left button
 	if (button == Left)
 	{
@@ -439,6 +442,7 @@ bool Input::mouseUp(MouseButton button)
  *******************************************************************/
 void Input::mouseWheel(bool up, double amount)
 {
+	context_.forceRefreshRenderer();
 	mouse_wheel_speed_ = amount;
 
 	if (up)
@@ -494,6 +498,7 @@ void Input::updateKeyModifiersWx(int modifiers)
  *******************************************************************/
 bool Input::keyDown(const string& key) const
 {
+	context_.forceRefreshRenderer();
 	// Send to overlay if active
 	if (context_.overlayActive())
 		context_.currentOverlay()->keyDown(key);
@@ -507,6 +512,7 @@ bool Input::keyDown(const string& key) const
  *******************************************************************/
 bool Input::keyUp(const string& key) const
 {
+	context_.forceRefreshRenderer();
 	// Let keybind system handle it
 	return KeyBind::keyReleased(key);
 }
@@ -516,6 +522,7 @@ bool Input::keyUp(const string& key) const
  *******************************************************************/
 void Input::onKeyBindPress(string name)
 {
+	context_.forceRefreshRenderer();
 	// Check if an overlay is active
 	if (context_.overlayActive())
 	{
@@ -570,6 +577,7 @@ void Input::onKeyBindPress(string name)
  *******************************************************************/
 void Input::onKeyBindRelease(string name)
 {
+	context_.forceRefreshRenderer();
 	if (name == "me2d_pan_view" && panning_)
 	{
 		panning_ = false;

--- a/src/MapEditor/UI/MapCanvas.cpp
+++ b/src/MapEditor/UI/MapCanvas.cpp
@@ -38,6 +38,7 @@
 
 using MapEditor::Mode;
 
+CVAR(Int, map_bg_ms, 15, CVAR_SAVE)
 
 /*******************************************************************
  * MAPCANVAS CLASS FUNCTIONS
@@ -84,7 +85,7 @@ MapCanvas::MapCanvas(wxWindow* parent, int id, MapEditContext* context) :
 	Bind(wxEVT_IDLE, &MapCanvas::onIdle, this);
 #endif
 
-	timer.Start(10, true);
+	timer.Start(map_bg_ms, true);
 }
 
 /* MapCanvas::~MapCanvas
@@ -504,7 +505,7 @@ void MapCanvas::onRTimer(wxTimerEvent& e)
 		Refresh();
 	}
 
-	timer.Start(-1, true);
+	timer.Start(map_bg_ms, true);
 }
 
 /* MapCanvas::onFocus


### PR DESCRIPTION
I noticed SLADE was using a lot of idle CPU regardless of whether or not the application was active. I use it a lot on my laptop so it's important to conserve battery life. This patch makes it so that the map editor only redraws on user input or when an animation is active. The "map_bg_ms" cvar was somewhat useless before so it has been changed so that it controls FPS for the map canvas. Ideally for smooth performance this setting should default to the screen refresh rate, but wxWidgets doesn't have a facility for that. I left it in so that people with slow machines can set it higher in case of GL hiccups.

This should clear up some of the CPU usage issues described in #876, but it seems there is also a memory leak somewhere, which is a separate issue. If someone would like to test this before merging that would be cool, I tested a bit but I'm not sure I covered everything so there may still be some corner cases where the UI is left in a stale state. Thanks.