### PR TITLE
Fix "Slopes" property group

### DIFF
--- a/dist/res/config/ports/include/props_zdoom.cfg
+++ b/dist/res/config/ports/include/props_zdoom.cfg
@@ -316,11 +316,11 @@ udmf_properties
 			}
 		}
 
-		Block "Slope"
+		group "Slopes"
 		{
-			show_always = false;
 			type = float;
 			default = 0;
+			show_always = false;
 
 			property ceilingplane_a = "Ceiling Plane Equation - A";
 			property ceilingplane_b = "Ceiling Plane Equation - B";


### PR DESCRIPTION
Slope properties will now show up in the list of properties at the side. Note that this doesn't fix saving slopes in UDMF maps; that's a completely different issue.