### PR TITLE
Fixed aarch64 building

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,9 +173,6 @@ if(APPLE)
 	set_source_files_properties(${OSX_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 endif(APPLE)
 
-# Enable SSE instructions for dumb library
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_USE_SSE -msse")
-
 # Enable debug symbols for glib (so gdb debugging works properly with strings etc.)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_GLIBCXX_DEBUG")
 

--- a/src/Utility/Colour.h
+++ b/src/Utility/Colour.h
@@ -14,11 +14,7 @@ struct ColRGBA
 	// Constructors
 	ColRGBA() = default;
 	ColRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255, char blend = -1, short index = -1) :
-		r{ r },
-		g{ g },
-		b{ b },
-		a{ a },
-		index{ index }
+		r{ r }, g{ g }, b{ b }, a{ a }, index{ index }
 	{
 	}
 	ColRGBA(const ColRGBA& c) : r{ c.r }, g{ c.g }, b{ c.b }, a{ c.a }, index{ c.index } {}
@@ -98,7 +94,7 @@ struct ColRGBA
 		if (na < 0)
 			na = 0;
 
-		return { (uint8_t)nr, (uint8_t)ng, (uint8_t)nb, (uint8_t)na, -1 };
+		return { (uint8_t)nr, (uint8_t)ng, (uint8_t)nb, (uint8_t)na, (char)-1 };
 	}
 
 	// Amplify/fade colour components by factors
@@ -126,7 +122,7 @@ struct ColRGBA
 		if (na < 0)
 			na = 0;
 
-		return { (uint8_t)nr, (uint8_t)ng, (uint8_t)nb, (uint8_t)na, -1 };
+		return { (uint8_t)nr, (uint8_t)ng, (uint8_t)nb, (uint8_t)na, (char)-1 };
 	}
 
 	void write(uint8_t* ptr) const


### PR DESCRIPTION
- Removed baked-in -msse call
- Added explicit casts for some compiler warnings

Fixes #1206 

And now it works fine on my Pinebook Pro and my RPi4.