### PR TITLE
Prevent assert in cmdlist console command

### DIFF
--- a/src/General/Console/Console.cpp
+++ b/src/General/Console/Console.cpp
@@ -252,7 +252,7 @@ CONSOLE_COMMAND (cmdlist, 0, true)
 	{
 		ConsoleCommand& cmd = App::console()->command(a);
 		if (cmd.showInList() || Global::debug)
-			Log::console(S_FMT("\"%s\" (%d args)", cmd.getName(), cmd.minArgs()));
+			Log::console(S_FMT("\"%s\" (%lu args)", cmd.getName(), cmd.minArgs()));
 	}
 }
 


### PR DESCRIPTION
ASSERT INFO:
/usr/include/wx-3.0/wx/strvararg.h(456): assert "(argtype & (wxFormatStringSpecifier<T>::value)) == argtype" failed in wxArgNormalizer(): format specifier doesn't match argument type

BACKTRACE:
[1] wxArgNormalizer<unsigned long>::wxArgNormalizer(unsigned long, wxFormatString const*, unsigned int)
[2] wxArgNormalizerWchar<unsigned long>::wxArgNormalizerWchar(unsigned long, wxFormatString const*, unsigned int)
[3] wxString wxString::Format<wxString, unsigned long>(wxFormatString const&, wxString, unsigned long)
[4] c_cmdlist(std::vector<wxString, std::allocator<wxString> >)
[5] ConsoleCommand::execute(std::vector<wxString, std::allocator<wxString> >)
[6] Console::execute(wxString)
[7] ConsolePanel::onCommandEnter(wxCommandEvent&)
[8] wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&)
[9] wxEvtHandler::SearchDynamicEventTable(wxEvent&)
[10] wxEvtHandler::TryHereOnly(wxEvent&)
[11] wxEvtHandler::ProcessEventLocally(wxEvent&)
[12] wxEvtHandler::ProcessEvent(wxEvent&)
[13] wxEvtHandler::SafelyProcessEvent(wxEvent&)
[14] wxTextCtrl::OnChar(wxKeyEvent&)
[15] wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&)
[16] wxEventHashTable::HandleEvent(wxEvent&, wxEvtHandler*)
[17] wxEvtHandler::TryHereOnly(wxEvent&)
[18] wxEvtHandler::ProcessEventLocally(wxEvent&)
[19] wxEvtHandler::ProcessEvent(wxEvent&)
[20] wxEvtHandler::SafelyProcessEvent(wxEvent&)
[21] g_closure_invoke
[22] g_signal_emit_valist
[23] g_signal_emit
[24] gtk_window_propagate_key_event
[25] g_closure_invoke
[26] g_signal_emit_valist
[27] g_signal_emit
[28] gtk_propagate_event
[29] gtk_main_do_event
[30] g_main_context_dispatch
[31] g_main_loop_run
[32] gtk_main
[33] wxGUIEventLoop::DoRun()
[34] wxEventLoopBase::Run()
[35] wxAppConsoleBase::MainLoop()
[36] wxEntry(int&, wchar_t**)
[37] main
[38] __libc_start_main
[39] _start