### PR TITLE
Fix UV coordinates and scale of scaled textures

### DIFF
--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -174,6 +174,7 @@ GLTexture* MapTextureManager::getTexture(string name, bool mixed)
 						h = image.getHeight();
 						sw = imgref.getWidth();
 						sh = imgref.getHeight();
+						mtex.texture->setWorldPanning(true);
 						mtex.texture->setScale((double)sw/(double)w, (double)sh/(double)h);
 					}
 				}
@@ -194,6 +195,7 @@ GLTexture* MapTextureManager::getTexture(string name, bool mixed)
 			mtex.texture->loadImage(&image, palette);
 			double sx = ctex->getScaleX(); if (sx == 0) sx = 1.0;
 			double sy = ctex->getScaleY(); if (sy == 0) sy = 1.0;
+			mtex.texture->setWorldPanning(ctex->worldPanning());
 			mtex.texture->setScale(1.0/sx, 1.0/sy);
 		}
 	}
@@ -262,6 +264,7 @@ GLTexture* MapTextureManager::getFlat(string name, bool mixed)
 				double sx = ctex->getScaleX(); if (sx == 0) sx = 1.0;
 				double sy = ctex->getScaleY(); if (sy == 0) sy = 1.0;
 				mtex.texture->setScale(1.0/sx, 1.0/sy);
+				mtex.texture->setWorldPanning(ctex->worldPanning());
 				return mtex.texture;
 			}
 		}

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -1289,9 +1289,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_mid"))
-				sx = 1.0 / line->s1()->floatProperty("scalex_mid");
+				sx *= 1.0 / line->s1()->floatProperty("scalex_mid");
 			if (line->s1()->hasProp("scaley_mid"))
-				sy = 1.0 / line->s1()->floatProperty("scaley_mid");
+				sy *= 1.0 / line->s1()->floatProperty("scaley_mid");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
@@ -1383,9 +1383,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_bottom"))
-				sx = 1.0 / line->s1()->floatProperty("scalex_bottom");
+				sx *= 1.0 / line->s1()->floatProperty("scalex_bottom");
 			if (line->s1()->hasProp("scaley_bottom"))
-				sy = 1.0 / line->s1()->floatProperty("scaley_bottom");
+				sy *= 1.0 / line->s1()->floatProperty("scaley_bottom");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
@@ -1516,9 +1516,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_top"))
-				sx = 1.0 / line->s1()->floatProperty("scalex_top");
+				sx *= 1.0 / line->s1()->floatProperty("scalex_top");
 			if (line->s1()->hasProp("scaley_top"))
-				sy = 1.0 / line->s1()->floatProperty("scaley_top");
+				sy *= 1.0 / line->s1()->floatProperty("scaley_top");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
@@ -1563,9 +1563,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_bottom"))
-				sx = 1.0 / line->s2()->floatProperty("scalex_bottom");
+				sx *= 1.0 / line->s2()->floatProperty("scalex_bottom");
 			if (line->s2()->hasProp("scaley_bottom"))
-				sy = 1.0 / line->s2()->floatProperty("scaley_bottom");
+				sy *= 1.0 / line->s2()->floatProperty("scaley_bottom");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
@@ -1616,9 +1616,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_mid"))
-				sx = 1.0 / line->s2()->floatProperty("scalex_mid");
+				sx *= 1.0 / line->s2()->floatProperty("scalex_mid");
 			if (line->s2()->hasProp("scaley_mid"))
-				sy = 1.0 / line->s2()->floatProperty("scaley_mid");
+				sy *= 1.0 / line->s2()->floatProperty("scaley_mid");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
@@ -1696,9 +1696,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_top"))
-				sx = 1.0 / line->s2()->floatProperty("scalex_top");
+				sx *= 1.0 / line->s2()->floatProperty("scalex_top");
 			if (line->s2()->hasProp("scaley_top"))
