### PR TITLE
Fix loading of Jaguar textures

### DIFF
--- a/src/Graphics/SImage/SImageFormats.cpp
+++ b/src/Graphics/SImage/SImageFormats.cpp
@@ -951,7 +951,7 @@ bool SImage::loadJaguarTexture(const uint8_t* gfx_data, int size, int i_width, i
 	// reset data
 	clearData();
 	data_.reSize(width_ * height_);
-	data_.fillData(*gfx_data);
+	memcpy(data_.data(), gfx_data, width_ * height_);
 	mask_.reSize(width_ * height_);
 	mask_.fillData(0xFF);
 


### PR DESCRIPTION
They are now actually displayed properly instead of being solid-filled with a single color.

Before:
![image](https://user-images.githubusercontent.com/1173058/146176535-bff3ef57-010e-4d19-9e3e-9d9b869c8a8d.png)

After:
![image](https://user-images.githubusercontent.com/1173058/146171870-c85a7a7c-cb19-496e-b086-e7320b42a6d5.png)
