### PR TITLE
Fixes to flat texture selection

### DIFF
--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -744,7 +744,7 @@ ArchiveEntry* ResourceManager::getHiresEntry(const string& texture, Archive* pri
 // Returns the most appropriate managed texture for [texture], or nullptr if no
 // match found
 // ----------------------------------------------------------------------------
-CTexture* ResourceManager::getTexture(const string& texture, Archive* priority, Archive* ignore)
+CTexture* ResourceManager::getTexture(const string& texture, const string& type, Archive* priority, Archive* ignore)
 {
 	// Check texture resource with matching name exists
 	TextureResource& res = composites_[texture.Upper()];
@@ -756,6 +756,10 @@ CTexture* ResourceManager::getTexture(const string& texture, Archive* priority, 
 	Archive* parent = res.textures_[0].get()->parent;
 	for (auto& res_tex : res.textures_)
 	{
+		// Skip if it's not the desired type
+		if (type != "" && res_tex->tex.getType() != type)
+			continue;
+
 		// Skip if it's in the 'ignore' archive
 		if (res_tex->parent == ignore)
 			continue;

--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -752,7 +752,7 @@ CTexture* ResourceManager::getTexture(const string& texture, const string& type,
 		return nullptr;
 
 	// Go through resource textures
-	CTexture* tex = &res.textures_[0].get()->tex;
+	CTexture* tex = nullptr;
 	Archive* parent = res.textures_[0].get()->parent;
 	for (auto& res_tex : res.textures_)
 	{
@@ -779,11 +779,7 @@ CTexture* ResourceManager::getTexture(const string& texture, const string& type,
 
 	// Return the most relevant texture
 	if (parent != ignore)
-	{
-		if (type != "" && type != tex->getType())
-			return nullptr;
 		return tex;
-	}
 	else
 		return nullptr;
 }

--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -296,7 +296,7 @@ void ResourceManager::removeArchive(Archive* archive)
 	removeArchiveFromMap(satextures_fp_, archive);
 
 	// Remove any textures in the archive
-	for (auto& i : textures_)
+	for (auto& i : composites_)
 		i.second.remove(archive);
 
 	// Announce resource update
@@ -452,7 +452,7 @@ void ResourceManager::addEntry(ArchiveEntry::SPtr& entry, bool log)
 		for (unsigned a = 0; a < tx.nTextures(); a++)
 		{
 			tex = tx.getTexture(a);
-			textures_[tex->getName()].add(tex, entry->getParent());
+			composites_[tex->getName()].add(tex, entry->getParent());
 		}
 	}
 }
@@ -509,7 +509,7 @@ void ResourceManager::removeEntry(ArchiveEntry::SPtr& entry, bool log, bool full
 
 		// Remove all texture resources
 		for (unsigned a = 0; a < tx.nTextures(); a++)
-			textures_[tx.getTexture(a)->getName()].remove(entry->getParent());
+			composites_[tx.getTexture(a)->getName()].remove(entry->getParent());
 	}
 }
 
@@ -562,7 +562,7 @@ void ResourceManager::getAllPatchEntries(vector<ArchiveEntry*>& list, Archive* p
 void ResourceManager::getAllTextures(vector<TextureResource::Texture*>& list, Archive* priority, Archive* ignore)
 {
 	// Add all primary textures to the list
-	for (auto& i : textures_)
+	for (auto& i : composites_)
 	{
 		// Skip if no entries
 		if (i.second.length() == 0)
@@ -602,7 +602,7 @@ void ResourceManager::getAllTextures(vector<TextureResource::Texture*>& list, Ar
 void ResourceManager::getAllTextureNames(vector<string>& list)
 {
 	// Add all primary textures to the list
-	for (auto& i : textures_)
+	for (auto& i : composites_)
 		if (i.second.length() > 0)	// Ignore if no entries
 			list.push_back(i.first);
 }
@@ -734,7 +734,7 @@ ArchiveEntry* ResourceManager::getTextureEntry(const string& texture, const stri
 CTexture* ResourceManager::getTexture(const string& texture, Archive* priority, Archive* ignore)
 {
 	// Check texture resource with matching name exists
-	TextureResource& res = textures_[texture.Upper()];
+	TextureResource& res = composites_[texture.Upper()];
 	if (res.textures_.empty())
 		return nullptr;
 

--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -779,7 +779,11 @@ CTexture* ResourceManager::getTexture(const string& texture, const string& type,
 
 	// Return the most relevant texture
 	if (parent != ignore)
+	{
+		if (type != "" && type != tex->getType())
+			return nullptr;
 		return tex;
+	}
 	else
 		return nullptr;
 }

--- a/src/General/ResourceManager.cpp
+++ b/src/General/ResourceManager.cpp
@@ -31,6 +31,7 @@
 //
 // ----------------------------------------------------------------------------
 #include "Main.h"
+#include "Archive/ArchiveEntry.h"
 #include "ResourceManager.h"
 #include "Archive/ArchiveManager.h"
 #include "General/Console/Console.h"
@@ -408,7 +409,7 @@ void ResourceManager::addEntry(ArchiveEntry::SPtr& entry, bool log)
 		}
 
 		// Check for stand-alone texture entry
-		if (entry->isInNamespace("textures") || entry->isInNamespace("hires"))
+		if (entry->isInNamespace("textures"))
 		{
 			satextures_[name].add(entry);
 			if (!entry->getParent()->isTreeless())
@@ -418,7 +419,10 @@ void ResourceManager::addEntry(ArchiveEntry::SPtr& entry, bool log)
 
 			// Add name to hash table
 			ResourceManager::doom64_hash_table_[getTextureHash(name)] = name;
-
+		}
+		else if (entry->isInNamespace("hires"))
+		{ // Handle hi-res textures
+			hires_[name].add(entry);
 		}
 	}
 
@@ -722,6 +726,15 @@ ArchiveEntry* ResourceManager::getTextureEntry(const string& texture, const stri
 	if (entry)
 		return entry;
 
+	return nullptr;
+}
+
+ArchiveEntry* ResourceManager::getHiresEntry(const string& texture, Archive* priority)
+{
+	// Hi-res textures can only be used with a short name
+	ArchiveEntry* entry = hires_[texture.Upper()].getEntry(priority, "hires", true);
+	if (entry)
+		return entry;
 	return nullptr;
 }
 

--- a/src/General/ResourceManager.h
+++ b/src/General/ResourceManager.h
@@ -123,7 +123,7 @@ private:
 	EntryResourceMap	satextures_;	// Stand Alone textures (e.g., between TX_ or T_ markers)
 	EntryResourceMap	satextures_fp_;
 	//EntryResourceMap	satextures_fp_only_; // Probably not needed
-	TextureResourceMap	textures_;		// Composite textures (defined in a TEXTUREx/TEXTURES lump)
+	TextureResourceMap	composites_;		// Composite textures (defined in a TEXTUREx/TEXTURES lump)
 
 	static ResourceManager*	instance_;
 	static string			doom64_hash_table_[65536];

--- a/src/General/ResourceManager.h
+++ b/src/General/ResourceManager.h
@@ -106,7 +106,7 @@ public:
 	ArchiveEntry*	getFlatEntry(const string& flat, Archive* priority = nullptr);
 	ArchiveEntry*	getTextureEntry(const string& texture, const string& nspace = "textures", Archive* priority = nullptr);
 	ArchiveEntry*	getHiresEntry(const string& texture, Archive* priority = nullptr);
-	CTexture*		getTexture(const string& texture, Archive* priority = nullptr, Archive* ignore = nullptr);
+	CTexture*		getTexture(const string& texture, const string& type = "", Archive* priority = nullptr, Archive* ignore = nullptr);
 	uint16_t		getTextureHash(const string& name);
 
 	void	onAnnouncement(Announcer* announcer, string event_name, MemChunk& event_data) override;

--- a/src/General/ResourceManager.h
+++ b/src/General/ResourceManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Archive/ArchiveEntry.h"
 #include "common.h"
 #include "Archive/Archive.h"
 #include "General/ListenerAnnouncer.h"
@@ -104,6 +105,7 @@ public:
 	ArchiveEntry*	getPatchEntry(const string& patch, const string& nspace = "patches", Archive* priority = nullptr);
 	ArchiveEntry*	getFlatEntry(const string& flat, Archive* priority = nullptr);
 	ArchiveEntry*	getTextureEntry(const string& texture, const string& nspace = "textures", Archive* priority = nullptr);
+	ArchiveEntry*	getHiresEntry(const string& texture, Archive* priority = nullptr);
 	CTexture*		getTexture(const string& texture, Archive* priority = nullptr, Archive* ignore = nullptr);
 	uint16_t		getTextureHash(const string& name);
 
@@ -123,6 +125,7 @@ private:
 	EntryResourceMap	satextures_;	// Stand Alone textures (e.g., between TX_ or T_ markers)
 	EntryResourceMap	satextures_fp_;
 	//EntryResourceMap	satextures_fp_only_; // Probably not needed
+	EntryResourceMap	hires_;
 	TextureResourceMap	composites_;		// Composite textures (defined in a TEXTUREx/TEXTURES lump)
 
 	static ResourceManager*	instance_;

--- a/src/Graphics/CTexture/CTexture.cpp
+++ b/src/Graphics/CTexture/CTexture.cpp
@@ -1090,7 +1090,7 @@ bool CTexture::loadPatchImage(unsigned pindex, SImage& image, Archive* parent, P
 
 		// Otherwise, try the resource manager
 		// TODO: Something has to be ignored here. The entire archive or just the current list?
-		CTexture* tex = theResourceManager->getTexture(patch->getName(), parent);
+		CTexture* tex = theResourceManager->getTexture(patch->getName(), "", parent);
 		if (tex)
 			return tex->toImage(image, parent, pal);
 	}

--- a/src/MainEditor/UI/TextureXEditor/PatchBrowser.cpp
+++ b/src/MainEditor/UI/TextureXEditor/PatchBrowser.cpp
@@ -90,7 +90,7 @@ bool PatchBrowserItem::loadImage()
 	if (type_ == 1)
 	{
 		// Find texture
-		CTexture* tex = theResourceManager->getTexture(name_, archive_);
+		CTexture* tex = theResourceManager->getTexture(name_, "", archive_);
 
 		// Load texture to image, if it exists
 		if (tex)

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -251,15 +251,14 @@ GLTexture* MapTextureManager::getFlat(string name, bool mixed)
 		}
 	}
 
-	// Search textures folder
-	if (mixed && !mtex.texture)
+	// Prioritize standalone textures
+	if (mixed && theResourceManager->getTextureEntry(name, "textures", archive))
 	{
-		mtex.texture = getTexture(name, false);
+		return getTexture(name, false);
 	}
 
-	// Prioritize flats, and use the flat if there is a composite texture with
-	// the same name.
-	if (!mtex.texture || theResourceManager->getTexture(name, archive))
+	// Try to search for an actual flat
+	if (!mtex.texture)
 	{
 		ArchiveEntry* entry = theResourceManager->getFlatEntry(name, archive);
 		if (entry)
@@ -292,6 +291,12 @@ GLTexture* MapTextureManager::getFlat(string name, bool mixed)
 	// Not found
 	if (!mtex.texture)
 	{
+		// Try to search for a composite texture instead
+		if (mixed)
+		{
+			return getTexture(name, false);
+		}
+
 		mtex.texture = &(GLTexture::missingTex());
 	}
 

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -266,20 +266,23 @@ GLTexture* MapTextureManager::getFlat(string name, bool mixed)
 	}
 
 	// Try composite flat texture
-	CTexture* ctex = theResourceManager->getTexture(name, "Flat", archive);
-	if (ctex)
+	if (mixed)
 	{
-		SImage image;
-		if (ctex->toImage(image, archive, palette, true))
+		CTexture* ctex = theResourceManager->getTexture(name, "Flat", archive);
+		if (ctex)
 		{
-			mtex.texture = new GLTexture(false);
-			mtex.texture->setFilter(filter);
-			mtex.texture->loadImage(&image, palette);
-			double sx = ctex->getScaleX(); if (sx == 0) sx = 1.0;
-			double sy = ctex->getScaleY(); if (sy == 0) sy = 1.0;
-			mtex.texture->setWorldPanning(ctex->worldPanning());
-			mtex.texture->setScale(1.0/sx, 1.0/sy);
-			return mtex.texture;
+			SImage image;
+			if (ctex->toImage(image, archive, palette, true))
+			{
+				mtex.texture = new GLTexture(false);
+				mtex.texture->setFilter(filter);
+				mtex.texture->loadImage(&image, palette);
+				double sx = ctex->getScaleX(); if (sx == 0) sx = 1.0;
+				double sy = ctex->getScaleY(); if (sy == 0) sy = 1.0;
+				mtex.texture->setWorldPanning(ctex->worldPanning());
+				mtex.texture->setScale(1.0/sx, 1.0/sy);
+				return mtex.texture;
+			}
 		}
 	}
 

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -144,7 +144,7 @@ GLTexture* MapTextureManager::getTexture(string name, bool mixed)
 	//Palette8bit* pal = getResourcePalette();
 
 	// Look for stand-alone textures first
-	ArchiveEntry* etex = theResourceManager->getTextureEntry(name, "hires", archive);
+	ArchiveEntry* etex = theResourceManager->getHiresEntry(name, archive);
 	int textypefound = TEXTYPE_HIRES;
 	if (etex)
 	{
@@ -181,6 +181,14 @@ GLTexture* MapTextureManager::getTexture(string name, bool mixed)
 	{
 		etex = theResourceManager->getTextureEntry(name, "textures", archive);
 		textypefound = TEXTYPE_TEXTURE;
+		SImage image;
+		// Get image format hint from type, if any
+		if (Misc::loadImageFromEntry(&image, etex))
+		{
+			mtex.texture = new GLTexture(false);
+			mtex.texture->setFilter(filter);
+			mtex.texture->loadImage(&image, palette);
+		}
 	}
 
 	// Try composite textures then
@@ -271,9 +279,8 @@ GLTexture* MapTextureManager::getFlat(string name, bool mixed)
 				mtex.texture->loadImage(&image, palette);
 			}
 
-			/*
 			// Check for hi-res equivalent
-			ArchiveEntry* hires_entry = theResourceManager->getTextureEntry(name, "hires", archive);
+			ArchiveEntry* hires_entry = theResourceManager->getHiresEntry(name, archive);
 			if (hires_entry)
 			{
 				SImage hires_image;
@@ -281,10 +288,11 @@ GLTexture* MapTextureManager::getFlat(string name, bool mixed)
 				{
 					double scaleX = (double)image.getWidth() / (double)hires_image.getWidth();
 					double scaleY = (double)image.getHeight() / (double)hires_image.getHeight();
+					mtex.texture->setFilter(filter);
+					mtex.texture->loadImage(&hires_image, palette);
 					mtex.texture->setScale(scaleX, scaleY);
 				}
 			}
-			*/
 		}
 	}
 

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -193,6 +193,8 @@ GLTexture* MapTextureManager::getTexture(string name, bool mixed)
 
 	// Try composite textures then
 	CTexture* ctex = theResourceManager->getTexture(name, "", archive);
+	CTexture* wallctex = theResourceManager->getTexture(name, "WallTexture", archive);
+	if (wallctex) ctex = wallctex;
 	if (ctex) // Composite textures take precedence over the textures directory
 	{
 		textypefound = TEXTYPE_WALLTEXTURE;

--- a/src/MapEditor/MapTextureManager.cpp
+++ b/src/MapEditor/MapTextureManager.cpp
@@ -192,7 +192,7 @@ GLTexture* MapTextureManager::getTexture(string name, bool mixed)
 	}
 
 	// Try composite textures then
-	CTexture* ctex = theResourceManager->getTexture(name, archive);
+	CTexture* ctex = theResourceManager->getTexture(name, "", archive);
 	if (ctex) // Composite textures take precedence over the textures directory
 	{
 		textypefound = TEXTYPE_WALLTEXTURE;
@@ -263,6 +263,24 @@ GLTexture* MapTextureManager::getFlat(string name, bool mixed)
 	if (mixed && theResourceManager->getTextureEntry(name, "textures", archive))
 	{
 		return getTexture(name, false);
+	}
+
+	// Try composite flat texture
+	CTexture* ctex = theResourceManager->getTexture(name, "Flat", archive);
+	if (ctex)
+	{
+		SImage image;
+		if (ctex->toImage(image, archive, palette, true))
+		{
+			mtex.texture = new GLTexture(false);
+			mtex.texture->setFilter(filter);
+			mtex.texture->loadImage(&image, palette);
+			double sx = ctex->getScaleX(); if (sx == 0) sx = 1.0;
+			double sy = ctex->getScaleY(); if (sy == 0) sy = 1.0;
+			mtex.texture->setWorldPanning(ctex->worldPanning());
+			mtex.texture->setScale(1.0/sx, 1.0/sy);
+			return mtex.texture;
+		}
 	}
 
 	// Try to search for an actual flat
@@ -379,7 +397,7 @@ GLTexture* MapTextureManager::getSprite(string name, string translation, string 
 	}
 	else  	// Try composite textures then
 	{
-		CTexture* ctex = theResourceManager->getTexture(name, archive);
+		CTexture* ctex = theResourceManager->getTexture(name, "", archive);
 		if (ctex && ctex->toImage(image, archive, this->palette, true))
 			found = true;
 	}


### PR DESCRIPTION
This improves separation of flats from wall textures, and make flat texture selection work like in GZDoom (AFAIK anyway). This fixes a bug where flat textures weren't scaled if they used a high-res texture.