-				sy = 1.0 / line->s2()->floatProperty("scaley_top");
+				sy *= 1.0 / line->s2()->floatProperty("scaley_top");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -1185,8 +1185,6 @@ void MapRenderer3D::setupQuadTexCoords(MapRenderer3D::quad_3d_t* quad, int lengt
 		y1 = y2 - height;
 	}
 
-	sx *= quad->texture->getScaleX();
-	sy *= quad->texture->getScaleY();
 	double x_mult = 1.0 / (quad->texture->getWidth() * sx);
 	double y_mult = 1.0 / (quad->texture->getHeight() * sy);
 
@@ -1285,7 +1283,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Texture scale
-		sx = sy = 1;
+		quad.texture = MapEditor::textureManager().getTexture(line->s1()->getTexMiddle(), mixed);
+		sx = quad.texture->getScaleX();
+		sy = quad.texture->getScaleY();
 		if (Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_mid"))
@@ -1293,15 +1293,16 @@ void MapRenderer3D::updateLine(unsigned index)
 			if (line->s1()->hasProp("scaley_mid"))
 				sy = 1.0 / line->s1()->floatProperty("scaley_mid");
 		}
-		xoff *= sx;
-		yoff *= sy;
+		if (!quad.texture->worldPanning()) {
+			xoff *= sx;
+			yoff *= sy;
+		}
 
 		// Create quad
 		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), cp1, fp1);
 		quad.colour = colour1;
 		quad.fogcolour = fogcolour1;
 		quad.light = light1;
-		quad.texture = MapEditor::textureManager().getTexture(line->s1()->getTexMiddle(), mixed);
 		setupQuadTexCoords(&quad, length, xoff, yoff, ceiling1, floor1, lpeg, sx, sy);
 
 		// Add middle quad and finish
@@ -1376,7 +1377,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Texture scale
-		sx = sy = 1;
+		quad.texture = MapEditor::textureManager().getTexture(line->s1()->getTexLower(), mixed);
+		sx = quad.texture->getScaleX();
+		sy = quad.texture->getScaleY();
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_bottom"))
@@ -1384,8 +1387,10 @@ void MapRenderer3D::updateLine(unsigned index)
 			if (line->s1()->hasProp("scaley_bottom"))
 				sy = 1.0 / line->s1()->floatProperty("scaley_bottom");
 		}
-		xoff *= sx;
-		yoff *= sy;
+		if (!quad.texture->worldPanning()) {
+			xoff *= sx;
+			yoff *= sy;
+		}
 
 		if (lpeg)	// Lower unpegged
 			yoff += (ceiling1 - floor2);
@@ -1395,7 +1400,6 @@ void MapRenderer3D::updateLine(unsigned index)
 		quad.colour = colour1;
 		quad.fogcolour = fogcolour1;
 		quad.light = light1;
-		quad.texture = MapEditor::textureManager().getTexture(line->s1()->getTexLower(), mixed);
 		setupQuadTexCoords(&quad, length, xoff, yoff, floor2, floor1, false, sx, sy);
 		// No, the sky hack is only for ceilings!
 		// if (S_CMPNOCASE(sky_flat, line->backSector()->getFloorTex())) quad.flags |= SKY;
@@ -1427,16 +1431,19 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Texture scale
-		sx = sy = 1;
+		sx = quad.texture->getScaleX();
+		sy = quad.texture->getScaleY();
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_mid"))
-				sx = 1.0 / line->s1()->floatProperty("scalex_mid");
+				sx *= 1.0 / line->s1()->floatProperty("scalex_mid");
 			if (line->s1()->hasProp("scaley_mid"))
-				sy = 1.0 / line->s1()->floatProperty("scaley_mid");
+				sy *= 1.0 / line->s1()->floatProperty("scaley_mid");
 		}
-		xoff *= sx;
-		yoff *= sy;
+		if (!quad.texture->worldPanning()) {
+			xoff *= sx;
+			yoff *= sy;
+		}
 
 		// Setup quad coordinates
 		double top, bottom;
