### PR TITLE
ZDoom Texture Cleanup Operations

### DIFF
--- a/dist/res/actions/arch.cfg
+++ b/dist/res/actions/arch.cfg
@@ -61,6 +61,12 @@ action arch_clean_flats
 	help_text	= "Remove any unused flats";
 }
 
+action arch_clean_zdoom_textures
+{
+	text		= "Remove Unused &Zdoom Textures";
+	help_text	= "Remove any unused textures, flats, and patches in a zdoom archive.";
+}
+
 action arch_check_duplicates
 {
 	text		= "Check Duplicate Entry Names";

--- a/dist/res/actions/arch.cfg
+++ b/dist/res/actions/arch.cfg
@@ -237,10 +237,16 @@ action arch_texturex_finderrors
 	help_text	= "Log to the console any error detected in the TEXTUREx entries";
 }
 
-action arch_zdtextures_clean
+action arch_texture_clean_iwaddupes
 {
-	text		= "Clean ZDoom Textures";
-	help_text	= "Utilities to clean ZDoom TEXTURES entries";
+	text		= "Remove Texture Entries Duplicated from IWAD";
+	help_text	= "Remove Texture entries that are exact duplicates of entries from the base resource archive";
+}
+
+action arch_zdtextures_clean_singlepatch
+{
+	text		= "Clean ZDoom Single Patch Textures";
+	help_text	= "Removes ZDoom TEXTURES entries that are just a single patch";
 }
 
 action arch_view_text

--- a/dist/res/actions/arch.cfg
+++ b/dist/res/actions/arch.cfg
@@ -237,6 +237,12 @@ action arch_texturex_finderrors
 	help_text	= "Log to the console any error detected in the TEXTUREx entries";
 }
 
