### PR TITLE
build: resolve compile error stemming from use of wrong types

### DIFF
--- a/src/MainEditor/UI/StartPage.cpp
+++ b/src/MainEditor/UI/StartPage.cpp
@@ -303,7 +303,7 @@ void SStartPage::load(bool new_tip)
 	}
 
 	// Get html as string
-	string html = wxString::FromAscii((const char*)(entry_html->rawData()), entry_html->size());
+	wxString html = wxString::FromAscii((const char*)(entry_html->rawData()), entry_html->size());
 
 	// Generate tip of the day string
 	string tip;
@@ -474,14 +474,14 @@ void SStartPage::onHTMLLinkClicked(wxEvent& e)
 void SStartPage::onHTMLLinkClicked(wxEvent& e)
 {
 	wxHtmlLinkEvent& ev = (wxHtmlLinkEvent&)e;
-	string href = ev.GetLinkInfo().GetHref();
+	wxString href = ev.GetLinkInfo().GetHref();
 
 	if (href.StartsWith("http://") || href.StartsWith("https://"))
 		wxLaunchDefaultBrowser(ev.GetLinkInfo().GetHref());
 	else if (href.StartsWith("recent://"))
 	{
 		// Recent file
-		string rs = href.Mid(9);
+		wxString rs = href.Mid(9);
 		unsigned long index = 0;
 		rs.ToULong(&index);
 		SActionHandler::setWxIdOffset(index);

--- a/src/UI/Dialogs/RunDialog.cpp
+++ b/src/UI/Dialogs/RunDialog.cpp
@@ -566,7 +566,7 @@ void RunDialog::onBtnEditConfig(wxCommandEvent& e)
 	RunConfigDialog dlg(this, "Edit Run Config", name, params, custom);
 	if (dlg.ShowModal() == wxID_OK)
 	{
-		wxString name         = dlg.name().IsEmpty() ? configs[index].first : dlg.name();
+		wxString name         = dlg.name().IsEmpty() ? wxString(configs[index].first) : dlg.name();
 		configs[index].first  = name;
 		configs[index].second = dlg.params();
 		choice_config_->SetString(index, name);


### PR DESCRIPTION
StartPage.cpp: In member function ‘void slade::SStartPage::load(bool)’:
StartPage.cpp:345:7: error: ‘std::__cxx11::string’ {aka ‘class
std::__cxx11::basic_string<char>’} has no member named ‘Replace’;
did you mean ‘replace’?
  html.Replace("#recent#", recent);

Fixes: #1169