### PR TITLE
Add the ability to convert to PSX DOOM format textures

### DIFF
--- a/src/Graphics/SImage/SImage.cpp
+++ b/src/Graphics/SImage/SImage.cpp
@@ -211,7 +211,7 @@ bool SImage::putIndexedData(MemChunk& mc) const
 	{
 	case Type::RGBA: return false; // Cannot do this for trucolor graphics.
 	case Type::PalMask:
-	case Type::AlphaMap: return mc.importMem(data_);
+	case Type::AlphaMap: return mc.write(data_.data(), data_.size());
 	default: return false;
 	}
 }


### PR DESCRIPTION
This pull request adds the ability for SLADE to convert images to the PSX Doom graphic format. SLADE can already read this format very well; all that is required is to extend the capabilities to writing. Most of the code is also copied from similar code for other formats.

This change was motivated by the advent of new tools which enable mapping for PlayStation Doom, and the reverse engineered PC backport, PsyDoom.

Note that this change is primarily intended to help out mappers targeting 'PsyDoom'. For the native PSX engine you would also need to update the `TEXTURE1` lump if adding in new wall textures; PsyDoom plans to bypass use of that lump however to make modding easier. `TEXTURE1` just contains an array of `PSXPicHeader` (one for each wall texture in the game between `T_START` and `T_END`) and allows the engine to know the size of each wall texture before loading it.