### PR TITLE
Remove pkg-config and GTK/GLib requirement on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ set(SLADE_OUTPUT_DIR ${CMAKE_BINARY_DIR} CACHE PATH "Directory where slade will 
 
 OPTION(NO_WEBVIEW "Disable wxWebview usage (for start page and documentation)" OFF)
 OPTION(USE_SFML_RENDERWINDOW "Use SFML RenderWindow for OpenGL displays" OFF)
-OPTION(WX_GTK3 "Use GTK3 (if wx is built with it)" ON)
+if(NOT APPLE)
+	OPTION(WX_GTK3 "Use GTK3 (if wx is built with it)" ON)
+endif(NOT APPLE)
 
 # c++14 is required to compile
 if(CMAKE_VERSION VERSION_LESS 3.1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,18 +83,14 @@ if (CMAKE_INSTALL_PREFIX)
 ADD_DEFINITIONS(-DINSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
 endif(CMAKE_INSTALL_PREFIX)
 
-find_package (PkgConfig REQUIRED)
-if (APPLE)
-	# There is no need to have GTK2 installed on OS X
-	# Although, GLib is required by FluidSynth
-	pkg_check_modules (GLib REQUIRED glib-2.0)
-else (APPLE)
+if (NOT APPLE)
+	find_package (PkgConfig REQUIRED)
 if (WX_GTK3)
 	pkg_check_modules (GTK3 REQUIRED gtk+-3.0)
 else (WX_GTK3)
 	pkg_check_modules (GTK2 REQUIRED gtk+-2.0)
 endif (WX_GTK3)
-endif (APPLE)
+endif (NOT APPLE)
 
 if(NOT NO_FLUIDSYNTH)
 	find_package(FluidSynth REQUIRED)


### PR DESCRIPTION
GLib dependency must be handled by FluidSynth itself
pkg-config is no longer needed
WX_GTK3 is unusable on macOS