### PR TITLE
 Map Editor: Force the renderer to refresh.

### DIFF
--- a/src/MapEditor/MapEditContext.cpp
+++ b/src/MapEditor/MapEditContext.cpp
@@ -180,7 +180,6 @@ void MapEditContext::setEditMode(Mode mode)
 	case Mode::Sectors:	addEditorMessage("Sectors mode (Normal)"); break;
 	case Mode::Things:	addEditorMessage("Things mode"); break;
 	case Mode::Visual:		addEditorMessage("3d mode"); break;
-	default: break;
 	};
 
 	if (edit_mode_ != Mode::Visual)
@@ -249,6 +248,7 @@ void MapEditContext::setSectorEditMode(SectorMode mode)
 		addEditorMessage("Sectors mode (Ceilings)");
 
 	updateStatusText();
+	forceRefreshRenderer();
 }
 
 // ----------------------------------------------------------------------------
@@ -1678,6 +1678,9 @@ bool MapEditContext::handleAction(string id)
 	else if (id == "mapw_flat_none")
 	{
 		flat_drawtype = 0;
+		addEditorMessage("Flats type: None");
+		updateStatusText();
+		forceRefreshRenderer();
 		return true;
 	}
 
@@ -1685,6 +1688,9 @@ bool MapEditContext::handleAction(string id)
 	else if (id == "mapw_flat_untextured")
 	{
 		flat_drawtype = 1;
+		addEditorMessage("Flats type: Untextured");
+		updateStatusText();
+		forceRefreshRenderer();
 		return true;
 	}
 
@@ -1692,6 +1698,9 @@ bool MapEditContext::handleAction(string id)
 	else if (id == "mapw_flat_textured")
 	{
 		flat_drawtype = 2;
+		addEditorMessage("Flats type: Textured");
+		updateStatusText();
+		forceRefreshRenderer();
 		return true;
 	}
 

--- a/src/MapEditor/UI/MapEditorWindow.cpp
+++ b/src/MapEditor/UI/MapEditorWindow.cpp
@@ -951,7 +951,7 @@ bool MapEditorWindow::saveMap()
 			map.head->getTopParent()->filename(false),
 			map.head->getName(true)
 		))
-		LOG_MESSAGE(1, "Warning: Failed to backup map data");
+		Log::warning(1, "Warning: Failed to backup map data");
 
 	// Add new map entries
 	for (unsigned a = 1; a < wad->numEntries(); a++)


### PR DESCRIPTION
The map editor 2d mode has been acting funny since 6029370232c8fd22f624e51c17c71b3a6eec06e2

This forces the map view to update after changing the flat render type or the sector mode. 