@@ -1503,7 +1510,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Texture scale
-		sx = sy = 1;
+		quad.texture = MapEditor::textureManager().getTexture(line->s1()->getTexUpper(), mixed);
+		sx = quad.texture->getScaleX();
+		sy = quad.texture->getScaleY();
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_top"))
@@ -1511,15 +1520,16 @@ void MapRenderer3D::updateLine(unsigned index)
 			if (line->s1()->hasProp("scaley_top"))
 				sy = 1.0 / line->s1()->floatProperty("scaley_top");
 		}
-		xoff *= sx;
-		yoff *= sy;
+		if (!quad.texture->worldPanning()) {
+			xoff *= sx;
+			yoff *= sy;
+		}
 
 		// Create quad
 		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), cp1, cp2);
 		quad.colour = colour1;
 		quad.fogcolour = fogcolour1;
 		quad.light = light1;
-		quad.texture = MapEditor::textureManager().getTexture(line->s1()->getTexUpper(), mixed);
 		setupQuadTexCoords(&quad, length, xoff, yoff, ceiling1, ceiling2, !upeg, sx, sy);
 		// Sky hack only applies if both sectors have a sky ceiling
 		if (S_CMPNOCASE(sky_flat, line->frontSector()->getCeilingTex()) && S_CMPNOCASE(sky_flat, line->backSector()->getCeilingTex())) quad.flags |= SKY;
@@ -1547,7 +1557,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Texture scale
-		sx = sy = 1;
+		quad.texture = MapEditor::textureManager().getTexture(line->s2()->getTexLower(), mixed);
+		sx = quad.texture->getScaleX();
+		sy = quad.texture->getScaleY();
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_bottom"))
@@ -1555,8 +1567,10 @@ void MapRenderer3D::updateLine(unsigned index)
 			if (line->s2()->hasProp("scaley_bottom"))
 				sy = 1.0 / line->s2()->floatProperty("scaley_bottom");
 		}
-		xoff *= sx;
-		yoff *= sy;
+		if (!quad.texture->worldPanning()) {
+			xoff *= sx;
+			yoff *= sy;
+		}
 
 		if (lpeg)	// Lower unpegged
 			yoff += (ceiling2 - floor1);
@@ -1566,7 +1580,6 @@ void MapRenderer3D::updateLine(unsigned index)
 		quad.colour = colour2;
 		quad.fogcolour = fogcolour2;
 		quad.light = light2;
-		quad.texture = MapEditor::textureManager().getTexture(line->s2()->getTexLower(), mixed);
 		setupQuadTexCoords(&quad, length, xoff, yoff, floor1, floor2, false, sx, sy);
 		if (S_CMPNOCASE(sky_flat, line->frontSector()->getFloorTex())) quad.flags |= SKY;
 		quad.flags |= BACK;
@@ -1598,7 +1611,8 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Texture scale
-		sx = sy = 1;
+		sx = quad.texture->getScaleX();
+		sy = quad.texture->getScaleY();
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_mid"))
@@ -1606,8 +1620,10 @@ void MapRenderer3D::updateLine(unsigned index)
 			if (line->s2()->hasProp("scaley_mid"))
 				sy = 1.0 / line->s2()->floatProperty("scaley_mid");
 		}
-		xoff *= sx;
-		yoff *= sy;
+		if (!quad.texture->worldPanning()) {
+			xoff *= sx;
+			yoff *= sy;
+		}
 
 		// Setup quad coordinates
 		double top, bottom;
@@ -1674,7 +1690,9 @@ void MapRenderer3D::updateLine(unsigned index)
 		}
 
 		// Texture scale
