### PR TITLE
util: do not pass nullptr to memcpy

### DIFF
--- a/src/Utility/MemChunk.cpp
+++ b/src/Utility/MemChunk.cpp
@@ -120,7 +120,12 @@ bool MemChunk::reSize(uint32_t new_size, bool preserve_data)
 		return false;
 
 	// Preserve existing data if specified
-	if (preserve_data)
+	if (!preserve_data)
+	{
+		clear();
+		data_ = ndata;
+	}
+	else if (data_ != nullptr)
 	{
 		memcpy(ndata, data_, size_ * sizeof(uint8_t));
 		delete[] data_;
@@ -128,7 +133,7 @@ bool MemChunk::reSize(uint32_t new_size, bool preserve_data)
 	}
 	else
 	{
-		clear();
+		memset(ndata, 0, size_ * sizeof(uint8_t));
 		data_ = ndata;
 	}
 


### PR DESCRIPTION
Something has passed nullptr to memcpy. (This probably happens upon
first allocation.) Avoid this, it is undefined behavior.

ASAN/UBSAN reported:

MemChunk.cpp:125:9: runtime error: null pointer passed as
argument 2, which is declared to never be null
/usr/include/bits/string_fortified.h:34:33: runtime error:
null pointer passed as argument 2, which is declared to never be null