+action arch_zdtextures_clean
+{
+	text		= "Clean ZDoom Textures";
+	help_text	= "Utilities to clean ZDoom TEXTURES entries";
+}
+
 action arch_view_text
 {
 	text		= "View as Text";

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ if (UNIX OR MINGW)
     else()
         set(WX_TOOL ${wxWidgets_CONFIG_EXECUTABLE})
     endif()
+    set(WX_TOOL /usr/local/bin/wx-config)
     if (NOT WX_TOOL)
         message(FATAL_ERROR
 "\nNo functional wx_config script was found in your PATH.\nIs the wxWidgets development package installed?\nIf you built wxWidgets yourself, you can specify the path to your built wx-config executable via WITH_WXPATH\neg. -DWITH_WXPATH=\"/path/to/wx-config/\""

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,6 @@ if (UNIX OR MINGW)
     else()
         set(WX_TOOL ${wxWidgets_CONFIG_EXECUTABLE})
     endif()
-    set(WX_TOOL /usr/local/bin/wx-config)
     if (NOT WX_TOOL)
         message(FATAL_ERROR
 "\nNo functional wx_config script was found in your PATH.\nIs the wxWidgets development package installed?\nIf you built wxWidgets yourself, you can specify the path to your built wx-config executable via WITH_WXPATH\neg. -DWITH_WXPATH=\"/path/to/wx-config/\""

--- a/src/Graphics/CTexture/TextureXList.cpp
+++ b/src/Graphics/CTexture/TextureXList.cpp
@@ -885,70 +885,70 @@ bool TextureXList::findErrors()
 // -----------------------------------------------------------------------------
 bool TextureXList::removeDupesFoundIn(TextureXList& texture_list)
 {
-    vector<unsigned int> indicesToRemove;
-    
-    for (unsigned a = 0; a < textures_.size(); a++)
-    {
-        CTexture* thisTexture = textures_[a].get();
-        int otherTextureIndex = texture_list.textureIndex(thisTexture->name());
-        
-        if (otherTextureIndex < 0)
-        {
-            // Other texture with this name not found
-            log::info(wxString::Format("KEEP Texture: %s. It's NOT in the other list.", thisTexture->name()));
-            continue;
-        }
-        
-        CTexture* otherTexture = texture_list.texture(otherTextureIndex);
-        
-        // Compare the textures by simply checking if their asText values are identical
-        // It may be slightly less fast to do it this way but it should be fairly future proof if more
-        // things get added and it deals with textures being extended in one list and not extended in
-        // the other list
-        
-        // Copy the textures over to a copy that is extended so asText works and we don't need to worry
-        // about messing with original copies
-        CTexture thisTextureCopy(true);
-        CTexture otherTextureCopy(true);
-        
-        thisTextureCopy.copyTexture(*thisTexture, true);
-        otherTextureCopy.copyTexture(*otherTexture, true);
-        
-        // Force a null texture because that value doesn't transfer from TEXTUREX defs
-        if (a == 0 && otherTextureIndex == 0
-            && (thisTexture->name() == "AASHITTY"
-            || thisTexture->name() == "AASTINKY"
-            || thisTexture->name() == "BADPATCH"
-            || thisTexture->name() == "ABADONE"))
-        {
-            thisTextureCopy.setNullTexture(true);
-            otherTextureCopy.setNullTexture(true);
-        }
-        
-        string thisTextureText = thisTextureCopy.asText();
-        string otherTextureText = otherTextureCopy.asText();
-        
-        if (thisTextureText == otherTextureText)
-        {
-            log::info(wxString::Format("DELETE Texture: %s. It's FOUND in the other list and IS identical.", thisTexture->name()));
-            indicesToRemove.push_back(a);
-        }
-        else
-        {
-            log::info(wxString::Format("KEEP Texture: %s. It's FOUND in the other list but IS NOT identical.", thisTexture->name()));
-        }
-        
-        log::info(thisTextureCopy.asText());
-        log::info(otherTextureCopy.asText());
-    }
-    
-    // Remove textures while going through the list back to front
-    for (int a = indicesToRemove.size() - 1; a >= 0; a--)
-    {
-        removeTexture(indicesToRemove[a]);
-    }
-    
-    return indicesToRemove.size();
+	vector<unsigned int> indicesToRemove;
+	
+	for (unsigned a = 0; a < textures_.size(); a++)
+	{
+		CTexture* thisTexture = textures_[a].get();
+		int otherTextureIndex = texture_list.textureIndex(thisTexture->name());
+		
+		if (otherTextureIndex < 0)
+		{
+			// Other texture with this name not found
+			log::info(wxString::Format("KEEP Texture: %s. It's NOT in the other list.", thisTexture->name()));
+			continue;
+		}
+		
+		CTexture* otherTexture = texture_list.texture(otherTextureIndex);
+		
+		// Compare the textures by simply checking if their asText values are identical
+		// It may be slightly less fast to do it this way but it should be fairly future proof if more
+		// things get added and it deals with textures being extended in one list and not extended in
+		// the other list
+		
+		// Copy the textures over to a copy that is extended so asText works and we don't need to worry
+		// about messing with original copies
+		CTexture thisTextureCopy(true);
+		CTexture otherTextureCopy(true);
+		
+		thisTextureCopy.copyTexture(*thisTexture, true);
+		otherTextureCopy.copyTexture(*otherTexture, true);
+		
+		// Force a null texture because that value doesn't transfer from TEXTUREX defs
+		if (a == 0 && otherTextureIndex == 0
+			&& (thisTexture->name() == "AASHITTY"
+			|| thisTexture->name() == "AASTINKY"
+			|| thisTexture->name() == "BADPATCH"
+			|| thisTexture->name() == "ABADONE"))
+		{
+			thisTextureCopy.setNullTexture(true);
+			otherTextureCopy.setNullTexture(true);
+		}
+		
+		string thisTextureText = thisTextureCopy.asText();
+		string otherTextureText = otherTextureCopy.asText();
+		
+		if (thisTextureText == otherTextureText)
+		{
+			log::info(wxString::Format("DELETE Texture: %s. It's FOUND in the other list and IS identical.", thisTexture->name()));
+			indicesToRemove.push_back(a);
+		}
+		else
+		{
+			log::info(wxString::Format("KEEP Texture: %s. It's FOUND in the other list but IS NOT identical.", thisTexture->name()));
+		}
+		
+		log::info(thisTextureCopy.asText());
+		log::info(otherTextureCopy.asText());
+	}
+	
+	// Remove textures while going through the list back to front
+	for (int a = indicesToRemove.size() - 1; a >= 0; a--)
+	{
+		removeTexture(indicesToRemove[a]);
+	}
+	
+	return indicesToRemove.size();
 }
 
 // -----------------------------------------------------------------------------
@@ -958,258 +958,258 @@ bool TextureXList::removeDupesFoundIn(TextureXList& texture_list)
 // -----------------------------------------------------------------------------
 bool TextureXList::cleanTEXTURESsinglePatch(Archive* currentArchive)
 {
-    // Check format is appropriate
-    if (txformat_ != Format::Textures)
-    {
-        global::error = "Not TEXTURES format";
-        return false;
-    }
-    
-    if (!currentArchive->formatDesc().supports_dirs)
-    {
-        global::error = "Archive doesn't support directories";
-        return false;
-    }
-    
-    std::map<ArchiveEntry*, unsigned int> patchEntryToSinglePatchTextures;
-    std::set<ArchiveEntry*> patchEntriesToOmit;
-    
-    for (unsigned a = 0; a < textures_.size(); a++)
-    {
-        CTexture* texture = textures_[a].get();
-        
-        if (!texture->isExtended())
-        {
-            log::info(wxString::Format("KEEP Texture: %s. It's not extended.", texture->name()));
-            continue;
-        }
-        
-        // Check the number of patches
-        if (texture->nPatches() != 1)
-        {
-            log::info(wxString::Format("KEEP Texture: %s. It has non-one number of patches.", texture->name()));
-            continue;
-        }
-        
-        // Check for any properties
-        if (texture->scaleX() != 1.0
-            || texture->scaleY() != 1.0
-            || texture->offsetX() != 0
-            || texture->offsetY() != 0
-            || texture->worldPanning()
-            || texture->isOptional()
-            || texture->noDecals()
-            || texture->nullTexture())
-        {
-            log::info(wxString::Format("KEEP Texture: %s. It has some special properties set.", texture->name()));
-            continue;
-        }
-        
-        // Check things about the single patch
-        CTPatchEx* patch = dynamic_cast<CTPatchEx*>(texture->patch(0));
-        
-        // Check if the single patch is actually a patch in another archive
-        ArchiveEntry* patchEntry = patch->patchEntry(nullptr);
-        
-        if (!patchEntry)
-        {
-            log::info(wxString::Format("KEEP Texture: %s. Its single patch %s failed to load.", texture->name(), patch->name()));
-            continue;
-        }
-        
-        if (patchEntry->parent() != currentArchive)
-        {
-            log::info(wxString::Format("KEEP Texture: %s. Its single patch is from a different archive.", texture->name()));
-            continue;
-        }
-        
-        // Check if the patch is in the patches directory
-        {
-            ArchiveDir* patchParentDir = patchEntry->parentDir();
-            
-            if (patchParentDir)
-            {
-                while(patchParentDir->parent()->parent())
-                {
-                    patchParentDir = patchParentDir->parent().get();
-                }
-                
-                if (patchParentDir->dirEntry()->upperName() != "PATCHES")
-                {
-                    log::info(wxString::Format("KEEP Texture: %s. Its single patch is not from the patches directory. Found in: \"%s\".", texture->name(), patchParentDir->dirEntry()->name()));
-                    continue;
-                }
-            }
-        }
-        
-        // Check if this patch entry is used in another texture
-        auto otherTextureIter = patchEntryToSinglePatchTextures.find(patchEntry);
-        if (otherTextureIter != patchEntryToSinglePatchTextures.end())
-        {
-            log::info(wxString::Format("KEEP Textures: %s and %s. They are both using the same single patch %s.", texture->name(), textures_[otherTextureIter->second]->name(), patch->name()));
-            patchEntriesToOmit.insert(patchEntry);
-            continue;
-        }
-        
-        // Check if the single patch is at 0,0 with no other special placement, and matches the texture size
-        if (patch->xOffset() != 0
-            || patch->yOffset() != 0)
-        {
-            log::info(wxString::Format("KEEP Texture: %s. Its single patch has non-zero offsets.", texture->name()));
-            continue;
-        }
-        
-        SImage img;
-        img.open(patchEntry->data());
-        
-        // Check if the single patch size matches the texture size
-        if (img.width() != texture->width()
-            || img.height() != texture->height())
-        {
-            log::info(wxString::Format("KEEP Texture: %s. Its single patch has different dimensions from the texture.", texture->name()));
-            continue;
-        }
-        
-        // Check for any properties
-        if (patch->flipX()
-            || patch->flipY()
-            || patch->useOffsets()
-            || patch->rotation() != 0
-            || patch->alpha() < 1.0f
-            || !(strutil::equalCI(patch->style(), "Copy"))
-            || patch->blendType() != CTPatchEx::BlendType::None)
-        {
-            log::info(wxString::Format("KEEP Texture: %s. Its single patch has some special properties set.", texture->name()));
-            continue;
-        }
-        
-        log::info(wxString::Format("MAYBE DELETE Texture: %s. It's a basic single patch texture.", texture->name()));
-        patchEntryToSinglePatchTextures[patchEntry] = a;
-    }
-    
-    // Remove all patchEntriesToOmit
-    for (ArchiveEntry* patchEntryToOmit : patchEntriesToOmit)
-    {
-        patchEntryToSinglePatchTextures.erase(patchEntryToSinglePatchTextures.find(patchEntryToOmit));
-    }
-    
-    patchEntriesToOmit.clear();
-    
-    // Now that it found all the single patch textures, make sure those patches aren't used in any other texture
-    if (!patchEntryToSinglePatchTextures.size())
-    {
-        return false;
-    }
-    
-    // Now load base resource archive textures into a single list
-    TextureXList archiveTxList;
-    
-    Archive::SearchOptions opt;
-    opt.match_type = EntryType::fromId("pnames");
-    auto pnames = currentArchive->findLast(opt);
-    
-    // Load patch table
-    PatchTable ptable;
-    if (pnames)
-    {
-        ptable.loadPNAMES(pnames);
-    
-        // Load all Texturex entries
-        Archive::SearchOptions texturexopt;
-        texturexopt.match_type = EntryType::fromId("texturex");
-        
-        for (ArchiveEntry* texturexentry: currentArchive->findAll(texturexopt))
-        {
-            archiveTxList.readTEXTUREXData(texturexentry, ptable, true);
-        }
-    }
-    
-    // Load all zdtextures entries
-    Archive::SearchOptions zdtexturesopt;
-    zdtexturesopt.match_type = EntryType::fromId("zdtextures");
-    
-    for (ArchiveEntry* texturesentry: currentArchive->findAll(zdtexturesopt))
-    {
-        archiveTxList.readTEXTURESData(texturesentry);
-    }
-    
-    // See if any other textures use any of the patch entries
-    for (int a = 0; a < archiveTxList.textures_.size(); a++)
-    {
-        CTexture* texture = archiveTxList.textures_[a].get();
-        
-        for (int p = 0; p < texture->nPatches(); p++)
-        {
-            ArchiveEntry* patchEntry = texture->patches()[p]->patchEntry(nullptr);
-            
-            auto iter = patchEntryToSinglePatchTextures.find(patchEntry);
-            
-            // If we found a texture that isn't the texture the patch is associated to
-            if (iter != patchEntryToSinglePatchTextures.end()
-                && textures_[iter->second]->name() != texture->name())
-            {
-                log::info(wxString::Format("KEEP Textures: %s and %s. They are both using patch %s.", texture->name(), textures_[iter->second]->name(), texture->patches()[p]->name()));
-                patchEntriesToOmit.insert(patchEntry);
-                continue;
-            }
-        }
-    }
-    
-    // Remove all patchEntriesToOmit
-    for (ArchiveEntry* patchEntryToOmit : patchEntriesToOmit)
-    {
-        patchEntryToSinglePatchTextures.erase(patchEntryToSinglePatchTextures.find(patchEntryToOmit));
-    }
-    
-    patchEntriesToOmit.clear();
-    
-    if (!patchEntryToSinglePatchTextures.size())
-    {
-        return false;
-    }
-    
-    // Now remove the texture entries and convert the patches to textures themselves
-    
-    // Build a list of texture indices to remove so we remove it in back to front order
-    vector<unsigned int> indicesToRemove;
-    std::map<unsigned int, wxString> removalMessages;
-    
-    for (auto iter : patchEntryToSinglePatchTextures)
-    {
-        ArchiveEntry* patchEntry = iter.first;
-        CTexture* texture = textures_[iter.second].get();
-        
-        indicesToRemove.push_back(iter.second);
-        
-        // Currently only supporting converting patch to texture in archives that support directories so just move things from patches to textures
-        string::size_type patchExtensionPos = patchEntry->name().find_last_of('.');
-        string patchExtension = patchExtensionPos != string::npos
-            ? patchEntry->name().substr(patchExtensionPos, patchEntry->name().size())
-            : "";
-        
-        string textureFileName = texture->name();
-        textureFileName.append(patchExtension);
-        
-        removalMessages[iter.second] = wxString::Format("DELETE Texture: %s. Convert Patch: %s to Texture File: %s.", texture->name(), patchEntry->name(), textureFileName);
-        
-        auto texturesDir = currentArchive->createDir("textures");
-        patchEntry->rename(textureFileName);
-        currentArchive->moveEntry(patchEntry, 0, texturesDir.get());
-    }
-    
-    std::sort(indicesToRemove.begin(), indicesToRemove.end());
-    
-    // Print the removal messages in original alphabetical texture order so it's easier to parse the output log
-    for (int a = 0; a < indicesToRemove.size(); a++)
-    {
-        log::info(removalMessages[indicesToRemove[a]]);
-    }
-    
-    // Remove textures while going through the list back to front
-    for (int a = indicesToRemove.size() - 1; a >= 0; a--)
-    {
-        removeTexture(indicesToRemove[a]);
-    }
-    
-    return true;
+	// Check format is appropriate
+	if (txformat_ != Format::Textures)
+	{
+		global::error = "Not TEXTURES format";
+		return false;
+	}
+	
+	if (!currentArchive->formatDesc().supports_dirs)
+	{
+		global::error = "Archive doesn't support directories";
+		return false;
+	}
+	
+	std::map<ArchiveEntry*, unsigned int> patchEntryToSinglePatchTextures;
+	std::set<ArchiveEntry*> patchEntriesToOmit;
+	
+	for (unsigned a = 0; a < textures_.size(); a++)
+	{
+		CTexture* texture = textures_[a].get();
+		
+		if (!texture->isExtended())
+		{
+			log::info(wxString::Format("KEEP Texture: %s. It's not extended.", texture->name()));
+			continue;
+		}
+		
+		// Check the number of patches
+		if (texture->nPatches() != 1)
+		{
+			log::info(wxString::Format("KEEP Texture: %s. It has non-one number of patches.", texture->name()));
+			continue;
+		}
+		
+		// Check for any properties
+		if (texture->scaleX() != 1.0
+			|| texture->scaleY() != 1.0
+			|| texture->offsetX() != 0
+			|| texture->offsetY() != 0
+			|| texture->worldPanning()
+			|| texture->isOptional()
+			|| texture->noDecals()
+			|| texture->nullTexture())
+		{
+			log::info(wxString::Format("KEEP Texture: %s. It has some special properties set.", texture->name()));
+			continue;
+		}
+		
+		// Check things about the single patch
+		CTPatchEx* patch = dynamic_cast<CTPatchEx*>(texture->patch(0));
+		
+		// Check if the single patch is actually a patch in another archive
+		ArchiveEntry* patchEntry = patch->patchEntry(nullptr);
+		
+		if (!patchEntry)
+		{
+			log::info(wxString::Format("KEEP Texture: %s. Its single patch %s failed to load.", texture->name(), patch->name()));
+			continue;
+		}
+		
+		if (patchEntry->parent() != currentArchive)
+		{
+			log::info(wxString::Format("KEEP Texture: %s. Its single patch is from a different archive.", texture->name()));
+			continue;
+		}
+		
+		// Check if the patch is in the patches directory
+		{
+			ArchiveDir* patchParentDir = patchEntry->parentDir();
+			
+			if (patchParentDir)
+			{
+				while(patchParentDir->parent()->parent())
+				{
+					patchParentDir = patchParentDir->parent().get();
+				}
+				
+				if (patchParentDir->dirEntry()->upperName() != "PATCHES")
+				{
+					log::info(wxString::Format("KEEP Texture: %s. Its single patch is not from the patches directory. Found in: \"%s\".", texture->name(), patchParentDir->dirEntry()->name()));
+					continue;
+				}
+			}
+		}
+		
+		// Check if this patch entry is used in another texture
+		auto otherTextureIter = patchEntryToSinglePatchTextures.find(patchEntry);
+		if (otherTextureIter != patchEntryToSinglePatchTextures.end())
+		{
+			log::info(wxString::Format("KEEP Textures: %s and %s. They are both using the same single patch %s.", texture->name(), textures_[otherTextureIter->second]->name(), patch->name()));
+			patchEntriesToOmit.insert(patchEntry);
+			continue;
+		}
+		
+		// Check if the single patch is at 0,0 with no other special placement, and matches the texture size
+		if (patch->xOffset() != 0
+			|| patch->yOffset() != 0)
+		{
+			log::info(wxString::Format("KEEP Texture: %s. Its single patch has non-zero offsets.", texture->name()));
+			continue;
+		}
+		
+		SImage img;
+		img.open(patchEntry->data());
+		
+		// Check if the single patch size matches the texture size
+		if (img.width() != texture->width()
+			|| img.height() != texture->height())
+		{
+			log::info(wxString::Format("KEEP Texture: %s. Its single patch has different dimensions from the texture.", texture->name()));
+			continue;
+		}
+		
+		// Check for any properties
+		if (patch->flipX()
+			|| patch->flipY()
+			|| patch->useOffsets()
+			|| patch->rotation() != 0
+			|| patch->alpha() < 1.0f
+			|| !(strutil::equalCI(patch->style(), "Copy"))
+			|| patch->blendType() != CTPatchEx::BlendType::None)
+		{
+			log::info(wxString::Format("KEEP Texture: %s. Its single patch has some special properties set.", texture->name()));
+			continue;
+		}
+		
+		log::info(wxString::Format("MAYBE DELETE Texture: %s. It's a basic single patch texture.", texture->name()));
+		patchEntryToSinglePatchTextures[patchEntry] = a;
+	}
+	
+	// Remove all patchEntriesToOmit
+	for (ArchiveEntry* patchEntryToOmit : patchEntriesToOmit)
+	{
+		patchEntryToSinglePatchTextures.erase(patchEntryToSinglePatchTextures.find(patchEntryToOmit));
+	}
+	
+	patchEntriesToOmit.clear();
+	
+	// Now that it found all the single patch textures, make sure those patches aren't used in any other texture
+	if (!patchEntryToSinglePatchTextures.size())
+	{
+		return false;
+	}
+	
+	// Now load base resource archive textures into a single list
+	TextureXList archiveTxList;
+	
+	Archive::SearchOptions opt;
+	opt.match_type = EntryType::fromId("pnames");
+	auto pnames = currentArchive->findLast(opt);
+	
+	// Load patch table
+	PatchTable ptable;
+	if (pnames)
+	{
+		ptable.loadPNAMES(pnames);
+	
+		// Load all Texturex entries
+		Archive::SearchOptions texturexopt;
+		texturexopt.match_type = EntryType::fromId("texturex");
+		
+		for (ArchiveEntry* texturexentry: currentArchive->findAll(texturexopt))
+		{
+			archiveTxList.readTEXTUREXData(texturexentry, ptable, true);
+		}
+	}
+	
+	// Load all zdtextures entries
+	Archive::SearchOptions zdtexturesopt;
+	zdtexturesopt.match_type = EntryType::fromId("zdtextures");
+	
+	for (ArchiveEntry* texturesentry: currentArchive->findAll(zdtexturesopt))
+	{
+		archiveTxList.readTEXTURESData(texturesentry);
+	}
+	
+	// See if any other textures use any of the patch entries
+	for (int a = 0; a < archiveTxList.textures_.size(); a++)
+	{
+		CTexture* texture = archiveTxList.textures_[a].get();
+		
+		for (int p = 0; p < texture->nPatches(); p++)
+		{
+			ArchiveEntry* patchEntry = texture->patches()[p]->patchEntry(nullptr);
+			
+			auto iter = patchEntryToSinglePatchTextures.find(patchEntry);
+			
+			// If we found a texture that isn't the texture the patch is associated to
+			if (iter != patchEntryToSinglePatchTextures.end()
+				&& textures_[iter->second]->name() != texture->name())
+			{
+				log::info(wxString::Format("KEEP Textures: %s and %s. They are both using patch %s.", texture->name(), textures_[iter->second]->name(), texture->patches()[p]->name()));
+				patchEntriesToOmit.insert(patchEntry);
+				continue;
+			}
+		}
+	}
+	
+	// Remove all patchEntriesToOmit
+	for (ArchiveEntry* patchEntryToOmit : patchEntriesToOmit)
+	{
+		patchEntryToSinglePatchTextures.erase(patchEntryToSinglePatchTextures.find(patchEntryToOmit));
+	}
+	
+	patchEntriesToOmit.clear();
+	
+	if (!patchEntryToSinglePatchTextures.size())
+	{
+		return false;
+	}
+	
+	// Now remove the texture entries and convert the patches to textures themselves
+	
+	// Build a list of texture indices to remove so we remove it in back to front order
+	vector<unsigned int> indicesToRemove;
+	std::map<unsigned int, wxString> removalMessages;
+	
+	for (auto iter : patchEntryToSinglePatchTextures)
+	{
+		ArchiveEntry* patchEntry = iter.first;
+		CTexture* texture = textures_[iter.second].get();
+		
+		indicesToRemove.push_back(iter.second);
+		
+		// Currently only supporting converting patch to texture in archives that support directories so just move things from patches to textures
+		string::size_type patchExtensionPos = patchEntry->name().find_last_of('.');
+		string patchExtension = patchExtensionPos != string::npos
+			? patchEntry->name().substr(patchExtensionPos, patchEntry->name().size())
+			: "";
+		
+		string textureFileName = texture->name();
+		textureFileName.append(patchExtension);
+		
+		removalMessages[iter.second] = wxString::Format("DELETE Texture: %s. Convert Patch: %s to Texture File: %s.", texture->name(), patchEntry->name(), textureFileName);
+		
+		auto texturesDir = currentArchive->createDir("textures");
+		patchEntry->rename(textureFileName);
+		currentArchive->moveEntry(patchEntry, 0, texturesDir.get());
+	}
+	
+	std::sort(indicesToRemove.begin(), indicesToRemove.end());
+	
+	// Print the removal messages in original alphabetical texture order so it's easier to parse the output log
+	for (int a = 0; a < indicesToRemove.size(); a++)
+	{
+		log::info(removalMessages[indicesToRemove[a]]);
+	}
+	
+	// Remove textures while going through the list back to front
+	for (int a = indicesToRemove.size() - 1; a >= 0; a--)
+	{
+		removeTexture(indicesToRemove[a]);
+	}
+	
+	return true;
 }

--- a/src/Graphics/CTexture/TextureXList.cpp
+++ b/src/Graphics/CTexture/TextureXList.cpp
@@ -1159,7 +1159,7 @@ bool TextureXList::cleanTEXTURESsinglePatch(Archive* currentArchive)
         // Currently only supporting converting patch to texture in archives that support directories
         if(!currentArchive->formatDesc().supports_dirs)
         {
-            removalMessages[iter.second] = wxString::Format("DELETE Texture: %s. Would Patch: %s to Texture File: %s but can't since archive doesn't support directories.", texture->name(), patchEntry->name(), texture->name());
+            removalMessages[iter.second] = wxString::Format("DELETE Texture: %s. Would convert Patch: %s to Texture File: %s but can't since archive doesn't support directories.", texture->name(), patchEntry->name(), texture->name());
         }
         else
         {

--- a/src/Graphics/CTexture/TextureXList.cpp
+++ b/src/Graphics/CTexture/TextureXList.cpp
@@ -895,6 +895,7 @@ bool TextureXList::removeDupesFoundIn(TextureXList& texture_list)
         if (otherTextureIndex < 0)
         {
             // Other texture with this name not found
+            log::info(wxString::Format("KEEP Texture: %s. It's NOT in the other list.", thisTexture->name()));
             continue;
         }
         
@@ -902,10 +903,15 @@ bool TextureXList::removeDupesFoundIn(TextureXList& texture_list)
         
         // Compare the textures by simply checking if their asText values are identical
         // It may be slightly less fast to do it this way but it's very future proof and
-        // deals with textures being extended format in one list and not extended format in the other list
+        // deals with textures being extended in one list and not extended format in the other list
         if (thisTexture->asText() == otherTexture->asText())
         {
+            log::info(wxString::Format("DELETE Texture: %s. It's FOUND in the other list and IS identical.", thisTexture->name()));
             indicesToRemove.push_back(a);
+        }
+        else
+        {
+            log::info(wxString::Format("KEEP Texture: %s. It's FOUND in the other list but IS NOT identical.", thisTexture->name()));
         }
     }
     

--- a/src/Graphics/CTexture/TextureXList.cpp
+++ b/src/Graphics/CTexture/TextureXList.cpp
@@ -902,9 +902,33 @@ bool TextureXList::removeDupesFoundIn(TextureXList& texture_list)
         CTexture* otherTexture = texture_list.texture(otherTextureIndex);
         
         // Compare the textures by simply checking if their asText values are identical
-        // It may be slightly less fast to do it this way but it's very future proof and
-        // deals with textures being extended in one list and not extended format in the other list
-        if (thisTexture->asText() == otherTexture->asText())
+        // It may be slightly less fast to do it this way but it should be fairly future proof if more
+        // things get added and it deals with textures being extended in one list and not extended in
+        // the other list
+        
+        // Copy the textures over to a copy that is extended so asText works and we don't need to worry
+        // about messing with original copies
+        CTexture thisTextureCopy(true);
+        CTexture otherTextureCopy(true);
+        
+        thisTextureCopy.copyTexture(*thisTexture, true);
+        otherTextureCopy.copyTexture(*otherTexture, true);
+        
+        // Force a null texture because that value doesn't transfer from TEXTUREX defs
+        if (a == 0 && otherTextureIndex == 0
+            && (thisTexture->name() == "AASHITTY"
+            || thisTexture->name() == "AASTINKY"
+            || thisTexture->name() == "BADPATCH"
+            || thisTexture->name() == "ABADONE"))
+        {
+            thisTextureCopy.setNullTexture(true);
+            otherTextureCopy.setNullTexture(true);
+        }
+        
+        string thisTextureText = thisTextureCopy.asText();
+        string otherTextureText = otherTextureCopy.asText();
+        
+        if (thisTextureText == otherTextureText)
         {
             log::info(wxString::Format("DELETE Texture: %s. It's FOUND in the other list and IS identical.", thisTexture->name()));
             indicesToRemove.push_back(a);
@@ -913,10 +937,13 @@ bool TextureXList::removeDupesFoundIn(TextureXList& texture_list)
         {
             log::info(wxString::Format("KEEP Texture: %s. It's FOUND in the other list but IS NOT identical.", thisTexture->name()));
         }
+        
+        log::info(thisTextureCopy.asText());
+        log::info(otherTextureCopy.asText());
     }
     
     // Remove textures while going through the list back to front
-    for (unsigned a = indicesToRemove.size() - 1; a >= 0; a--)
+    for (int a = indicesToRemove.size() - 1; a >= 0; a--)
     {
         removeTexture(indicesToRemove[a]);
     }

--- a/src/Graphics/CTexture/TextureXList.cpp
+++ b/src/Graphics/CTexture/TextureXList.cpp
@@ -879,3 +879,41 @@ bool TextureXList::findErrors()
 	}
 	return ret;
 }
+
+// -----------------------------------------------------------------------------
+// Find and remove duplicates that exist in another texture list
+// -----------------------------------------------------------------------------
+bool TextureXList::removeDupesFoundIn(TextureXList& texture_list)
+{
+    vector<unsigned int> indicesToRemove;
+    
+    for (unsigned a = 0; a < textures_.size(); a++)
+    {
+        CTexture* thisTexture = textures_[a].get();
+        int otherTextureIndex = texture_list.textureIndex(thisTexture->name());
+        
+        if (otherTextureIndex < 0)
+        {
+            // Other texture with this name not found
+            continue;
+        }
+        
+        CTexture* otherTexture = texture_list.texture(otherTextureIndex);
+        
+        // Compare the textures by simply checking if their asText values are identical
+        // It may be slightly less fast to do it this way but it's very future proof and
+        // deals with textures being extended format in one list and not extended format in the other list
+        if (thisTexture->asText() == otherTexture->asText())
+        {
+            indicesToRemove.push_back(a);
+        }
+    }
+    
+    // Remove textures while going through the list back to front
+    for (unsigned a = indicesToRemove.size() - 1; a >= 0; a--)
+    {
+        removeTexture(indicesToRemove[a]);
+    }
+    
+    return indicesToRemove.size();
+}

--- a/src/Graphics/CTexture/TextureXList.h
+++ b/src/Graphics/CTexture/TextureXList.h
@@ -63,6 +63,7 @@ public:
 
 	bool convertToTEXTURES();
 	bool findErrors();
+    bool removeDupesFoundIn(TextureXList& texture_list);
 
 private:
 	vector<unique_ptr<CTexture>> textures_;

--- a/src/Graphics/CTexture/TextureXList.h
+++ b/src/Graphics/CTexture/TextureXList.h
@@ -63,8 +63,8 @@ public:
 
 	bool convertToTEXTURES();
 	bool findErrors();
-    bool removeDupesFoundIn(TextureXList& texture_list);
-    bool cleanTEXTURESsinglePatch(Archive* currentArchive);
+	bool removeDupesFoundIn(TextureXList& texture_list);
+	bool cleanTEXTURESsinglePatch(Archive* currentArchive);
 
 private:
 	vector<unique_ptr<CTexture>> textures_;

--- a/src/Graphics/CTexture/TextureXList.h
+++ b/src/Graphics/CTexture/TextureXList.h
@@ -64,6 +64,7 @@ public:
 	bool convertToTEXTURES();
 	bool findErrors();
     bool removeDupesFoundIn(TextureXList& texture_list);
+    bool cleanTEXTURESsinglePatch(Archive* currentArchive);
 
 private:
 	vector<unique_ptr<CTexture>> textures_;

--- a/src/MainEditor/ArchiveOperations.cpp
+++ b/src/MainEditor/ArchiveOperations.cpp
@@ -798,6 +798,19 @@ void archiveoperations::removeUnusedFlats(Archive* archive)
 	wxMessageBox(wxString::Format("Removed %d unused flats", n_removed));
 }
 
