### PR TITLE
build: add cmake option to skip Lua components

### DIFF
--- a/src/Application/App.cpp
+++ b/src/Application/App.cpp
@@ -466,8 +466,10 @@ bool app::init(vector<string>& args, double ui_scale)
 	SAction::setBaseWxId(26000);
 	SAction::initActions();
 
+#ifdef USE_LUA
 	// Init lua
 	lua::init();
+#endif
 
 	// Init UI
 	ui::init(ui_scale);
@@ -530,8 +532,10 @@ bool app::init(vector<string>& args, double ui_scale)
 	log::info("Loading game configurations");
 	game::init();
 
+#ifdef USE_LUA
 	// Init script manager
 	scriptmanager::init();
+#endif
 
 	// Show the main window
 	maineditor::windowWx()->Show(true);
@@ -655,8 +659,10 @@ void app::exit(bool save_config)
 		// Save custom special presets
 		game::saveCustomSpecialPresets();
 
+#ifdef USE_LUA
 		// Save custom scripts
 		scriptmanager::saveUserScripts();
+#endif
 	}
 
 	// Close all open archives
@@ -677,8 +683,10 @@ void app::exit(bool save_config)
 			log::warning("Could not clean up temporary file \"{}\": {}", item.path().string(), error.message());
 	}
 
+#ifdef USE_LUA
 	// Close lua
 	lua::close();
