### PR TITLE
Fixes for macOS + continuous integration workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,0 +1,56 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "macOS",
+            os: macos-10.15,
+            deps_cmdline: "brew install fluidsynth fmt freeimage ftgl glew lua mpg123 sfml wxwidgets"
+          }
+        - {
+            name: "Linux GCC",
+            os: ubuntu-20.04,
+            deps_cmdline: "sudo apt update && sudo apt install \
+                           libcurl4-openssl-dev libfluidsynth-dev libfmt-dev libfreeimage-dev \
+                           libftgl-dev libglew-dev libgtk-3-dev liblua5.3-dev libmpg123-dev libsfml-dev \
+                           libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev"
+          }
+        - {
+            name: "Linux Clang",
+            os: ubuntu-20.04,
+            extra_options: "-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++",
+            deps_cmdline: "sudo apt update && sudo apt install \
+                           libcurl4-openssl-dev libfluidsynth-dev libfmt-dev libfreeimage-dev \
+                           libftgl-dev libglew-dev libgtk-3-dev liblua5.3-dev libmpg123-dev libsfml-dev \
+                           libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev"
+          }
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        if [[ ! -z "${{ matrix.config.deps_cmdline }}" ]]; then
+          eval ${{ matrix.config.deps_cmdline }}
+        fi
+
+    - name: Configure
+      shell: bash
+      run: |
+        mkdir build
+        cmake -B build ${{ matrix.config.extra_options }} .
+
+    - name: Build
+      shell: bash
+      run: |
+        export MAKEFLAGS=--keep-going
+        cmake --build build --parallel 3

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,8 +209,11 @@ target_link_libraries(slade
 	${LUA_LIBRARIES}
 	${MPG123_LIBRARIES}
 	${fmt_LIBRARIES}
-	-lstdc++fs
 )
+
+if(LINUX)
+	target_link_libraries(slade -lstdc++fs)
+endif()
 
 if (WX_GTK3)
 	target_link_libraries(slade ${GTK3_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ set(SFML_FIND_COMPONENTS system audio window graphics network)
 ADD_DEFINITIONS(-DUSE_SFML_RENDERWINDOW)
 else (USE_SFML_RENDERWINDOW)
 set(SFML_FIND_COMPONENTS system audio window network)
+find_package(Freetype REQUIRED)
 find_package(FTGL REQUIRED)
 endif(USE_SFML_RENDERWINDOW)
 
@@ -113,6 +114,7 @@ find_package(MPG123 REQUIRED)
 include_directories(
 	${FREEIMAGE_INCLUDE_DIR}
 	${SFML_INCLUDE_DIR}
+	${FREETYPE_INCLUDE_DIRS}
 	${FTGL_INCLUDE_DIR}
 	${GLEW_INCLUDE_PATH}
 	${CURL_INCLUDE_DIR}
@@ -199,6 +201,7 @@ target_link_libraries(slade
 	${wxWidgets_LIBRARIES}
 	${FREEIMAGE_LIBRARIES}
 	${SFML_LIBRARY}
+	${FREETYPE_LIBRARIES}
 	${FTGL_LIBRARIES}
 	${OPENGL_LIBRARIES}
 	${GLEW_LIBRARY}

--- a/src/Scripting/Export/General.cpp
+++ b/src/Scripting/Export/General.cpp
@@ -86,7 +86,7 @@ template<typename T> sol::object memChunkRead(MemChunk& self, unsigned offset)
 	// just to return 0 if the read fails, rather than nil
 	T val;
 	if (!self.read(offset, &val, sizeof(T)))
-		return sol::make_object(lua::state().lua_state(), sol::nil);
+		return sol::make_object(lua::state().lua_state(), sol::lua_nil);
 	return sol::make_object(lua::state().lua_state(), val);
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -143,6 +143,7 @@
 #include <cmath>
 #include <memory>
 #include <optional>
+#include <unordered_map>
 
 // C
 #include <locale.h>

--- a/src/common.h
+++ b/src/common.h
@@ -123,6 +123,11 @@
 #define FREEIMAGE_LIB
 #include <FreeImage.h>
 
+// Undefine _WINDOWS_ that has been defined by FreeImage
+#ifndef _WIN32
+#undef _WINDOWS_
+#endif
+
 // fmt
 #include <fmt/core.h>
 


### PR DESCRIPTION
This supersedes #1271 but without useless changes.

[Here](https://github.com/alexey-lysiuk/SLADE/actions/runs/1109826553) is this build in my fork. Windows targets are more complicated as they need dependency packages for Win32 and x64, or `vcpkg` with a cache for built libraries.