+bool archiveoperations::removeUnusedZDoomTextures(Archive* archive)
+{
+	// Check archive was given
+	if (!archive)
+		return;
+
+	// --- Build list of used flats ---
+	TexUsedMap used_textures;
+	int        total_maps = 0;
+	
+	return false;
+}
+
 
 CONSOLE_COMMAND(test_cleantex, 0, false)
 {
@@ -811,6 +824,13 @@ CONSOLE_COMMAND(test_cleanflats, 0, false)
 	auto current = maineditor::currentArchive();
 	if (current)
 		archiveoperations::removeUnusedFlats(current);
+}
+
+CONSOLE_COMMAND(test_cleanzdoomtex, 0, false)
+{
+	auto current = maineditor::currentArchive();
+	if (current)
+		archiveoperations::removeUnusedZDoomTextures(current);
 }
 
 void importEntryDataKeepType(ArchiveEntry* entry, const void* data, unsigned size)

--- a/src/MainEditor/ArchiveOperations.cpp
+++ b/src/MainEditor/ArchiveOperations.cpp
@@ -821,7 +821,9 @@ void archiveoperations::removeUnusedZDoomTextures(Archive* archive)
 	
 	// must keep this smart pointer around or the archive gets dealloced immediately
 	// from the heap and we get huge memory issues while referencing a dangling pointer
