### PR TITLE
Fixed slight issues when building for Clang

### DIFF
--- a/src/Graphics/CTexture/TextureXList.h
+++ b/src/Graphics/CTexture/TextureXList.h
@@ -67,6 +67,6 @@ public:
 private:
 	vector<unique_ptr<CTexture>> textures_;
 	Format                       txformat_ = Format::Normal;
-	CTexture tex_invalid_{ "INVALID_TEXTURE" }; // Deliberately set the invalid name to >8 characters
+	CTexture tex_invalid_{ static_cast<string_view>("INVALID_TEXTURE") }; // Deliberately set the invalid name to >8 characters
 };
 } // namespace slade


### PR DESCRIPTION
When I tried to build the project using CMake and clang a while back, it failed due to a issue when it tried to disambiguate the argument list of a function with multiple overloaded signatures. Using a `std::static_cast` seemed to fix it, so I pushed it to my fork. The issue might just as well have been solved separately in upstream, but it might be worth taking a look into it anyway :)