### PR TITLE
Fix memory leak in vertex mode (gtk3 branch)

### DIFF
--- a/src/MapEditor/Renderer/MapRenderer2D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer2D.cpp
@@ -212,10 +212,17 @@ void MapRenderer2D::renderVertices(float alpha)
  *******************************************************************/
 void MapRenderer2D::renderVerticesImmediate()
 {
-	if (list_vertices > 0 && map->nVertices() == n_vertices && map->geometryUpdated() <= vertices_updated)
+	if (list_vertices > 0 &&
+		map->nVertices() == n_vertices &&
+		map->geometryUpdated() <= vertices_updated &&
+		!map->modifiedSince(vertices_updated, MOBJ_VERTEX))
 		glCallList(list_vertices);
 	else
 	{
+		// Rebuild display list
+		if (list_vertices > 0)
+			glDeleteLists(list_vertices, 1);
+
 		list_vertices = glGenLists(1);
 		glNewList(list_vertices, GL_COMPILE_AND_EXECUTE);
 


### PR DESCRIPTION
MapRenderer2D::renderVerticesImmediate() did not call glDeleteLists(), which lead to vertices being allocated but not deleted. I applied similar checks as the ones in MapRenderer2D::renderLinesImmediate(). Probably worth applying this fix to the main branches?