-	auto archiveSmartPtr = app::archiveManager().openDirArchive(archive->filename(), false, true);
+	auto archiveSmartPtr = archive->formatId() == "folder"
+		? app::archiveManager().openDirArchive(archive->filename(), false, true)
+		: app::archiveManager().openArchive(archive->filename(), false, true);
 	archive = archiveSmartPtr.get();
 
 	// --- Build list of used textures ---

--- a/src/MainEditor/ArchiveOperations.h
+++ b/src/MainEditor/ArchiveOperations.h
@@ -9,7 +9,7 @@ bool checkDuplicateEntryNames(Archive* archive);
 bool checkDuplicateEntryContent(Archive* archive);
 void removeUnusedTextures(Archive* archive);
 void removeUnusedFlats(Archive* archive);
-bool removeUnusedZDoomTextures(Archive* archive);
+void removeUnusedZDoomTextures(Archive* archive);
 void removeEntriesUnchangedFromIWAD(Archive* archive);
 
 // Search and replace in maps

--- a/src/MainEditor/ArchiveOperations.h
+++ b/src/MainEditor/ArchiveOperations.h
@@ -9,6 +9,7 @@ bool checkDuplicateEntryNames(Archive* archive);
 bool checkDuplicateEntryContent(Archive* archive);
 void removeUnusedTextures(Archive* archive);
 void removeUnusedFlats(Archive* archive);
