### PR TITLE
Fix crash when opening DBIGFONT files

### DIFF
--- a/src/Graphics/SImage/SImageFormats.cpp
+++ b/src/Graphics/SImage/SImageFormats.cpp
@@ -356,7 +356,7 @@ bool SImage::loadFont2(const uint8_t* gfx_data, int size)
 			if (chars[j].width)
 			{
 				memcpy(d, chars[j].data + (i * chars[j].width), chars[j].width);
-				d += chars[j].width + 1;
+				d += chars[j].width;
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes a buffer overrun that leads to heap corruption and eventual crash when opening DBIGFONT files