### PR TITLE
archive: fix read-past-end when analyzing .wad as a .tar

### DIFF
--- a/src/Archive/Formats/TarArchive.cpp
+++ b/src/Archive/Formats/TarArchive.cpp
@@ -520,7 +520,7 @@ bool TarArchive::isTarArchive(MemChunk& mc)
 		// Read tar header
 		TarHeader header;
 		mc.read(&header, 512);
-		if (!strutil::equalCI(header.magic, TMAGIC))
+		if (!strutil::equalCI({header.magic, sizeof(header.magic)}, TMAGIC))
 		{
 			if (tarMakeChecksum(&header) == 0)
 			{


### PR DESCRIPTION
magic.header is treated like a C string, but if there is no \0 in the
buffer, there is your classic read-past-the-end bug.

ERROR: AddressSanitizer: stack-buffer-overflow on address [..]
READ of size 262 at 0x7ffd5e27b480 thread T0
    f0 (/usr/lib64/libasan.so.5+0x67617)
    f1 in std::char_traits<char>::length(char const*) /usr/include/c++/8/bits/char_traits.h:320
    f2 in std::basic_string_view<char, std::char_traits<char> >::basic_string_view(char const*) /usr/include/c++/8/string_view:100
    f3 in slade::TarArchive::isTarArchive(slade::MemChunk&) src/Archive/Formats/TarArchive.cpp:523
    f4 in TarDataFormat::isThisFormat(slade::MemChunk&) src/Archive/EntryType/DataFormats/ArchiveFormats.h:171
    f5 in slade::EntryType::isThisType(slade::ArchiveEntry&) src/Archive/EntryType/EntryType.cpp:201
    f6 in slade::EntryType::detectEntryType(slade::ArchiveEntry&) src/Archive/EntryType/EntryType.cpp:612
    f7 in slade::WadArchive::open(slade::MemChunk&) src/Archive/Formats/WadArchive.cpp:498
    f8 in slade::Archive::open(std::basic_string_view<char, std::char_traits<char> >) src/Archive/Archive.cpp:424
       <file in question: "doom2.wad">
    f9 in slade::ArchiveManager::openBaseResource(int) src/Archive/ArchiveManager.cpp:917
    f10 in slade::ArchiveManager::initBaseResource() src/Archive/ArchiveManager.cpp:175
    f11 in slade::app::init(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, double) src/Application/App.cpp:528
    f12 in SLADEWxApp::OnInit() src/Application/SLADEWxApp.cpp:559
    f13 in wxAppConsoleBase::CallOnInit() (slade+0xc6b163)
    f14 in wxEntry(int&, wchar_t**) (/usr/lib64/libwx_baseu-suse.so.3.0.4+0xeb971)
    f15 in main src/Application/SLADEWxApp.cpp:457
    f16 in __libc_start_main (/lib64/libc.so.6+0x24349)
    f17 in _start (slade+0xbf4f39)

Address 0x7ffd5e27b480 is located in stack of thread T0 at offset 672 in frame
    f0 0x109e5bb in slade::TarArchive::isTarArchive(slade::MemChunk&) src/Archive/Formats/TarArchive.cpp:515

  This frame has 3 object(s):
    [32, 48) '<unknown>'
    [96, 112) '<unknown>'
    [160, 672) 'header' <== Memory access at offset 672 overflows this variable

Fixes: 3.1.4-144-g2dd1daab