+bool removeUnusedZDoomTextures(Archive* archive);
 void removeEntriesUnchangedFromIWAD(Archive* archive);
 
 // Search and replace in maps

--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -735,7 +735,7 @@ bool entryoperations::cleanZdTextureSinglePatch(const vector<ArchiveEntry*>& ent
     if (parent->formatDesc().supports_dirs)
     {
         int dialogAnswer = wxMessageBox(
-            "This will remove all textures that are made out of a basic single patch from this textures entry. It will also rename all of the patches to the texture name and move them into the textures folder.",
+            "This will remove all textures that are made out of a basic single patch from this textures entry. It will also rename all of the patches to the texture name and move them from the patches to the textures folder.",
             "Clean single patch texture entries.",
             wxOK | wxCANCEL | wxICON_WARNING);
         
@@ -748,9 +748,10 @@ bool entryoperations::cleanZdTextureSinglePatch(const vector<ArchiveEntry*>& ent
     {
         // Warn that patch to texture conversion only works archives that support folders
         wxMessageBox(
-            "This can convert patches for single patch textures into textures but this is only supported for archives that can contain folders. This will move patches into the textures folder for the zdoom format.",
+            "This currently only works with archives that support directories",
             "Clean single patch texture entries.",
             wxOK | wxICON_WARNING);
+        return false;
     }
     
     bool ret = false;

--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -568,9 +568,9 @@ bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries
         return false;
     
     int dialogAnswer = wxMessageBox(
-        "This can clean redundant texture entries from a pwad/archive. Newer more advanced source ports like GZDoom can still properly access iwad textures if you don't include their entries in a pwad. However, running this operation should be avoided for wads not intended to run in modern more advanced source ports since they may rely on the TEXTURE1/TEXTURE2 entries in the pwad having all of the same entries as the iwad.",
+        "Don't run this on TEXTURE entries unless your wad/archive is intended for newer more advanced source ports like GZDoom. The newer source ports can still properly access iwad textures if you don't include their entries in a pwad. However, older engines may rely on all of the iwad TEXTUREs being redefined in a pwad to work correctly. You should have nothing to worry about for ZDoom Format TEXTURES files.",
         "Remove duplicate texture entries.",
-        wxOK | wxCANCEL | wxCENTRE | wxICON_INFORMATION);
+        wxOK | wxCANCEL | wxICON_WARNING);
     
     if (dialogAnswer != wxOK)
     {
@@ -696,6 +696,21 @@ bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries
         {
             log::info(wxString::Format("Found no entries to clean from: %s.", entry->name()));
         }
+    }
+    
+    if (ret)
+    {
+        wxMessageBox(
+            "Found duplicate texture entries to remove. Check the console for output info. The PATCH table was left untouched. You can either delete it or clean it using the Remove Unused Patches tool.",
+            "Remove duplicate texture entries.",
+            wxOK | wxCENTER | wxICON_INFORMATION);
+    }
+    else
+    {
+        wxMessageBox(
+            "Didn't find any duplicate texture entries to remove. Check the console for output info.",
+            "Remove duplicate texture entries.",
+            wxOK | wxCENTER | wxICON_INFORMATION);
     }
     
     return ret;

--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -559,6 +559,22 @@ bool entryoperations::findTextureErrors(const vector<ArchiveEntry*>& entries)
 }
 
 // -----------------------------------------------------------------------------
+// Clean texture entries that are duplicates of entries in the iwad
+// -----------------------------------------------------------------------------
+bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries)
+{
+    return false;
+}
+
+// -----------------------------------------------------------------------------
+// Clean ZDTEXTURES entries that are just a single patch
+// -----------------------------------------------------------------------------
+bool entryoperations::cleanZdTextureSinglePatch(const vector<ArchiveEntry*>& entries)
+{
+    return false;
+}
+
+// -----------------------------------------------------------------------------
 // Attempts to compile [entry] as an ACS script.
 // If the entry is named SCRIPTS, the compiled data is imported to the BEHAVIOR
 // entry previous to it, otherwise it is imported to a same-name compiled

--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -624,7 +624,10 @@ bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries
     
     // If we ended up not loading textures from base resource archive
     if (!braTxList.size())
+    {
+        log::error("Base resource archive has no texture entries to compare against");
         return false;
+    }
 
     // Find patch table in parent archive
     auto pnames    = parent->findLast(opt);
@@ -650,9 +653,11 @@ bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries
             {
                 tx.readTEXTUREXData(entry, ptable, true);
                 isTexturex = true;
+                log::info(wxString::Format("Cleaning duplicate entries from TEXTUREx entry %s.", entry->name()));
             }
             else
             {
+                log::error(wxString::Format("Skipping cleaning TEXTUREx entry %s since this archive has no patch table.", entry->name()));
                 // Skip cleaning this texturex entry if there is no patch table for us to load it with
                 continue;
             }
@@ -660,10 +665,13 @@ bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries
         else if (entry->type()->id() == "zdtextures")
         {
             tx.readTEXTURESData(entry);
+            log::info(wxString::Format("Cleaning duplicate entries from ZDoom TEXTURES entry %s.", entry->name()));
         }
         
         if (tx.removeDupesFoundIn(braTxList))
         {
+            log::info(wxString::Format("Cleaned entries from: %s.", entry->name()));
+            
             if (tx.size())
             {
                 if (isTexturex)
@@ -679,9 +687,14 @@ bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries
             {
                 // If we emptied out the entry, just delete it
                 parent->removeEntry(entry);
+                log::info(wxString::Format("%s no longer has any entries so deleting it.", entry->name()));
             }
             
             ret = true;
+        }
+        else
+        {
+            log::info(wxString::Format("Found no entries to clean from: %s.", entry->name()));
         }
     }
     

