### PR TITLE
Fix endianness support on FreeBSD

### DIFF
--- a/src/External/zreaders/portable_endian.h
+++ b/src/External/zreaders/portable_endian.h
@@ -48,11 +48,11 @@
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
-#elif defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 
 #	include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__NetBSD__) || defined(__DragonFly__)
 
 #	include <sys/endian.h>
 


### PR DESCRIPTION
Just as on OpenBSD, `#include <sys/endian.h>` is enough without any extra macro (re)definition; in fact, doing that breaks the build.