### PR TITLE
Fix exporting with multiple textureX entries

### DIFF
--- a/src/MainEditor/UI/TextureXEditor/PatchTablePanel.cpp
+++ b/src/MainEditor/UI/TextureXEditor/PatchTablePanel.cpp
@@ -105,7 +105,7 @@ string PatchTableListView::getItemText(long item, long column, long index) const
 	patch_t& patch = patch_table_->patch(index);
 
 	if (column == 0)						// Index column
-		return S_FMT("%04d", index);
+		return S_FMT("%04ld", index);
 	else if (column == 1)					// Name column
 		return patch.name;
 	else if (column == 2)					// Usage count column

--- a/src/MainEditor/UI/TextureXEditor/TextureXPanel.cpp
+++ b/src/MainEditor/UI/TextureXEditor/TextureXPanel.cpp
@@ -1489,7 +1489,8 @@ void TextureXPanel::onRedo(string action)
 bool TextureXPanel::handleAction(string id)
 {
 	// Don't handle if hidden
-	if (!tx_editor_->IsShown() || !IsShown())
+	wxNotebook* parent = dynamic_cast<wxNotebook*>(GetParent());
+	if (parent->GetCurrentPage() != this)
 		return false;
 
 	// Only interested in "txed_" events


### PR DESCRIPTION
Check to see whether the TextureXPanel is the current page in the notebook.
Also, fix a lot of assertions from the SLADE debug build by using the correct type in PatchTableListView::getItemText.