### PR TITLE
Set CMP0072 NEW behabiour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,10 @@ project(Slade3)
 
 if(COMMAND cmake_policy)
 	cmake_policy( SET CMP0012 NEW )
-endif(COMMAND cmake_policy)
-
-if(COMMAND cmake_policy)
 	cmake_policy( SET CMP0003 NEW )
-endif(COMMAND cmake_policy)
-
-if(COMMAND cmake_policy)
 	cmake_policy( SET CMP0005 NEW )
-endif(COMMAND cmake_policy)
-
-if(COMMAND cmake_policy)
 	cmake_policy( SET CMP0011 NEW )
+	cmake_policy( SET CMP0072 NEW )
 endif(COMMAND cmake_policy)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)


### PR DESCRIPTION
CMP0072
-------

``FindOpenGL`` prefers GLVND by default when available.

The ``FindOpenGL`` module provides an ``OpenGL::GL`` target and an
``OPENGL_LIBRARIES`` variable for projects to use for legacy GL interfaces.
When both a legacy GL library (e.g. ``libGL.so``) and GLVND libraries
for OpenGL and GLX (e.g. ``libOpenGL.so`` and ``libGLX.so``) are available,
the module must choose between them.  It documents an ``OpenGL_GL_PREFERENCE``
variable that can be used to specify an explicit preference.  When no such
preference is set, the module must choose a default preference.

CMake 3.11 and above prefer to choose GLVND libraries.  This policy provides
compatibility with projects that expect the legacy GL library to be used.

The ``OLD`` behavior for this policy is to set ``OpenGL_GL_PREFERENCE`` to
``LEGACY``.  The ``NEW`` behavior for this policy is to set
``OpenGL_GL_PREFERENCE`` to ``GLVND``.

This policy was introduced in CMake version 3.11.  CMake version
3.12.4 warns when the policy is not set and uses ``OLD`` behavior.
Use the ``cmake_policy()`` command to set it to ``OLD`` or ``NEW``
explicitly.

.. note::
  The ``OLD`` behavior of a policy is
  ``deprecated by definition``
  and may be removed in a future version of CMake.