### PR TITLE
Add the recently-added GZDoom UDMF properties

### DIFF
--- a/dist/res/config/ports/include/props_zdoom.cfg
+++ b/dist/res/config/ports/include/props_zdoom.cfg
@@ -193,7 +193,7 @@ udmf_properties
 			property nogradient_top		= "Disable upper gradient";
 			property flipgradient_top	= "Flip upper gradient";
 			property clampgradient_top	= "Clamp upper gradient";
-			property useowncolors_top	= "Use this sidedef's upper colors";
+			property useowncolors_top	= "Custom upper colors";
 			property uppercolor_top
 			{
 				name = "Upper top color";
@@ -210,7 +210,7 @@ udmf_properties
 			property nogradient_mid		= "Disable middle gradient";
 			property flipgradient_mid	= "Flip middle gradient";
 			property clampgradient_mid	= "Clamp middle gradient";
-			property useowncolors_mid	= "Use this sidedef's middle colors";
+			property useowncolors_mid	= "Custom middle colors";
 			property uppercolor_mid
 			{
 				name = "Middle top color";
@@ -227,7 +227,7 @@ udmf_properties
 			property nogradient_bottom		= "Disable lower gradient";
 			property flipgradient_bottom	= "Flip lower gradient";
 			property clampgradient_bottom	= "Clamp lower gradient";
-			property useowncolors_bottom	= "Use this sidedef's lower colors";
+			property useowncolors_bottom	= "Custom lower colors";
 			property uppercolor_bottom
 			{
 				name = "Lower top color";

--- a/dist/res/config/ports/include/props_zdoom.cfg
+++ b/dist/res/config/ports/include/props_zdoom.cfg
@@ -117,6 +117,30 @@ udmf_properties
 				default = "";
 			}
 		}
+
+		group "Lightmaps"
+		{
+			show_always = false;
+
+			property lightcolor
+			{
+				name = "Light color";
+				type = colour;
+				default = 0;
+			}
+			property lightintensity
+			{
+				name = "Light intensity";
+				type = float;
+				default = 1;
+			}
+			property lightdistance
+			{
+				name = "Light distance";
+				type = float;
+				default = 0;
+			}
+		}
 	}
 
 	block sidedef
@@ -165,6 +189,57 @@ udmf_properties
 			property lightabsolute	= "Absolute Light Level";
 			property nofakecontrast	= "No Fake Contrast";
 			property smoothlighting	= "Smooth Fake Contrast";
+
+			property nogradient_top		= "Disable upper gradient";
+			property flipgradient_top	= "Flip upper gradient";
+			property clampgradient_top	= "Clamp upper gradient";
+			property useowncolors_top	= "Use this sidedef's upper colors";
+			property uppercolor_top
+			{
+				name = "Upper top color";
+				type = colour;
+				default = 16777215;
+			}
+			property lowercolor_top
+			{
+				name = "Upper bottom color";
+				type = colour;
+				default = 16777215;
+			}
+
+			property nogradient_mid		= "Disable middle gradient";
+			property flipgradient_mid	= "Flip middle gradient";
+			property clampgradient_mid	= "Clamp middle gradient";
+			property useowncolors_mid	= "Use this sidedef's middle colors";
+			property uppercolor_mid
+			{
+				name = "Middle top color";
+				type = colour;
+				default = 16777215;
+			}
+			property lowercolor_mid
+			{
+				name = "Middle bottom color";
+				type = colour;
+				default = 16777215;
+			}
+
+			property nogradient_bottom		= "Disable lower gradient";
+			property flipgradient_bottom	= "Flip lower gradient";
+			property clampgradient_bottom	= "Clamp lower gradient";
+			property useowncolors_bottom	= "Use this sidedef's lower colors";
+			property uppercolor_bottom
+			{
+				name = "Lower top color";
+				type = colour;
+				default = 16777215;
+			}
+			property lowercolor_bottom
+			{
+				name = "Lower bottom color";
+				type = colour;
+				default = 16777215;
+			}
 		}
 
 		group "Rendering"
@@ -551,6 +626,47 @@ udmf_properties
 				default = "";
 			}
 		}
+
+		group "Lightmaps"
+		{
+			property lightcolorfloor
+			{
+				name = "Floor light color";
+				type = colour;
+				default = 0;
+			}
+			property lightintensityfloor
+			{
+				name = "Floor light intensity";
+				type = float;
+				default = 1;
+			}
+			property lightdistancefloor
+			{
+				name = "Floor light distance";
+				type = float;
+				default = 0;
+			}
+
+			property lightcolorceiling
+			{
+				name = "Ceiling light color";
+				type = colour;
+				default = 0;
+			}
+			property lightintensityceiling
+			{
+				name = "Ceiling light intensity";
+				type = float;
+				default = 1;
+			}
+			property lightdistanceceiling
+			{
+				name = "Ceiling light distance";
+				type = float;
+				default = 0;
+			}
+		}
 	}
 
 	block thing
@@ -717,6 +833,42 @@ udmf_properties
 				default = 1;
 			}
 			property score = "Score";
+		}
+
+		group "Lightmaps"
+		{
+			show_always = false;
+
+			property lightcolor
+			{
+				name = "Light color";
+				type = colour;
+				default = 0;
+			}
+			property lightintensity
+			{
+				name = "Light intensity";
+				type = float;
+				default = 1;
+			}
+			property lightdistance
+			{
+				name = "Light distance";
+				type = float;
+				default = 0;
+			}
+			property lightinnerangle
+			{
+				name = "Light inner angle";
+				type = float;
+				default = 180;
+			}
+			property lightouterangle
+			{
+				name = "Light outer angle";
+				type = float;
+				default = 180;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This includes the [new properties](https://github.com/coelckers/gzdoom/commit/f2dcff43868b2cf34f7b69e677a32b76724b02b3) for Doom 64-style lighting, as well as the lightmap-related properties used by [ZDRay](https://github.com/dpJudas/ZDRay).