### PR TITLE
Use current page check in addition to visibility check

### DIFF
--- a/src/MainEditor/UI/TextureXEditor/TextureXPanel.cpp
+++ b/src/MainEditor/UI/TextureXEditor/TextureXPanel.cpp
@@ -1488,7 +1488,11 @@ void TextureXPanel::onRedo(string action)
 // ----------------------------------------------------------------------------
 bool TextureXPanel::handleAction(string id)
 {
-	// Don't handle if hidden
+	// Skip event if this panel is not the current page
+	TabControl* parent = static_cast<TabControl*>(GetParent());
+	if (parent->GetCurrentPage() != this)
+		return false;
+	// Skip event if this panel is hidden
 	if (!tx_editor_->IsShown() || !IsShown())
 		return false;
 


### PR DESCRIPTION
This makes copying and pasting textures from one archive to another work, as well as exporting PNGs or patches from TEXTURE2 work.