### PR TITLE
Fix build

### DIFF
--- a/src/Archive/Formats/WadArchive.cpp
+++ b/src/Archive/Formats/WadArchive.cpp
@@ -35,7 +35,7 @@
 #include "General/UI.h"
 #include "Utility/Tokenizer.h"
 
-bool JaguarDecode(MemChunk& mc);
+bool JaguarDecode(MemChunk& mc) { return false; };
 
 // -----------------------------------------------------------------------------
 //
@@ -230,7 +230,7 @@ void WadArchive::updateNamespaces()
 				}
 			}
 			// Flat hack: closing the flat namespace without opening it
-			if (found == false && ns_name == "f")
+			if (!found && ns_name == "f")
 			{
 				NSPair ns(rootDir()->entryAt(0), entry);
 				ns.start_index = 0;


### PR DESCRIPTION
```
/usr/bin/ld: External/libexternal.a(loslib.o): in function `os_tmpname':
/home/sergio/workspace/dev/SLADE/src/External/lua/loslib.c:169: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
/usr/bin/ld: CMakeFiles/slade.dir/Archive/Formats/WadArchive.o: in function `WadArchive::open(MemChunk&)':
/home/sergio/workspace/dev/SLADE/src/Archive/Formats/WadArchive.cpp:475: undefined reference to `JaguarDecode(MemChunk&)'
collect2: error: ld returned 1 exit status
make[3]: *** [src/CMakeFiles/slade.dir/build.make:4148: slade] Error 1
make[2]: *** [CMakeFiles/Makefile2:227: src/CMakeFiles/slade.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:239: src/CMakeFiles/slade.dir/rule] Error 2
make: *** [Makefile:216: slade] Error 2
```