### PR TITLE
Add GL sector specials to ZDoom configuration

### DIFF
--- a/dist/res/config/ports/include/sectors_zdoom.cfg
+++ b/dist/res/config/ports/include/sectors_zdoom.cfg
@@ -45,6 +45,8 @@ sector_types
 	type 84		= "5% Lava Damage + Scroll East (12)";
 	type 85		= "4% Damage";
 	type 87		= "Outside Fog";
+	type 89		= "Doom64 sky rendering";
+	type 90		= "Clamp textures and disable SSAO (Skybox)";
 	type 104	= "5% Damage + Light On+Off Randomly";
 	type 105	= "Delayed damage weak";
 	type 115	= "Instant death";


### PR DESCRIPTION
This allows GLSector_Skybox and GLSector_NoSkyDraw to show up in the editor as valid special sector types.