### PR TITLE
Change "print" from "logMessage" to "LogMessage"

### DIFF
--- a/src/Scripting/Lua.cpp
+++ b/src/Scripting/Lua.cpp
@@ -179,7 +179,7 @@ bool lua::init()
             for i,v in ipairs({...}) do\
                line = line .. tostring(v) .. ' '\
             end\
-            App.logMessage(line)\
+            App.LogMessage(line)\
          end";
 	lua.script(new_print);
 


### PR DESCRIPTION
All of the functions have apparently been changed to start with capital letters, but `new_print` hasn't been updated to use the new capitalization. Since Lua is case-sensitive, that means issue #1134 has returned. This pull request fixes the issue.

When was this capitalization change made, however? If it's only in the beta for 3.2.0, and not any prior versions, then rather than merging this pull request, I think it would be better to just revert the capitalization change. Unless it serves some important purpose I'm unaware of, it seems like a needless change that breaks compatibility with old scripts for no apparent benefit. It is of course up to you; that's just my advice.