### PR TITLE
Add .VOX -> .KVX voxel conversion

### DIFF
--- a/src/MainEditor/Conversions.h
+++ b/src/MainEditor/Conversions.h
@@ -16,5 +16,6 @@ bool musToMidi(MemChunk& in, MemChunk& out);
 bool zmusToMidi(MemChunk& in, MemChunk& out, int subsong = 0, int* num_tracks = nullptr);
 bool gmidToMidi(MemChunk& in, MemChunk& out);
 bool rmidToMidi(MemChunk& in, MemChunk& out);
+bool voxToKvx(MemChunk& in, MemChunk& out);
 bool addImfHeader(MemChunk& in, MemChunk& out);
 }; // namespace Conversions

--- a/src/MainEditor/UI/ArchivePanel.h
+++ b/src/MainEditor/UI/ArchivePanel.h
@@ -71,6 +71,7 @@ public:
 	bool gfxTint();
 	bool gfxModifyOffsets() const;
 	bool gfxExportPNG();
+	bool voxelConvert();
 	bool swanConvert() const;
 	bool basConvert(bool animdefs = false);
 	bool palConvert() const;
@@ -138,6 +139,7 @@ protected:
 	EntryPanel* text_area_     = nullptr;
 	EntryPanel* ansi_area_     = nullptr;
 	EntryPanel* gfx_area_      = nullptr;
+	EntryPanel* voxel_area_    = nullptr;
 	EntryPanel* pal_area_      = nullptr;
 	EntryPanel* texturex_area_ = nullptr;
 	EntryPanel* pnames_area_   = nullptr;


### PR DESCRIPTION
This pull request adds an option to convert Ken Silverman's .VOX voxel modes to .KVX models, that are supported by ZDoom.