### PR TITLE
Fix sector deletion in sector mode

### DIFF
--- a/src/MapEditor/Edit/Edit2D.cpp
+++ b/src/MapEditor/Edit/Edit2D.cpp
@@ -1136,8 +1136,6 @@ void Edit2D::deleteSector() const
 		for (unsigned s = 0; s < sector->connectedSides().size(); s++)
 			connected_sides.push_back(sector->connectedSides()[s]);
 		sector->getLines(connected_lines);
-
-		context_.map().removeSector(sector);
 	}
 
 	// Remove all connected sides


### PR DESCRIPTION
Now that the sector is deleted in removeSide, the sector no longer needs to be deleted in deleteSector, since deleteSector calls removeSide, which in turn causes sectors without sidedefs to be deleted, resulting in two sectors being deleted.

This commit removes the sector deletion code from deleteSector, instead delegating it to removeSide.