--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -563,157 +563,157 @@ bool entryoperations::findTextureErrors(const vector<ArchiveEntry*>& entries)
 // -----------------------------------------------------------------------------
 bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries)
 {
-    // Check any entries were given
-    if (entries.empty())
-        return false;
-    
-    int dialogAnswer = wxMessageBox(
-        "Don't run this on TEXTURE entries unless your wad/archive is intended for newer more advanced source ports like GZDoom. The newer source ports can still properly access iwad textures if you don't include their entries in a pwad. However, older engines may rely on all of the iwad TEXTUREs being redefined in a pwad to work correctly. You should have nothing to worry about for ZDoom Format TEXTURES files.",
-        "Remove duplicate texture entries.",
-        wxOK | wxCANCEL | wxICON_WARNING);
-    
-    if (dialogAnswer != wxOK)
-    {
-        return false;
-    }
+	// Check any entries were given
+	if (entries.empty())
+		return false;
+	
+	int dialogAnswer = wxMessageBox(
+		"Don't run this on TEXTURE entries unless your wad/archive is intended for newer more advanced source ports like GZDoom. The newer source ports can still properly access iwad textures if you don't include their entries in a pwad. However, older engines may rely on all of the iwad TEXTUREs being redefined in a pwad to work correctly. You should have nothing to worry about for ZDoom Format TEXTURES files.",
+		"Remove duplicate texture entries.",
+		wxOK | wxCANCEL | wxICON_WARNING);
+	
+	if (dialogAnswer != wxOK)
+	{
+		return false;
+	}
 
-    // Get parent archive of entries
-    auto parent = entries[0]->parent();
+	// Get parent archive of entries
+	auto parent = entries[0]->parent();
 
-    // Can't do anything if entry isn't in an archive
-    if (!parent)
-        return false;
-    
-    // Do nothing if there is no base resource archive,
-    // or if the archive *is* the base resource archive.
-    auto bra = app::archiveManager().baseResourceArchive();
-    if (bra == nullptr || bra == parent)
-        return false;
-    
-    // Now load base resource archive textures into a single list
-    TextureXList braTxList;
-    
-    Archive::SearchOptions opt;
-    opt.match_type = EntryType::fromId("pnames");
-    auto braPnames    = bra->findLast(opt);
-    
-    // Load patch table
-    PatchTable braPtable;
-    if (braPnames)
-    {
-        braPtable.loadPNAMES(braPnames);
-    
-        // Load all Texturex entries
-        Archive::SearchOptions texturexopt;
-        texturexopt.match_type = EntryType::fromId("texturex");
-        
-        for (ArchiveEntry* texturexentry: bra->findAll(texturexopt))
-        {
-            braTxList.readTEXTUREXData(texturexentry, braPtable, true);
-        }
-    }
-    
-    // Load all zdtextures entries
-    Archive::SearchOptions zdtexturesopt;
-    zdtexturesopt.match_type = EntryType::fromId("zdtextures");
-    
-    for (ArchiveEntry* texturesentry: bra->findAll(zdtexturesopt))
-    {
-        braTxList.readTEXTURESData(texturesentry);
-    }
-    
-    // If we ended up not loading textures from base resource archive
-    if (!braTxList.size())
-    {
-        log::error("Base resource archive has no texture entries to compare against");
-        return false;
-    }
+	// Can't do anything if entry isn't in an archive
+	if (!parent)
+		return false;
+	
+	// Do nothing if there is no base resource archive,
+	// or if the archive *is* the base resource archive.
+	auto bra = app::archiveManager().baseResourceArchive();
+	if (bra == nullptr || bra == parent)
+		return false;
+	
+	// Now load base resource archive textures into a single list
+	TextureXList braTxList;
+	
+	Archive::SearchOptions opt;
+	opt.match_type = EntryType::fromId("pnames");
+	auto braPnames	= bra->findLast(opt);
+	
+	// Load patch table
+	PatchTable braPtable;
+	if (braPnames)
+	{
+		braPtable.loadPNAMES(braPnames);
+	
+		// Load all Texturex entries
+		Archive::SearchOptions texturexopt;
+		texturexopt.match_type = EntryType::fromId("texturex");
+		
+		for (ArchiveEntry* texturexentry: bra->findAll(texturexopt))
+		{
+			braTxList.readTEXTUREXData(texturexentry, braPtable, true);
+		}
+	}
+	
+	// Load all zdtextures entries
+	Archive::SearchOptions zdtexturesopt;
+	zdtexturesopt.match_type = EntryType::fromId("zdtextures");
+	
+	for (ArchiveEntry* texturesentry: bra->findAll(zdtexturesopt))
+	{
+		braTxList.readTEXTURESData(texturesentry);
+	}
+	
+	// If we ended up not loading textures from base resource archive
+	if (!braTxList.size())
+	{
+		log::error("Base resource archive has no texture entries to compare against");
+		return false;
+	}
 
-    // Find patch table in parent archive
-    auto pnames    = parent->findLast(opt);
+	// Find patch table in parent archive
+	auto pnames	= parent->findLast(opt);
 
-    // Load patch table if we have it
-    PatchTable ptable;
-    if (pnames)
-        ptable.loadPNAMES(pnames);
+	// Load patch table if we have it
+	PatchTable ptable;
+	if (pnames)
+		ptable.loadPNAMES(pnames);
 
-    bool ret = false;
-    
-    // For each selected entry, perform the clean operation and save it out
-    for (auto& entry : entries)
-    {
-        TextureXList tx;
-        
-        bool isTexturex = false;
-        
-        // If it's a texturex entry
-        if (entry->type()->id() == "texturex")
-        {
-            if (pnames)
-            {
-                tx.readTEXTUREXData(entry, ptable, true);
-                isTexturex = true;
-                log::info(wxString::Format("Cleaning duplicate entries from TEXTUREx entry %s.", entry->name()));
-            }
-            else
-            {
-                log::error(wxString::Format("Skipping cleaning TEXTUREx entry %s since this archive has no patch table.", entry->name()));
-                // Skip cleaning this texturex entry if there is no patch table for us to load it with
-                continue;
-            }
-        }
-        else if (entry->type()->id() == "zdtextures")
-        {
-            tx.readTEXTURESData(entry);
-            log::info(wxString::Format("Cleaning duplicate entries from ZDoom TEXTURES entry %s.", entry->name()));
-        }
-        
-        if (tx.removeDupesFoundIn(braTxList))
-        {
-            log::info(wxString::Format("Cleaned entries from: %s.", entry->name()));
-            
-            if (tx.size())
-            {
-                if (isTexturex)
-                {
-                    tx.writeTEXTUREXData(entry, ptable);
-                }
-                else
-                {
-                    tx.writeTEXTURESData(entry);
-                }
-            }
-            else
-            {
-                // If we emptied out the entry, just delete it
-                parent->removeEntry(entry);
-                log::info(wxString::Format("%s no longer has any entries so deleting it.", entry->name()));
-            }
-            
-            ret = true;
-        }
-        else
-        {
-            log::info(wxString::Format("Found no entries to clean from: %s.", entry->name()));
-        }
-    }
-    
-    if (ret)
-    {
-        wxMessageBox(
-            "Found duplicate texture entries to remove. Check the console for output info. The PATCH table was left untouched. You can either delete it or clean it using the Remove Unused Patches tool.",
-            "Remove duplicate texture entries.",
-            wxOK | wxCENTER | wxICON_INFORMATION);
-    }
-    else
-    {
-        wxMessageBox(
-            "Didn't find any duplicate texture entries to remove. Check the console for output info.",
-            "Remove duplicate texture entries.",
-            wxOK | wxCENTER | wxICON_INFORMATION);
-    }
-    
-    return ret;
+	bool ret = false;
+	
+	// For each selected entry, perform the clean operation and save it out
+	for (auto& entry : entries)
+	{
+		TextureXList tx;
+		
+		bool isTexturex = false;
+		
+		// If it's a texturex entry
+		if (entry->type()->id() == "texturex")
+		{
+			if (pnames)
+			{
+				tx.readTEXTUREXData(entry, ptable, true);
+				isTexturex = true;
+				log::info(wxString::Format("Cleaning duplicate entries from TEXTUREx entry %s.", entry->name()));
+			}
+			else
+			{
+				log::error(wxString::Format("Skipping cleaning TEXTUREx entry %s since this archive has no patch table.", entry->name()));
+				// Skip cleaning this texturex entry if there is no patch table for us to load it with
+				continue;
+			}
+		}
+		else if (entry->type()->id() == "zdtextures")
+		{
+			tx.readTEXTURESData(entry);
+			log::info(wxString::Format("Cleaning duplicate entries from ZDoom TEXTURES entry %s.", entry->name()));
+		}
+		
+		if (tx.removeDupesFoundIn(braTxList))
+		{
+			log::info(wxString::Format("Cleaned entries from: %s.", entry->name()));
+			
+			if (tx.size())
+			{
+				if (isTexturex)
+				{
+					tx.writeTEXTUREXData(entry, ptable);
+				}
+				else
+				{
+					tx.writeTEXTURESData(entry);
+				}
+			}
+			else
+			{
+				// If we emptied out the entry, just delete it
+				parent->removeEntry(entry);
+				log::info(wxString::Format("%s no longer has any entries so deleting it.", entry->name()));
+			}
+			
+			ret = true;
+		}
+		else
+		{
+			log::info(wxString::Format("Found no entries to clean from: %s.", entry->name()));
+		}
+	}
+	
+	if (ret)
+	{
+		wxMessageBox(
+			"Found duplicate texture entries to remove. Check the console for output info. The PATCH table was left untouched. You can either delete it or clean it using the Remove Unused Patches tool.",
+			"Remove duplicate texture entries.",
+			wxOK | wxCENTER | wxICON_INFORMATION);
+	}
+	else
+	{
+		wxMessageBox(
+			"Didn't find any duplicate texture entries to remove. Check the console for output info.",
+			"Remove duplicate texture entries.",
+			wxOK | wxCENTER | wxICON_INFORMATION);
+	}
+	
+	return ret;
 }
 
 // -----------------------------------------------------------------------------