-		sx = sy = 1;
+		quad.texture = MapEditor::textureManager().getTexture(line->s2()->getTexUpper(), mixed);
+		sx = quad.texture->getScaleX();
+		sy = quad.texture->getScaleY();
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_top"))
@@ -1682,15 +1700,16 @@ void MapRenderer3D::updateLine(unsigned index)
 			if (line->s2()->hasProp("scaley_top"))
 				sy = 1.0 / line->s2()->floatProperty("scaley_top");
 		}
-		xoff *= sx;
-		yoff *= sy;
+		if (!quad.texture->worldPanning()) {
+			xoff *= sx;
+			yoff *= sy;
+		}
 
 		// Create quad
 		setupQuad(&quad, line->x2(), line->y2(), line->x1(), line->y1(), cp2, cp1);
 		quad.colour = colour2;
 		quad.fogcolour = fogcolour2;
 		quad.light = light2;
-		quad.texture = MapEditor::textureManager().getTexture(line->s2()->getTexUpper(), mixed);
 		setupQuadTexCoords(&quad, length, xoff, yoff, ceiling2, ceiling1, !upeg, sx, sy);
 		if (S_CMPNOCASE(sky_flat, line->frontSector()->getCeilingTex())) quad.flags |= SKY;
 		quad.flags |= BACK;

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -1181,7 +1181,7 @@ void MapRenderer3D::setupQuadTexCoords(MapRenderer3D::quad_3d_t* quad, int lengt
 	double y2 = o_top + height;
 	if (pegbottom)
 	{
-		y2 = o_top + quad->texture->getHeight();
+		y2 = o_top + quad->texture->getHeight() * sy;
 		y1 = y2 - height;
 	}
 

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -1226,7 +1226,7 @@ void MapRenderer3D::updateLine(unsigned index)
 	int map_format = MapEditor::editContext().mapDesc().format;
 	bool upeg = Game::configuration().lineBasicFlagSet("dontpegtop", line, map_format);
 	bool lpeg = Game::configuration().lineBasicFlagSet("dontpegbottom", line, map_format);
-	double xoff, yoff, sx, sy;
+	double xoff, yoff, sx, sy, lsx, lsy;
 	bool mixed = Game::configuration().featureSupported(Feature::MixTexFlats);
 	lines[index].line = line;
 	double alpha = 1.0;
@@ -1266,6 +1266,8 @@ void MapRenderer3D::updateLine(unsigned index)
 	}
 
 	// --- One-sided line ---
+	lsx = 1;
+	lsy = 1;
 	int length = MathStuff::round(line->getLength());
 	if (line->s1() && !line->s2())
 	{
@@ -1289,14 +1291,18 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_mid"))
-				sx *= 1.0 / line->s1()->floatProperty("scalex_mid");
+				lsx = 1.0 / line->s1()->floatProperty("scalex_mid");
 			if (line->s1()->hasProp("scaley_mid"))
-				sy *= 1.0 / line->s1()->floatProperty("scaley_mid");
+				lsy = 1.0 / line->s1()->floatProperty("scaley_mid");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
 			yoff *= sy;
 		}
+		sx *= lsx;
+		sy *= lsy;
+		xoff *= lsx;
+		yoff *= lsy;
 
 		// Create quad
 		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), cp1, fp1);
@@ -1360,6 +1366,8 @@ void MapRenderer3D::updateLine(unsigned index)
 	}
 
 	// Front lower
+	lsx = 1;
+	lsy = 1;
 	if (f2h1 > f1h1 || f2h2 > f1h2)
 	{
 		quad_3d_t quad;
@@ -1383,14 +1391,18 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_bottom"))
-				sx *= 1.0 / line->s1()->floatProperty("scalex_bottom");
+				lsx = 1.0 / line->s1()->floatProperty("scalex_bottom");
 			if (line->s1()->hasProp("scaley_bottom"))
-				sy *= 1.0 / line->s1()->floatProperty("scaley_bottom");
+				lsy = 1.0 / line->s1()->floatProperty("scaley_bottom");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
 			yoff *= sy;
 		}
