### PR TITLE
Tokenizer improvements.

### DIFF
--- a/src/Utility/Tokenizer.cpp
+++ b/src/Utility/Tokenizer.cpp
@@ -110,8 +110,8 @@ bool Tokenizer::Token::isFloat() const
 bool Tokenizer::Token::asBool() const
 {
 	return !(S_CMPNOCASE(text, "false") ||
-			S_CMPNOCASE(text, "no") ||
-			S_CMPNOCASE(text, "0"));
+			 S_CMPNOCASE(text, "no") ||
+			 S_CMPNOCASE(text, "0"));
 }
 
 // ----------------------------------------------------------------------------
@@ -182,7 +182,7 @@ const Tokenizer::Token& Tokenizer::next()
 //
 // Advances [inc] tokens
 // ----------------------------------------------------------------------------
-void Tokenizer::adv(int inc)
+void Tokenizer::adv(size_t inc)
 {
 	if (inc <= 0)
 		return;
@@ -199,7 +199,7 @@ void Tokenizer::adv(int inc)
 //
 // Advances [inc] tokens if the current token matches [check]
 // ----------------------------------------------------------------------------
-bool Tokenizer::advIf(const char* check, int inc)
+bool Tokenizer::advIf(const char* check, size_t inc)
 {
 	if (token_current_ == check)
 	{
@@ -209,7 +209,7 @@ bool Tokenizer::advIf(const char* check, int inc)
 
 	return false;
 }
-bool Tokenizer::advIf(const string& check, int inc)
+bool Tokenizer::advIf(const string& check, size_t inc)
 {
 	if (token_current_ == check)
 	{
@@ -219,7 +219,7 @@ bool Tokenizer::advIf(const string& check, int inc)
 
 	return false;
 }
-bool Tokenizer::advIf(char check, int inc)
+bool Tokenizer::advIf(char check, size_t inc)
 {
 	if (token_current_ == check)
 	{
@@ -235,7 +235,7 @@ bool Tokenizer::advIf(char check, int inc)
 //
 // Advances [inc] tokens if the current token matches [check] (Case-Insensitive)
 // ----------------------------------------------------------------------------
-bool Tokenizer::advIfNC(const char* check, int inc)
+bool Tokenizer::advIfNC(const char* check, size_t inc)
 {
 	if (S_CMPNOCASE(token_current_.text, check))
 	{
@@ -245,7 +245,7 @@ bool Tokenizer::advIfNC(const char* check, int inc)
 
 	return false;
 }
-bool Tokenizer::advIfNC(const string& check, int inc)
+bool Tokenizer::advIfNC(const string& check, size_t inc)
 {
 	if (S_CMPNOCASE(token_current_.text, check))
 	{
@@ -261,7 +261,7 @@ bool Tokenizer::advIfNC(const string& check, int inc)
 //
 // Advances [inc] tokens if the next token matches [check]
 // ----------------------------------------------------------------------------
-bool Tokenizer::advIfNext(const char* check, int inc)
+bool Tokenizer::advIfNext(const char* check, size_t inc)
 {
 	if (!token_next_.valid)
 		return false;
@@ -274,7 +274,7 @@ bool Tokenizer::advIfNext(const char* check, int inc)
 
 	return false;
 }
-bool Tokenizer::advIfNext(const string& check, int inc)
+bool Tokenizer::advIfNext(const string& check, size_t inc)
 {
 	if (!token_next_.valid)
 		return false;
@@ -287,7 +287,7 @@ bool Tokenizer::advIfNext(const string& check, int inc)
 
 	return false;
 }
-bool Tokenizer::advIfNext(char check, int inc)
+bool Tokenizer::advIfNext(char check, size_t inc)
 {
 	if (!token_next_.valid)
 		return false;
@@ -306,7 +306,7 @@ bool Tokenizer::advIfNext(char check, int inc)
 //
 // Advances [inc] tokens if the next token matches [check] (Case-Insensitive)
 // ----------------------------------------------------------------------------
-bool Tokenizer::advIfNextNC(const char* check, int inc)
+bool Tokenizer::advIfNextNC(const char* check, size_t inc)
 {
 	if (!token_next_.valid)
 		return false;
@@ -561,7 +561,7 @@ bool Tokenizer::checkNextNC(const char* check) const
 // Opens text from a file [filename], reading [length] bytes from [offset].
 // If [length] is 0, read to the end of the file
 // ----------------------------------------------------------------------------
-bool Tokenizer::openFile(const string& filename, unsigned offset, unsigned length)
+bool Tokenizer::openFile(const string& filename, size_t offset, size_t length)
 {
 	// Open the file
 	wxFile file(filename);
@@ -579,12 +579,12 @@ bool Tokenizer::openFile(const string& filename, unsigned offset, unsigned lengt
 	// If length isn't specified or exceeds the file length,
 	// only read to the end of the file
 	if (offset + length > file.Length() || length == 0)
-		length = file.Length() - offset;
+		length = (size_t) file.Length() - offset;
 
 	// Read the file portion
-	data_.resize(length, 0);
+	data_.resize((size_t) length, 0);
 	file.Seek(offset, wxFromStart);
-	file.Read(data_.data(), length);
+	file.Read(data_.data(), (size_t) length);
 
 	reset();
 
@@ -597,15 +597,15 @@ bool Tokenizer::openFile(const string& filename, unsigned offset, unsigned lengt
 // Opens text from a string [text], reading [length] bytes from [offset].
 // If [length] is 0, read to the end of the string
 // ----------------------------------------------------------------------------
-bool Tokenizer::openString(const string& text, unsigned offset, unsigned length, const string& source)
+bool Tokenizer::openString(const string& text, size_t offset, size_t length, const string& source)
 {
 	source_ = source;
 
 	// If length isn't specified or exceeds the string's length,
 	// only copy to the end of the string
 	auto ascii = text.ToAscii();
-	if (offset + length > (unsigned)ascii.length() || length == 0)
-		length = (unsigned)ascii.length() - offset;
+	if (offset + length > ascii.length() || length == 0)
+		length = ascii.length() - offset;
 
 	// Copy the string portion
 	data_.assign(ascii.data() + offset, ascii.data() + offset + length);
@@ -620,7 +620,7 @@ bool Tokenizer::openString(const string& text, unsigned offset, unsigned length,
 //
 // Opens text from memory [mem], reading [length] bytes
 // ----------------------------------------------------------------------------
-bool Tokenizer::openMem(const char* mem, unsigned length, const string& source)
+bool Tokenizer::openMem(const char* mem, size_t length, const string& source)
 {
 	source_ = source;
 	data_.assign(mem, mem + length);
@@ -888,7 +888,8 @@ bool Tokenizer::readNext(Token* target)
 	while (state_.position < state_.size && !state_.done)
 	{
 		// Check for newline
-		if (data_[state_.position] == '\n')
+		if (data_[state_.position] == '\n' &&
+			state_.state != TokenizeState::State::Token)
 			++state_.current_line;
 
 		// Process current character depending on state
@@ -898,7 +899,6 @@ bool Tokenizer::readNext(Token* target)
 		case TokenizeState::State::Whitespace:	tokenizeWhitespace(); break;
 		case TokenizeState::State::Token:		tokenizeToken(); break;
 		case TokenizeState::State::Comment:		tokenizeComment(); break;
-		default: ++state_.position; break;
 		}
 	}
 

--- a/src/Utility/Tokenizer.h
+++ b/src/Utility/Tokenizer.h
@@ -46,7 +46,7 @@ public:
 		void 	toInt(int& val) const { val = wxAtoi(text); }
 		void 	toBool(bool& val) const;
 		void 	toFloat(double& val) const { val = wxAtof(text); }
-		void	toFloat(float& val) const { val = wxAtof(text); }
+		void	toFloat(float& val) const { val = (float) wxAtof(text); }
 	};
 
 	struct TokenizeState
@@ -61,7 +61,7 @@ public:
 
 		State		state = State::Unknown;
 		unsigned	position = 0;
-		unsigned	size = 0;
+		size_t	    size = 0;
 		unsigned	current_line = 1;
 		unsigned	comment_type = 0;
 		Token		current_token;
@@ -92,16 +92,16 @@ public:
 
 	// Token Iterating
 	const Token&	next();
-	void			adv(int inc = 1);
-	bool			advIf(const char* check, int inc = 1);
-	bool			advIf(const string& check, int inc = 1);
-	bool			advIf(char check, int inc = 1);
-	bool			advIfNC(const char* check, int inc = 1);
-	bool			advIfNC(const string& check, int inc = 1);
-	bool			advIfNext(const char* check, int inc = 1);
-	bool			advIfNext(const string& check, int inc = 1);
-	bool			advIfNext(char check, int inc = 1);
-	bool			advIfNextNC(const char* check, int inc = 1);
+	void			adv(size_t inc = 1);
+	bool			advIf(const char* check, size_t inc = 1);
+	bool			advIf(const string& check, size_t inc = 1);
+	bool			advIf(char check, size_t inc = 1);
+	bool			advIfNC(const char* check, size_t inc = 1);
+	bool			advIfNC(const string& check, size_t inc = 1);
+	bool			advIfNext(const char* check, size_t inc = 1);
+	bool			advIfNext(const string& check, size_t inc = 1);
+	bool			advIfNext(char check, size_t inc = 1);
+	bool			advIfNextNC(const char* check, size_t inc = 1);
 	void			advToNextLine();
 	void			advToEndOfLine();
 	void 			skipSection(const char* begin, const char* end, bool allow_quoted = false);
@@ -113,7 +113,7 @@ public:
 	// Operators
 	void operator++() { adv(); }
 	void operator++(int) { adv(); }
-	void operator+=(const int inc) { adv(inc); }
+	void operator+=(const size_t inc) { adv(inc); }
 
 	// Token Checking
 	bool	check(const char* check) const { return token_current_ == check; }
@@ -130,14 +130,14 @@ public:
 	bool	checkNextNC(const char* check) const;
 
 	// Load Data
-	bool	openFile(const string& filename, unsigned offset = 0, unsigned length = 0);
+	bool	openFile(const string& filename, size_t offset = 0, size_t length = 0);
 	bool	openString(
-				const string& text,
-				unsigned offset = 0,
-				unsigned length = 0,
-				const string& source = "unknown"
+				const  string& text,
+				size_t offset = 0,
+				size_t length = 0,
+				const  string& source = "unknown"
 			);
-	bool	openMem(const char* mem, unsigned length, const string& source);
+	bool	openMem(const char* mem, size_t length, const string& source);
 	bool	openMem(const MemChunk& mc, const string& source);
 
 	// General


### PR DESCRIPTION
* Do not increment `state_.current_line` if a token is ended at a newline

Currently if that's the case, 'current_line' is incremented twice.
This makes the text editor jump points to misbehave in files with a
code style like this:


```
1   function void
2   function_name ()
3   {
4     ...code...
5   }
6
7   if (test)
8   {
9     ...code...
10  }
11  else
12  {
13    ...code...
14  }
```


`state_.current_line` is incremented twice at lines 1 and 11

* Remove default case in switch statement, all possible cases are dealt
with

* Use the more robust `wxFileOffset` and `size_t` types where appropriate

* Make some implicit casts explicit