+#endif
 
 	// Close DUMB
 	dumb_exit();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,7 +104,9 @@ find_package(SFML COMPONENTS ${SFML_FIND_COMPONENTS} REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(CURL REQUIRED)
-find_package(Lua REQUIRED)
+if (NOT NO_LUA)
+	find_package(Lua REQUIRED)
+endif()
 find_package(fmt CONFIG REQUIRED)
 find_package(MPG123 REQUIRED)
 include_directories(
@@ -133,6 +135,7 @@ endif()
 
 set(SLADE_SOURCES
 )
+set(SLADE_SCRIPTING_SOURCES)
 # Don't include external libraries here as they should be compiled separately
 file(GLOB_RECURSE SLADE_SOURCES
 	Application/*.cpp
@@ -145,12 +148,17 @@ file(GLOB_RECURSE SLADE_SOURCES
 	MainEditor/*.cpp
 	MapEditor/*.cpp
 	OpenGL/*.cpp
-	Scripting/*.cpp
 	SLADEMap/*.cpp
 	TextEditor/*.cpp
 	UI/*.cpp
 	Utility/*.cpp
 	)
+if (NOT NO_LUA)
+	file(GLOB_RECURSE SLADE_SCRIPTING_SOURCES Scripting/*.cpp)
+	set(SLADE_SOURCES ${SLADE_SOURCES} ${SLADE_SCRIPTING_SOURCES})
+	ADD_DEFINITIONS(-DUSE_LUA)
+else ()
+endif ()
 set(SLADE_HEADERS
 )
 file(GLOB_RECURSE SLADE_HEADERS *.h *.hpp)

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -657,7 +657,9 @@ void ArchivePanel::addMenus() const
 		auto menu_clean = createMaintenanceMenu();
 		menu_archive->AppendSubMenu(menu_clean, "&Maintenance")->SetBitmap(icons::getIcon(icons::Type::Any, "wrench"));
 		auto menu_scripts = new wxMenu();
+#ifdef USE_LUA
 		scriptmanager::populateEditorScriptMenu(menu_scripts, scriptmanager::ScriptType::Archive, "arch_script");
+#endif
 		menu_archive->AppendSubMenu(menu_scripts, "&Run Script");
 	}
 	if (!menu_entry)
@@ -681,7 +683,9 @@ void ArchivePanel::addMenus() const
 		menu_entry->AppendSeparator();
 		// SAction::fromId("arch_entry_bookmark")->addToMenu(menu_entry);
 		auto menu_scripts = new wxMenu();
+#ifdef USE_LUA
 		scriptmanager::populateEditorScriptMenu(menu_scripts, scriptmanager::ScriptType::Entry, "arch_entry_script");
+#endif
 		menu_entry->AppendSubMenu(menu_scripts, "&Run Script");
 	}
 
@@ -3324,9 +3328,11 @@ bool ArchivePanel::handleAction(string_view id)
 		dlg.ShowModal();
 	}
 
+#ifdef USE_LUA
 	// Archive->Scripts->...
 	else if (id == "arch_script")
 		scriptmanager::runArchiveScript(archive.get(), wx_id_offset_);
+#endif
 
 
 	// ------------------------------------------------------------------------
@@ -3404,9 +3410,11 @@ bool ArchivePanel::handleAction(string_view id)
 	else if (id == "arch_entry_openext")
 		openEntryExternal();
 
+#ifdef USE_LUA
 	// Entry->Run Script
 	else if (id == "arch_entry_script")
 		scriptmanager::runEntryScript(entry_tree_->selectedEntries(), wx_id_offset_, maineditor::windowWx());
+#endif
 
 
 	// Context menu actions
@@ -3943,6 +3951,7 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 #endif
 	}
 
+#ifdef USE_LUA
 	// Entry scripts
 	if (!scriptmanager::editorScripts(scriptmanager::ScriptType::Entry).empty())
 	{
@@ -3951,6 +3960,7 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 		context.AppendSeparator();
 		context.AppendSubMenu(menu_scripts, "Run &Script");
 	}
+#endif
 
 	// Popup the context menu
 	PopupMenu(&context);

--- a/src/MainEditor/UI/MainWindow.cpp
+++ b/src/MainEditor/UI/MainWindow.cpp
@@ -633,12 +633,14 @@ bool MainWindow::handleAction(string_view id)
 	if (id == "main_showstartpage")
 		openStartPageTab();
 
+#ifdef USE_LUA
 	// Tools->Run Script
 	if (id == "main_runscript")
 	{
 		scriptmanager::open();
 		return true;
 	}
+#endif
 
 	// Help->About
 	if (id == "main_about")

--- a/src/MapEditor/UI/MapEditorWindow.cpp
+++ b/src/MapEditor/UI/MapEditorWindow.cpp
@@ -266,7 +266,9 @@ void MapEditorWindow::setupMenu()
 	// Tools menu
 	auto menu_tools = new wxMenu("");
 	menu_scripts_   = new wxMenu();
+#ifdef USE_LUA
 	scriptmanager::populateEditorScriptMenu(menu_scripts_, scriptmanager::ScriptType::Map, "mapw_script");
+#endif
 	menu_tools->AppendSubMenu(menu_scripts_, "Run Script");
 	SAction::fromId("mapw_runscript")->addToMenu(menu_tools);
 	menu->Append(menu_tools, "&Tools");
@@ -1060,7 +1062,9 @@ void MapEditorWindow::reloadScriptsMenu() const
 	while (menu_scripts_->FindItemByPosition(0))
 		menu_scripts_->Delete(menu_scripts_->FindItemByPosition(0));
 
+#ifdef USE_LUA
 	scriptmanager::populateEditorScriptMenu(menu_scripts_, scriptmanager::ScriptType::Map, "mapw_script");
+#endif
 }
 
 // -----------------------------------------------------------------------------
@@ -1354,6 +1358,7 @@ bool MapEditorWindow::handleAction(string_view id)
 		return true;
 	}
 
+#ifdef USE_LUA
 	// Tools->Run Script
 	else if (id == "mapw_script")
 	{
@@ -1367,6 +1372,7 @@ bool MapEditorWindow::handleAction(string_view id)
 		scriptmanager::open();
 		return true;
 	}
+#endif
 
 	return false;
 }


### PR DESCRIPTION
sol.hpp has a lot of templates which, when building with -g
-fsanitize=address -fsanitize=undefined, incur long compile time and
high memory usage (~8500MB) [applies to Scripting/Export/Archive.cpp
and Scripting/Export/Graphics.cpp].

Add a cmake option so I can skip building some parts and focus on
the rest.