+		sx *= lsx;
+		sy *= lsy;
+		xoff *= lsx;
+		yoff *= lsy;
 
 		if (lpeg)	// Lower unpegged
 			yoff += (ceiling1 - floor2);
@@ -1410,6 +1422,8 @@ void MapRenderer3D::updateLine(unsigned index)
 	}
 
 	// Front middle
+	lsx = 1;
+	lsy = 1;
 	string midtex1 = line->stringProperty("side1.texturemiddle");
 	if (!midtex1.IsEmpty() && midtex1 != hidden_tex && show_midtex)
 	{
@@ -1436,14 +1450,18 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_mid"))
-				sx *= 1.0 / line->s1()->floatProperty("scalex_mid");
+				lsx = 1.0 / line->s1()->floatProperty("scalex_mid");
 			if (line->s1()->hasProp("scaley_mid"))
-				sy *= 1.0 / line->s1()->floatProperty("scaley_mid");
+				lsy = 1.0 / line->s1()->floatProperty("scaley_mid");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
 			yoff *= sy;
 		}
+		sx *= lsx;
+		sy *= lsy;
+		xoff *= lsx;
+		yoff *= lsy;
 
 		// Setup quad coordinates
 		double top, bottom;
@@ -1493,6 +1511,8 @@ void MapRenderer3D::updateLine(unsigned index)
 	}
 
 	// Front upper
+	lsx = 1;
+	lsy = 1;
 	if (c1h1 > c2h1 || c1h2 > c2h2)
 	{
 		quad_3d_t quad;
@@ -1516,14 +1536,18 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s1()->hasProp("scalex_top"))
-				sx *= 1.0 / line->s1()->floatProperty("scalex_top");
+				lsx = 1.0 / line->s1()->floatProperty("scalex_top");
 			if (line->s1()->hasProp("scaley_top"))
-				sy *= 1.0 / line->s1()->floatProperty("scaley_top");
+				lsy = 1.0 / line->s1()->floatProperty("scaley_top");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
 			yoff *= sy;
 		}
+		sx *= lsx;
+		sy *= lsy;
+		xoff *= lsx;
+		yoff *= lsy;
 
 		// Create quad
 		setupQuad(&quad, line->x1(), line->y1(), line->x2(), line->y2(), cp1, cp2);
@@ -1540,6 +1564,8 @@ void MapRenderer3D::updateLine(unsigned index)
 	}
 
 	// Back lower
+	lsx = 1;
+	lsy = 1;
 	if (f1h1 > f2h1 || f1h2 > f2h2)
 	{
 		quad_3d_t quad;
@@ -1563,14 +1589,18 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_bottom"))
-				sx *= 1.0 / line->s2()->floatProperty("scalex_bottom");
+				lsx = 1.0 / line->s2()->floatProperty("scalex_bottom");
 			if (line->s2()->hasProp("scaley_bottom"))
-				sy *= 1.0 / line->s2()->floatProperty("scaley_bottom");
+				lsy = 1.0 / line->s2()->floatProperty("scaley_bottom");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
 			yoff *= sy;
 		}
+		sx *= lsx;
+		sy *= lsy;
+		xoff *= lsx;
+		yoff *= lsy;
 
 		if (lpeg)	// Lower unpegged
 			yoff += (ceiling2 - floor1);
@@ -1590,6 +1620,8 @@ void MapRenderer3D::updateLine(unsigned index)
 	}
 
 	// Back middle
+	lsx = 1;
+	lsy = 1;
 	string midtex2 = line->stringProperty("side2.texturemiddle");
 	if (!midtex2.IsEmpty() && midtex2 != hidden_tex && show_midtex)
 	{
@@ -1616,14 +1648,18 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_mid"))
-				sx *= 1.0 / line->s2()->floatProperty("scalex_mid");
+				lsx = 1.0 / line->s2()->floatProperty("scalex_mid");
 			if (line->s2()->hasProp("scaley_mid"))
-				sy *= 1.0 / line->s2()->floatProperty("scaley_mid");
+				lsy = 1.0 / line->s2()->floatProperty("scaley_mid");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
 			yoff *= sy;
 		}
