### PR TITLE
ArchivePanel: deleted windows should be replaced in the splitter

### DIFF
--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -1298,10 +1298,9 @@ bool ArchivePanel::deleteEntry(bool confirm)
 	undo_manager_->endRecord(true);
 
 	// Switch to blank entry panel
-	auto sizer = GetSizer();
 	cur_area_->Show(false);
 	cur_area_->nullEntry();
-	sizer->Replace(cur_area_, entry_area_);
+	splitter_->ReplaceWindow(cur_area_, entry_area_);
 	cur_area_ = entry_area_;
 	cur_area_->Show(true);
 	Layout();


### PR DESCRIPTION
The sizer contains the splitter, which contains the two panes.  When an
archive entry is deleted, the splitter's the one that we need to be
replacing it in.

This fixes an assertion when an archive entry is deleted, then another one
is selected. This regression seems to be from eb6eeb5db6fa, when the
splitter was introduced.