### PR TITLE
Fix ZIP archive corruption caused by not overwriting the temp file

### DIFF
--- a/src/Utility/FileUtils.cpp
+++ b/src/Utility/FileUtils.cpp
@@ -80,13 +80,14 @@ bool FileUtil::removeFile(string_view path)
 }
 
 // -----------------------------------------------------------------------------
-// Copies the file at [from] to a file at [to], overwriting it if the target
-// file already exists
+// Copies the file at [from] to a file at [to]. If [overwrite] is true, it will
+// overwrite the file if it already exists.
 // -----------------------------------------------------------------------------
-bool FileUtil::copyFile(string_view from, string_view to)
+bool FileUtil::copyFile(string_view from, string_view to, bool overwrite)
 {
 	static std::error_code ec;
-	if (!fs::copy_file(from, to, ec))
+	auto options = overwrite ? fs::copy_options::overwrite_existing : fs::copy_options::none;
+	if (!fs::copy_file(from, to, options, ec))
 	{
 		Log::warning("Unable to copy file from \"{}\" to \"{}\": {}", from, to, ec.message());
 		return false;

--- a/src/Utility/FileUtils.h
+++ b/src/Utility/FileUtils.h
@@ -7,7 +7,7 @@ namespace FileUtil
 bool           fileExists(string_view path);
 bool           dirExists(string_view path);
 bool           removeFile(string_view path);
-bool           copyFile(string_view from, string_view to);
+bool           copyFile(string_view from, string_view to, bool overwrite = true);
 bool           readFileToString(const string& path, string& str);
 bool           writeStringToFile(string& str, const string& path);
 bool           createDir(string_view path);


### PR DESCRIPTION
Because `FileUtil::copyFile()` does not actually overwrite existing files, the temp file is not updated on save. `ZipArchive::save()` copies unchanged entries from the temp file, which leads to loss of earlier changes, and duplicate/invalid entries if entry ZipIds have changed on earlier saves.