+		sx *= lsx;
+		sy *= lsy;
+		xoff *= lsx;
+		yoff *= lsy;
 
 		// Setup quad coordinates
 		double top, bottom;
@@ -1673,6 +1709,8 @@ void MapRenderer3D::updateLine(unsigned index)
 	}
 
 	// Back upper
+	lsx = 1;
+	lsy = 1;
 	if (c2h1 > c1h1 || c2h2 > c1h2)
 	{
 		quad_3d_t quad;
@@ -1696,14 +1734,18 @@ void MapRenderer3D::updateLine(unsigned index)
 		if (map->currentFormat() == MAP_UDMF && Game::configuration().featureSupported(UDMFFeature::TextureScaling))
 		{
 			if (line->s2()->hasProp("scalex_top"))
-				sx *= 1.0 / line->s2()->floatProperty("scalex_top");
+				lsx = 1.0 / line->s2()->floatProperty("scalex_top");
 			if (line->s2()->hasProp("scaley_top"))
-				sy *= 1.0 / line->s2()->floatProperty("scaley_top");
+				lsy = 1.0 / line->s2()->floatProperty("scaley_top");
 		}
 		if (!quad.texture->worldPanning()) {
 			xoff *= sx;
 			yoff *= sy;
 		}
+		sx *= lsx;
+		sy *= lsy;
+		xoff *= lsx;
+		yoff *= lsy;
 
 		// Create quad
 		setupQuad(&quad, line->x2(), line->y2(), line->x1(), line->y1(), cp2, cp1);
@@ -1718,7 +1760,6 @@ void MapRenderer3D::updateLine(unsigned index)
 		// Add quad
 		lines[index].quads.push_back(quad);
 	}
-
 
 	// Finished
 	lines[index].updated_time = App::runTimer();

--- a/src/OpenGL/GLTexture.cpp
+++ b/src/OpenGL/GLTexture.cpp
@@ -57,6 +57,7 @@ GLTexture::GLTexture(bool allow_split)
 	this->tiling = true;
 	this->scale_x = 1.0;
 	this->scale_y = 1.0;
+	this->world_panning = false;
 }
 
 /* GLTexture::~GLTexture

--- a/src/OpenGL/GLTexture.h
+++ b/src/OpenGL/GLTexture.h
@@ -24,6 +24,7 @@ private:
 	bool				tiling;
 	double				scale_x;
 	double				scale_y;
+	bool 				world_panning;
 
 	// Some generic/global textures
 	static GLTexture	tex_background;	// Checkerboard background texture
@@ -56,7 +57,9 @@ public:
 	double		getScaleY() { return scale_y; }
 	bool		isTiling() { return tiling; }
 	unsigned	glId() { if (!tex.empty()) return tex[0].id; else return 0; }
+	bool		worldPanning() { return world_panning; }
 
+	void		setWorldPanning(bool wp) { world_panning = wp; }
 	void		setFilter(int filter) { this->filter = filter; }
 	void		setTiling(bool tiling) { this->tiling = tiling; }
 	void		setScale(double sx, double sy) { this->scale_x = sx; this->scale_y = sy; }


### PR DESCRIPTION
Fix UV coordinates and scale for quads that use scaled textures.
Set sx and sy to the scale specified in the texture definition.
Add world_panning field to GLTexture so that the "World panning" flag is passed to the renderer, and set it in MapTextureManager.getTexture/getFlat.
Use GLTexture worldPanning to determine how UVs of quads should be manipulated.
Don't scale UVs in setupQuadTexCoords

I tested my changes on [Final NeoDoom](https://forum.zdoom.org/viewtopic.php?f=19&t=49090&hilit=NeoDoom#p848714) MAP06, which has several road signs made from midtextures.