@@ -721,80 +721,80 @@ bool entryoperations::cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries
 // -----------------------------------------------------------------------------
 bool entryoperations::cleanZdTextureSinglePatch(const vector<ArchiveEntry*>& entries)
 {
-    // Check any entries were given
-    if (entries.empty())
-        return false;
-    
-    // Get parent archive of entries
-    auto parent = entries[0]->parent();
+	// Check any entries were given
+	if (entries.empty())
+		return false;
+	
+	// Get parent archive of entries
+	auto parent = entries[0]->parent();
 
-    // Can't do anything if entry isn't in an archive
-    if (!parent)
-        return false;
-    
-    if (parent->formatDesc().supports_dirs)
-    {
-        int dialogAnswer = wxMessageBox(
-            "This will remove all textures that are made out of a basic single patch from this textures entry. It will also rename all of the patches to the texture name and move them from the patches to the textures folder.",
-            "Clean single patch texture entries.",
-            wxOK | wxCANCEL | wxICON_WARNING);
-        
-        if (dialogAnswer != wxOK)
-        {
-            return false;
-        }
-    }
-    else
-    {
-        // Warn that patch to texture conversion only works archives that support folders
-        wxMessageBox(
-            "This currently only works with archives that support directories",
-            "Clean single patch texture entries.",
-            wxOK | wxICON_WARNING);
-        return false;
-    }
-    
-    bool ret = false;
-    
-    for (auto& entry : entries)
-    {
-        TextureXList tx;
-        tx.readTEXTURESData(entry);
-        if (tx.cleanTEXTURESsinglePatch(parent))
-        {
-            log::info(wxString::Format("Cleaned entries from: %s.", entry->name()));
-            
-            if (tx.size())
-            {
-                tx.writeTEXTURESData(entry);
-            }
-            else
-            {
-                // If we emptied out the entry, just delete it
-                parent->removeEntry(entry);
-                log::info(wxString::Format("%s no longer has any entries so deleting it.", entry->name()));
-            }
-            
-            ret = true;
-        }
-    }
-    
-    if (ret)
-    {
-        wxMessageBox(
-            "Found texture entries to clean. Check the console for output info.",
-            "Clean single patch texture entries.",
-            wxOK | wxCENTER | wxICON_INFORMATION);
-    }
-    else
-    {
-        wxMessageBox(
-            "Didn't find any texture entries to clean. Check the console for output info.",
-            "Clean single patch texture entries.",
-            wxOK | wxCENTER | wxICON_INFORMATION);
-    }
-    
-    return ret;
+	// Can't do anything if entry isn't in an archive
+	if (!parent)
+		return false;
+	
+	if (parent->formatDesc().supports_dirs)
+	{
+		int dialogAnswer = wxMessageBox(
+			"This will remove all textures that are made out of a basic single patch from this textures entry. It will also rename all of the patches to the texture name and move them from the patches to the textures folder.",
+			"Clean single patch texture entries.",
+			wxOK | wxCANCEL | wxICON_WARNING);
+		
+		if (dialogAnswer != wxOK)
+		{
+			return false;
+		}
+	}
+	else
+	{
+		// Warn that patch to texture conversion only works archives that support folders
+		wxMessageBox(
+			"This currently only works with archives that support directories",
+			"Clean single patch texture entries.",
+			wxOK | wxICON_WARNING);
+		return false;
+	}
+	
+	bool ret = false;
+	
+	for (auto& entry : entries)
+	{
+		TextureXList tx;
+		tx.readTEXTURESData(entry);
+		if (tx.cleanTEXTURESsinglePatch(parent))
+		{
+			log::info(wxString::Format("Cleaned entries from: %s.", entry->name()));
+			
+			if (tx.size())
+			{
+				tx.writeTEXTURESData(entry);
+			}
+			else
+			{
+				// If we emptied out the entry, just delete it
+				parent->removeEntry(entry);
+				log::info(wxString::Format("%s no longer has any entries so deleting it.", entry->name()));
+			}
+			
+			ret = true;
+		}
+	}
+	
+	if (ret)
+	{
+		wxMessageBox(
+			"Found texture entries to clean. Check the console for output info.",
+			"Clean single patch texture entries.",
+			wxOK | wxCENTER | wxICON_INFORMATION);
+	}
+	else
+	{
+		wxMessageBox(
+			"Didn't find any texture entries to clean. Check the console for output info.",
+			"Clean single patch texture entries.",
+			wxOK | wxCENTER | wxICON_INFORMATION);
+	}
+	
+	return ret;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/MainEditor/EntryOperations.h
+++ b/src/MainEditor/EntryOperations.h
@@ -17,8 +17,8 @@ namespace entryoperations
 	bool createTexture(const vector<ArchiveEntry*>& entries);
 	bool convertTextures(const vector<ArchiveEntry*>& entries);
 	bool findTextureErrors(const vector<ArchiveEntry*>& entries);
-    bool cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries);
-    bool cleanZdTextureSinglePatch(const vector<ArchiveEntry*>& entries);
+	bool cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries);
+	bool cleanZdTextureSinglePatch(const vector<ArchiveEntry*>& entries);
 	bool compileACS(ArchiveEntry* entry, bool hexen = false, ArchiveEntry* target = nullptr, wxFrame* parent = nullptr);
 	bool exportAsPNG(ArchiveEntry* entry, const wxString& filename);
 	bool optimizePNG(ArchiveEntry* entry);

--- a/src/MainEditor/EntryOperations.h
+++ b/src/MainEditor/EntryOperations.h
@@ -17,6 +17,8 @@ namespace entryoperations
 	bool createTexture(const vector<ArchiveEntry*>& entries);
 	bool convertTextures(const vector<ArchiveEntry*>& entries);
 	bool findTextureErrors(const vector<ArchiveEntry*>& entries);
+    bool cleanTextureIwadDupes(const vector<ArchiveEntry*>& entries);
+    bool cleanZdTextureSinglePatch(const vector<ArchiveEntry*>& entries);
 	bool compileACS(ArchiveEntry* entry, bool hexen = false, ArchiveEntry* target = nullptr, wxFrame* parent = nullptr);
 	bool exportAsPNG(ArchiveEntry* entry, const wxString& filename);
 	bool optimizePNG(ArchiveEntry* entry);

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -2851,7 +2851,7 @@ bool ArchivePanel::findTextureErrors() const
 // -----------------------------------------------------------------------------
 bool ArchivePanel::cleanTextureIwadDupes() const
 {
-    return entryoperations::cleanTextureIwadDupes(entry_tree_->selectedEntries());
+	return entryoperations::cleanTextureIwadDupes(entry_tree_->selectedEntries());
 }
 
 // -----------------------------------------------------------------------------
@@ -2859,7 +2859,7 @@ bool ArchivePanel::cleanTextureIwadDupes() const
 // -----------------------------------------------------------------------------
 bool ArchivePanel::cleanZdTextureSinglePatch() const
 {
-    return entryoperations::cleanZdTextureSinglePatch(entry_tree_->selectedEntries());
+	return entryoperations::cleanZdTextureSinglePatch(entry_tree_->selectedEntries());
 }
 
 // -----------------------------------------------------------------------------
@@ -3414,10 +3414,10 @@ bool ArchivePanel::handleAction(string_view id)
 		convertTextures();
 	else if (id == "arch_texturex_finderrors")
 		findTextureErrors();
-    else if (id == "arch_texture_clean_iwaddupes")
-        cleanTextureIwadDupes();
-    else if (id == "arch_zdtextures_clean_singlepatch")
-        cleanZdTextureSinglePatch();
+	else if (id == "arch_texture_clean_iwaddupes")
+		cleanTextureIwadDupes();
+	else if (id == "arch_zdtextures_clean_singlepatch")
+		cleanZdTextureSinglePatch();
 	else if (id == "arch_map_opendb2")
 		mapOpenDb2();
 	else if (id == "arch_entry_setup_external")
@@ -3638,7 +3638,7 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 	bool text_selected     = false;
 	bool unknown_selected  = false;
 	bool texturex_selected = false;
-    bool zdtextures_selected = false;
+	bool zdtextures_selected = false;
 	bool modified_selected = false;
 	bool map_selected      = false;
 	bool swan_selected     = false;
@@ -3706,11 +3706,11 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 			if (entry->type()->formatId() == "texturex")
 				texturex_selected = true;
 		}
