### PR TITLE
fix for std::bad_variant_access exception that causes issue #1220

### DIFF
--- a/src/SLADEMap/MapObject/MapLine.cpp
+++ b/src/SLADEMap/MapObject/MapLine.cpp
@@ -893,11 +893,11 @@ void MapLine::writeBackup(Backup* backup)
 	if (side1_)
 		backup->props_internal["s1"] = side1_->objId();
 	else
-		backup->props_internal["s1"] = 0;
+		backup->props_internal["s1"] = (unsigned)0;
 	if (side2_)
 		backup->props_internal["s2"] = side2_->objId();
 	else
-		backup->props_internal["s2"] = 0;
+		backup->props_internal["s2"] = (unsigned)0;
 
 	// Flags
 	backup->props_internal[PROP_FLAGS] = flags_;


### PR DESCRIPTION
issue mentioned here https://github.com/sirjuddington/SLADE/issues/1220
is caused by a std::bad_variant_access exception

in the call stack in question 
https://github.com/sirjuddington/SLADE/blob/d55762dad1cd40f9791e4150aa93963de142ce75/src/SLADEMap/MapObject/MapLine.cpp#L939
https://github.com/sirjuddington/SLADE/blob/4f8aac7007aaa931a2c41adaed798a59a2bdbc1b/src/Utility/Property.h#L84

the issue was: 
`backup->props_internal["s1"] = 0;`
was setting the "s1" property to a signed integer, instead of an unsigned integer