### PR TITLE
Attempt to fix blank SCRIPTS/BEHAVIOR lump names

### DIFF
--- a/src/MapEditor/UI/ScriptEditorPanel.cpp
+++ b/src/MapEditor/UI/ScriptEditorPanel.cpp
@@ -102,15 +102,13 @@ ScriptEditorPanel::ScriptEditorPanel(wxWindow* parent)
 	if (S_CMPNOCASE(lang, "acs_hexen"))
 	{
 		text_editor->setLanguage(TextLanguage::fromId("acs"));
-		entry_script->setName("SCRIPTS");
-		entry_compiled->setName("BEHAVIOR");
 	}
 	else if (S_CMPNOCASE(lang, "acs_zdoom"))
 	{
 		text_editor->setLanguage(TextLanguage::fromId("acs_z"));
-		entry_script->setName("SCRIPTS");
-		entry_compiled->setName("BEHAVIOR");
 	}
+	entry_script->setName("SCRIPTS");
+	entry_compiled->setName("BEHAVIOR");
 
 	// Add Find+Replace panel
 	panel_fr = new FindReplacePanel(this, *text_editor);


### PR DESCRIPTION
Name the lumps "SCRIPTS" and "BEHAVIOR" respectively, regardless of whether or not they are Hexen or ZDoom ACS scripts. If any special cases need consideration, they can be added in later, with "SCRIPTS" and "BEHAVIOR" as the default lump names.