-        if (!zdtextures_selected)
-        {
-            if (entry->type()->id() == "zdtextures")
-                zdtextures_selected = true;
-        }
+		if (!zdtextures_selected)
+		{
+			if (entry->type()->id() == "zdtextures")
+				zdtextures_selected = true;
+		}
 		if (!modified_selected)
 		{
 			if (entry->state() == ArchiveEntry::State::Modified)
@@ -3806,18 +3806,18 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 		SAction::fromId("arch_texturex_convertzd")->addToMenu(&context, true);
 		SAction::fromId("arch_texturex_finderrors")->addToMenu(&context, true);
 	}
-    
-    // Add texturex/zdtextures related menu items if needed
-    if (texturex_selected || zdtextures_selected)
-    {
-        SAction::fromId("arch_texture_clean_iwaddupes")->addToMenu(&context, true);
-    }
-    
-    // Add zdtextures related menu items if needed
-    if (zdtextures_selected)
-    {
-        SAction::fromId("arch_zdtextures_clean_singlepatch")->addToMenu(&context, true);
-    }
+
+	// Add texturex/zdtextures related menu items if needed
+	if (texturex_selected || zdtextures_selected)
+	{
+		SAction::fromId("arch_texture_clean_iwaddupes")->addToMenu(&context, true);
+	}
+
+	// Add zdtextures related menu items if needed
+	if (zdtextures_selected)
+	{
+		SAction::fromId("arch_zdtextures_clean_singlepatch")->addToMenu(&context, true);
+	}
 
 	// 'View As' menu
 	if (context_submenus)

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -2847,6 +2847,22 @@ bool ArchivePanel::findTextureErrors() const
 }
 
 // -----------------------------------------------------------------------------
+// Clean texture entries that are duplicates of entries in the iwad
+// -----------------------------------------------------------------------------
+bool ArchivePanel::cleanTextureIwadDupes() const
+{
+    return entryoperations::cleanTextureIwadDupes(entry_tree_->selectedEntries());
+}
+
+// -----------------------------------------------------------------------------
+// Clean ZDTEXTURES entries that are just a single patch
+// -----------------------------------------------------------------------------
+bool ArchivePanel::cleanZdTextureSinglePatch() const
+{
+    return entryoperations::cleanZdTextureSinglePatch(entry_tree_->selectedEntries());
+}
+
+// -----------------------------------------------------------------------------
 // Opens the currently selected entry in Doom Builder 2 if it is a valid map
 // entry (either a map header or archive in maps/)
 // -----------------------------------------------------------------------------
@@ -3398,8 +3414,10 @@ bool ArchivePanel::handleAction(string_view id)
 		convertTextures();
 	else if (id == "arch_texturex_finderrors")
 		findTextureErrors();
-    else if (id == "arch_zdtextures_clean")
-        findTextureErrors();    // TODO: make it open the clean zdtextures dialog
+    else if (id == "arch_texture_clean_iwaddupes")
+        cleanTextureIwadDupes();
+    else if (id == "arch_zdtextures_clean_singlepatch")
+        cleanZdTextureSinglePatch();
 	else if (id == "arch_map_opendb2")
 		mapOpenDb2();
 	else if (id == "arch_entry_setup_external")
@@ -3789,10 +3807,16 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 		SAction::fromId("arch_texturex_finderrors")->addToMenu(&context, true);
 	}
     
+    // Add texturex/zdtextures related menu items if needed
+    if (texturex_selected || zdtextures_selected)
+    {
+        SAction::fromId("arch_texture_clean_iwaddupes")->addToMenu(&context, true);
+    }
+    
     // Add zdtextures related menu items if needed
     if (zdtextures_selected)
     {
-        SAction::fromId("arch_zdtextures_clean")->addToMenu(&context, true);
+        SAction::fromId("arch_zdtextures_clean_singlepatch")->addToMenu(&context, true);
     }
 
 	// 'View As' menu

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -3260,6 +3260,9 @@ bool ArchivePanel::handleAction(string_view id)
 	// Archive->Maintenance->Remove Unused Flats
 	else if (id == "arch_clean_flats")
 		archiveoperations::removeUnusedFlats(archive.get());
+	
+	else if (id == "arch_clean_zdoom_textures")
+		archiveoperations::removeUnusedZDoomTextures(archive.get());
 
 	// Archive->Maintenance->Check Duplicate Entry Names
 	else if (id == "arch_check_duplicates")
@@ -3511,6 +3514,7 @@ wxMenu* ArchivePanel::createMaintenanceMenu()
 	SAction::fromId("arch_clean_patches")->addToMenu(menu_clean);
 	SAction::fromId("arch_clean_textures")->addToMenu(menu_clean);
 	SAction::fromId("arch_clean_flats")->addToMenu(menu_clean);
+	SAction::fromId("arch_clean_zdoom_textures")->addToMenu(menu_clean);
 	SAction::fromId("arch_clean_iwaddupes")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_duplicates")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_duplicates2")->addToMenu(menu_clean);

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -3398,6 +3398,8 @@ bool ArchivePanel::handleAction(string_view id)
 		convertTextures();
 	else if (id == "arch_texturex_finderrors")
 		findTextureErrors();
+    else if (id == "arch_zdtextures_clean")
+        findTextureErrors();    // TODO: make it open the clean zdtextures dialog
 	else if (id == "arch_map_opendb2")
 		mapOpenDb2();
 	else if (id == "arch_entry_setup_external")
@@ -3618,6 +3620,7 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 	bool text_selected     = false;
 	bool unknown_selected  = false;
 	bool texturex_selected = false;
+    bool zdtextures_selected = false;
 	bool modified_selected = false;
 	bool map_selected      = false;
 	bool swan_selected     = false;
@@ -3685,6 +3688,11 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 			if (entry->type()->formatId() == "texturex")
 				texturex_selected = true;
 		}
+        if (!zdtextures_selected)
+        {
+            if (entry->type()->id() == "zdtextures")
+                zdtextures_selected = true;
+        }
 		if (!modified_selected)
 		{
 			if (entry->state() == ArchiveEntry::State::Modified)
@@ -3780,6 +3788,12 @@ void ArchivePanel::onEntryListRightClick(wxDataViewEvent& e)
 		SAction::fromId("arch_texturex_convertzd")->addToMenu(&context, true);
 		SAction::fromId("arch_texturex_finderrors")->addToMenu(&context, true);
 	}
+    
+    // Add zdtextures related menu items if needed
+    if (zdtextures_selected)
+    {
+        SAction::fromId("arch_zdtextures_clean")->addToMenu(&context, true);
+    }
 
 	// 'View As' menu
 	if (context_submenus)

--- a/src/MainEditor/UI/ArchivePanel.h
+++ b/src/MainEditor/UI/ArchivePanel.h
@@ -78,8 +78,8 @@ public:
 	bool compileACS(bool hexen = false) const;
 	bool convertTextures() const;
 	bool findTextureErrors() const;
-    bool cleanTextureIwadDupes() const;
-    bool cleanZdTextureSinglePatch() const;
+	bool cleanTextureIwadDupes() const;
+	bool cleanZdTextureSinglePatch() const;
 	bool mapOpenDb2() const;
 	bool crc32() const;
 

--- a/src/MainEditor/UI/ArchivePanel.h
+++ b/src/MainEditor/UI/ArchivePanel.h
@@ -78,6 +78,8 @@ public:
 	bool compileACS(bool hexen = false) const;
 	bool convertTextures() const;
 	bool findTextureErrors() const;
+    bool cleanTextureIwadDupes() const;
+    bool cleanZdTextureSinglePatch() const;
 	bool mapOpenDb2() const;
 	bool crc32() const;
 


### PR DESCRIPTION
This adds 2 right click options for texture entries and an archive maintenance option for finding all unused zdoom textures.

<img width="552" alt="Screen Shot 2022-02-01 at 1 30 25 AM" src="https://user-images.githubusercontent.com/173169/151943814-d4001e04-1a79-475b-9755-ff92364ea7e7.png">

<img width="467" alt="Screen Shot 2022-02-12 at 5 49 56 AM" src="https://user-images.githubusercontent.com/173169/153714043-06b916fc-3404-4552-b71f-860ab992f1ef.png">

Doom style and Zdoom style textures both have an option to clean out duplicate unmodified texture entries that also exist in the iwad.

Zdoom style textures also have another option to clean out redundant single patch textures and convert those patches into textures themselves.

The Remove Unused Zdoom textures option scans through all wall and floor/ceil textures in every map similar to the existing remove unused textures/remove unused flats tools.  Except remove unused textures currently doesn't check floor/ceil, and remove unused flats currently doesn't check walls.  Also I have a rudimentary Animdefs parser to add animated and switch textures to the exclude list.  This will remove texture/flat images themselves from the archive, and it will remove texture entries from texturex and textures files.

This way you can easily do some large scale cleanup when working with texture packs and making them ready for zdoom format games.