### PR TITLE
Fix minor issues in Info.plist

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>SLADE</string>
+	<string>slade</string>
 	<key>CFBundleGetInfoString</key>
 	<string>SLADE</string>
 	<key>CFBundleIconFile</key>
@@ -23,6 +23,8 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
 	<key>CFBundleVersion</key>
 	<string>3.1.0</string>


### PR DESCRIPTION
* Case of executable filename on disk and in Info.plist must match. Digital signature process will fail otherwise
* Do not switch GPU by default. This requires custom change to wxWidgets, see alexey-lysiuk/slade-macos-build@ccbd0b6a48fb2540f70bdb441b20e4ecfeccd4aa, as there is no support for user specified OpenGL pixel format attributes yet. Without this feature the entry has no effect, although it will be needed if such support will be added in the future