### PR TITLE
Update for wx3.1.6+ compatibility

### DIFF
--- a/src/Graphics/Icons.cpp
+++ b/src/Graphics/Icons.cpp
@@ -373,14 +373,16 @@ wxBitmap loadPNGIcon(const IconDef& icon, int size, Point2i padding)
 bool icons::loadIcons()
 {
 	// Check for dark mode
-#if wxMAJOR_VERSION >= 3 && wxMINOR_VERSION >= 1
+#if defined(__WXMSW__)
+	ui_icons_dark = false; // Force light theme icons in windows
+#elif wxCHECK_VERSION(3, 1, 0)
 	ui_icons_dark = wxSystemSettings::GetAppearance().IsDark();
 #else
-	auto fg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+	auto fg   = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
 	auto fg_r = fg.Red();
 	auto fg_g = fg.Green();
 	auto fg_b = fg.Blue();
-	auto bg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+	auto bg   = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
 	auto bg_r = bg.Red();
 	auto bg_g = bg.Green();
 	auto bg_b = bg.Blue();
@@ -438,6 +440,47 @@ bool icons::loadIcons()
 	return true;
 }
 
+#if wxCHECK_VERSION(3, 1, 6)
+// -----------------------------------------------------------------------------
+// Loads the icon [name] of [type] into a wxBitmapBundle of minimum [size], with
+// optional [padding] (png icons only).
+//
+// NOTE: this does not use any kind of caching and will generate/load the icon
+// from svg/png data each time
+// -----------------------------------------------------------------------------
+wxBitmapBundle icons::getIcon(Type type, string_view name, int size, Point2i padding)
+{
+	// Get icon definition
+	const auto* icon_def = iconDef(type, name);
+	if (!icon_def)
+	{
+		log::warning("Unknown icon \"{}\"", name);
+		return wxNullBitmap;
+	}
+
+	// Check size
+	if (size <= 0)
+		size = 16;
+
+	// If there is SVG data use that
+	if (!icon_def->svg_data.empty())
+		return wxBitmapBundle::FromSVG(icon_def->svg_data.c_str(), { size, size });
+
+	// Otherwise load from png
+	if (icon_def->entry_png16 || icon_def->entry_png32)
+	{
+		wxVector<wxBitmap> bitmaps;
+		if (size <= 16)
+			bitmaps.push_back(loadPNGIcon(*icon_def, 16, padding));
+		if (size <= 24)
+			bitmaps.push_back(loadPNGIcon(*icon_def, 24, padding));
+		bitmaps.push_back(loadPNGIcon(*icon_def, 32, padding));
+		return wxBitmapBundle::FromBitmaps(bitmaps);
+	}
+
+	return wxNullBitmap;
+}
+#else
 // -----------------------------------------------------------------------------
 // Loads the icon [name] of [type] into a wxBitmap of [size], with optional
 // [padding].
@@ -469,7 +512,49 @@ wxBitmap icons::getIcon(Type type, string_view name, int size, Point2i padding)
 
 	return wxNullBitmap;
 }
+#endif
 
+#if wxCHECK_VERSION(3, 1, 6)
+// -----------------------------------------------------------------------------
+// Loads the interface icon [name] from [theme] into a wxBitmapBundle of minimum
+// [size].
+//
+// NOTE: this does not use any kind of caching and will generate/load the icon
+// from svg/png data each time
+// -----------------------------------------------------------------------------
+wxBitmapBundle icons::getInterfaceIcon(string_view name, int size, InterfaceTheme theme)
+{
+	// Get theme to use
+	bool dark = false;
+	switch (theme)
+	{
+	case System: dark = ui_icons_dark; break;
+	case Light: dark = false; break;
+	case Dark: dark = true; break;
+	}
+
+	// Get icon definition
+	auto&    icon_set = dark ? iconset_ui_dark : iconset_ui_light;
+	IconDef* icon_def = nullptr;
+	if (auto i = icon_set.icons.find(name); i != icon_set.icons.end())
+		icon_def = &i->second;
+	if (!icon_def)
+	{
+		log::warning("Unknown interface icon \"{}\"", name);
+		return wxNullBitmap;
+	}
+
+	// Check size
+	if (size <= 0)
+		size = 16;
+
+	// If there is SVG data use that
+	if (!icon_def->svg_data.empty())
+		return wxBitmapBundle::FromSVG(icon_def->svg_data.c_str(), { size, size });
+
+	return wxNullBitmap;
+}
+#else
 // -----------------------------------------------------------------------------
 // Loads the interface icon [name] from [theme] into a wxBitmap of [size].
 //
@@ -488,7 +573,7 @@ wxBitmap icons::getInterfaceIcon(string_view name, int size, InterfaceTheme them
 	}
 
 	// Get icon definition
-	auto& icon_set = dark ? iconset_ui_dark : iconset_ui_light;
+	auto&    icon_set = dark ? iconset_ui_dark : iconset_ui_light;
 	IconDef* icon_def = nullptr;
 	if (auto i = icon_set.icons.find(name); i != icon_set.icons.end())
 		icon_def = &i->second;
@@ -508,6 +593,7 @@ wxBitmap icons::getInterfaceIcon(string_view name, int size, InterfaceTheme them
 
 	return wxNullBitmap;
 }
+#endif
 
 // -----------------------------------------------------------------------------
 // Returns a list of all defined icon sets for [type]
@@ -525,4 +611,12 @@ vector<string> icons::iconSets(Type type)
 			sets.emplace_back(set.name);
 
 	return sets;
+}
+
+// -----------------------------------------------------------------------------
+// Returns true if [icon] of [type] exists
+// -----------------------------------------------------------------------------
+bool icons::iconExists(Type type, string_view name)
+{
+	return iconDef(type, name) != nullptr;
 }

--- a/src/Graphics/Icons.h
+++ b/src/Graphics/Icons.h
@@ -21,9 +21,17 @@ namespace icons
 		Dark   = 1   // Dark theme (white icons)
 	};
 
-	bool           loadIcons();
-	wxBitmap       getIcon(Type type, string_view name, int size = -1, Point2i padding = { 0, 0 });
-	wxBitmap       getInterfaceIcon(string_view name, int size = -1, InterfaceTheme theme = System);
+	bool loadIcons();
+
+#if wxCHECK_VERSION(3, 1, 6)
+	wxBitmapBundle getIcon(Type type, string_view name, int size = -1, Point2i padding = { 0, 0 });
+	wxBitmapBundle getInterfaceIcon(string_view name, int size = -1, InterfaceTheme theme = System);
+#else
+	wxBitmap getIcon(Type type, string_view name, int size = -1, Point2i padding = { 0, 0 });
+	wxBitmap getInterfaceIcon(string_view name, int size = -1, InterfaceTheme theme = System);
+#endif
+
 	vector<string> iconSets(Type type);
+	bool           iconExists(Type type, string_view name);
 } // namespace icons
 } // namespace slade

--- a/src/MainEditor/UI/ArchiveManagerPanel.cpp
+++ b/src/MainEditor/UI/ArchiveManagerPanel.cpp
@@ -71,7 +71,7 @@ CVAR(Int, dir_archive_change_action, 2, CVar::Flag::Save) // 0=always ignore, 1=
 //
 // External Variables
 //
-// ----------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 EXTERN_CVAR(String, dir_last)
 EXTERN_CVAR(Int, autosave_entry_changes)
 
@@ -295,8 +295,10 @@ ArchiveManagerPanel::ArchiveManagerPanel(wxWindow* parent, STabCtrl* nb_archives
 	auto  et_icon_list  = EntryType::iconList();
 	for (const auto& name : et_icon_list)
 	{
-		if (bm_image_list->Add(icons::getIcon(icons::Entry, name)) < 0)
-			bm_image_list->Add(icons::getIcon(icons::Entry, "default"));
+		if (icons::iconExists(icons::Entry, name))
+			wxutil::addImageListIcon(bm_image_list, icons::Entry, name);
+		else
+			wxutil::addImageListIcon(bm_image_list, icons::Entry, "default");
 	}
 	list_bookmarks_->SetImageList(bm_image_list, wxIMAGE_LIST_SMALL);
 	menu_bookmarks_ = new wxMenu();
@@ -369,10 +371,10 @@ void ArchiveManagerPanel::createRecentPanel()
 
 	// Setup image list
 	auto list = wxutil::createSmallImageList();
-	list->Add(icons::getIcon(icons::Entry, "archive"));
-	list->Add(icons::getIcon(icons::Entry, "wad"));
-	list->Add(icons::getIcon(icons::Entry, "zip"));
-	list->Add(icons::getIcon(icons::Entry, "folder"));
+	wxutil::addImageListIcon(list, icons::Entry, "archive");
+	wxutil::addImageListIcon(list, icons::Entry, "wad");
+	wxutil::addImageListIcon(list, icons::Entry, "zip");
+	wxutil::addImageListIcon(list, icons::Entry, "folder");
 	list_recent_->SetImageList(list, wxIMAGE_LIST_SMALL);
 }
 

--- a/src/Scripting/UI/ScriptManagerWindow.cpp
+++ b/src/Scripting/UI/ScriptManagerWindow.cpp
@@ -185,8 +185,8 @@ wxTreeItemId getOrCreateNode(wxTreeCtrl* tree, wxTreeItemId parent_node, const w
 wxImageList* createTreeImageList()
 {
 	auto image_list = wxutil::createSmallImageList();
-	image_list->Add(icons::getIcon(icons::Entry, "code"));
-	image_list->Add(icons::getIcon(icons::Entry, "folder"));
+	wxutil::addImageListIcon(image_list, icons::Entry, "code");
+	wxutil::addImageListIcon(image_list, icons::Entry, "folder");
 	return image_list;
 }
 

--- a/src/TextEditor/UI/SCallTip.cpp
+++ b/src/TextEditor/UI/SCallTip.cpp
@@ -85,7 +85,11 @@ void SCallTip::setFont(const wxString& face, int size)
 	if (face.empty())
 	{
 		font_.SetFaceName(GetFont().GetFaceName());
+#if wxCHECK_VERSION(3, 1, 6)
+		font_.SetPointSize(FromDIP(GetFont().GetPointSize()));
+#else
 		font_.SetPointSize(GetFont().GetPointSize());
+#endif
 	}
 	else
 	{

--- a/src/TextEditor/UI/TextEditorCtrl.cpp
+++ b/src/TextEditor/UI/TextEditorCtrl.cpp
@@ -185,11 +185,20 @@ TextEditorCtrl::TextEditorCtrl(wxWindow* parent, int id) :
 	SetMarginWidth(2, 4);
 
 	// Register icons for autocompletion list
+#if wxCHECK_VERSION(3, 1, 6)
+	auto size = wxSize{ ui::scalePx(16), ui::scalePx(16) };
+	RegisterImage(1, icons::getIcon(icons::TextEditor, "keyword", -1, { 1, 3 }).GetBitmap(size));
+	RegisterImage(2, icons::getIcon(icons::TextEditor, "constant", -1, { 1, 3 }).GetBitmap(size));
+	RegisterImage(3, icons::getIcon(icons::TextEditor, "type", -1, { 1, 3 }).GetBitmap(size));
+	RegisterImage(4, icons::getIcon(icons::TextEditor, "property", -1, { 1, 3 }).GetBitmap(size));
+	RegisterImage(5, icons::getIcon(icons::TextEditor, "function", -1, { 1, 3 }).GetBitmap(size));
+#else
 	RegisterImage(1, icons::getIcon(icons::TextEditor, "keyword", -1, { 1, 3 }));
 	RegisterImage(2, icons::getIcon(icons::TextEditor, "constant", -1, { 1, 3 }));
 	RegisterImage(3, icons::getIcon(icons::TextEditor, "type", -1, { 1, 3 }));
 	RegisterImage(4, icons::getIcon(icons::TextEditor, "property", -1, { 1, 3 }));
 	RegisterImage(5, icons::getIcon(icons::TextEditor, "function", -1, { 1, 3 }));
+#endif
 
 	// Init w/no language
 	setLanguage(nullptr);

--- a/src/UI/Controls/SIconButton.cpp
+++ b/src/UI/Controls/SIconButton.cpp
@@ -54,6 +54,9 @@ SIconButton::SIconButton(
 	int             icon_size) :
 	wxBitmapButton{ parent, -1, wxNullBitmap }
 {
+#if wxCHECK_VERSION(3, 1, 6)
+	auto bmp = icons::getIcon(icon_type, icon.ToStdString(), icon_size);
+#else
 	// Create icon
 	auto size = ui::scalePx(icon_size);
 	auto bmp  = icons::getIcon(icon_type, icon.ToStdString(), size);
@@ -65,6 +68,7 @@ SIconButton::SIconButton(
 		img.Rescale(size, size, wxIMAGE_QUALITY_BICUBIC);
 		bmp = wxBitmap(img);
 	}
+#endif
 
 	// Set button image and tooltip
 	SetBitmap(bmp);

--- a/src/UI/Controls/STabCtrl.h
+++ b/src/UI/Controls/STabCtrl.h
@@ -19,7 +19,7 @@ public:
 		int       height        = -1,
 		bool      main_tabs     = false,
 		bool      move_tabs     = false);
-	~STabCtrl() = default;
+	~STabCtrl() override = default;
 
 	static TabControl* createControl(
 		wxWindow* parent,

--- a/src/UI/Dialogs/MapEditorConfigDialog.cpp
+++ b/src/UI/Dialogs/MapEditorConfigDialog.cpp
@@ -223,8 +223,8 @@ MapEditorConfigDialog::MapEditorConfigDialog(wxWindow* parent, Archive* archive,
 
 	// Setup image list
 	img_list_ = wxutil::createSmallImageList();
-	img_list_->Add(icons::getIcon(icons::General, "tick"));
-	img_list_->Add(icons::getIcon(icons::General, "close"));
+	wxutil::addImageListIcon(img_list_, icons::General, "tick");
+	wxutil::addImageListIcon(img_list_, icons::General, "close");
 
 	// Map section
 	if (show_maplist)

--- a/src/UI/Lists/ArchiveEntryList.cpp
+++ b/src/UI/Lists/ArchiveEntryList.cpp
@@ -102,8 +102,8 @@ ArchiveEntryList::ArchiveEntryList(wxWindow* parent) : VirtualListView(parent)
 	auto  et_icon_list = EntryType::iconList();
 	for (const auto& name : et_icon_list)
 	{
-		if (image_list->Add(icons::getIcon(icons::Entry, name, elist_icon_size, pad)) < 0)
-			image_list->Add(icons::getIcon(icons::Entry, "default", elist_icon_size, pad));
+		//if (image_list->Add(icons::getIcon(icons::Entry, name, elist_icon_size, pad)) < 0)
+		//	image_list->Add(icons::getIcon(icons::Entry, "default", elist_icon_size, pad));
 	}
 
 	wxListCtrl::SetImageList(image_list, wxIMAGE_LIST_SMALL);

--- a/src/UI/Lists/ArchiveEntryTree.cpp
+++ b/src/UI/Lists/ArchiveEntryTree.cpp
@@ -57,7 +57,11 @@ namespace slade::ui
 wxColour                           col_text_modified(0, 0, 0, 0);
 wxColour                           col_text_new(0, 0, 0, 0);
 wxColour                           col_text_locked(0, 0, 0, 0);
+#if wxCHECK_VERSION(3, 1, 6)
+std::unordered_map<string, wxBitmapBundle> icon_cache;
+#else
 std::unordered_map<string, wxIcon> icon_cache;
+#endif
 } // namespace slade::ui
 
 CVAR(Int, elist_colsize_name_tree, 150, CVar::Save)
@@ -398,12 +402,18 @@ void ArchiveViewModel::GetValue(wxVariant& variant, const wxDataViewItem& item, 
 		{
 			// Not found, add to cache
 			const auto pad  = Point2i{ 1, elist_icon_padding };
+
+#if wxCHECK_VERSION(3, 1, 6)
+			const auto bundle  = icons::getIcon(icons::Type::Entry, entry->type()->icon(), elist_icon_size, pad);
+			icon_cache[entry->type()->icon()] = bundle;
+#else
 			const auto size = scalePx(elist_icon_size);
 			const auto bmp  = icons::getIcon(icons::Type::Entry, entry->type()->icon(), size, pad);
 
 			wxIcon icon;
 			icon.CopyFromBitmap(bmp);
 			icon_cache[entry->type()->icon()] = icon;
+#endif
 		}
 
 		wxString name = entry->name();

--- a/src/UI/SAuiTabArt.cpp
+++ b/src/UI/SAuiTabArt.cpp
@@ -114,8 +114,8 @@ void IndentPressedBitmap(wxRect* rect, int button_state)
 SAuiTabArt::SAuiTabArt(bool close_buttons, bool main_tabs) :
 	close_buttons_{ close_buttons }, main_tabs_{ main_tabs }, padding_(tabs_condensed ? ui::scalePx(4) : ui::scalePx(8))
 {
-	m_normalFont    = *wxNORMAL_FONT;
-	m_selectedFont  = *wxNORMAL_FONT;
+	m_normalFont   = *wxNORMAL_FONT;
+	m_selectedFont = *wxNORMAL_FONT;
 
 #if wxCHECK_VERSION(3, 1, 6) && defined(__WXMSW__)
 	m_normalFont.SetPointSize(ui::scalePx(m_normalFont.GetPointSize()));
@@ -140,16 +140,16 @@ SAuiTabArt::SAuiTabArt(bool close_buttons, bool main_tabs) :
 #if wxCHECK_VERSION(3, 1, 6)
 	m_activeCloseBmp    = icons::getInterfaceIcon("cross");
 	close_bitmap_white_ = icons::getInterfaceIcon("cross", -1, icons::Dark);
-	m_disabledCloseBmp  = icons::getInterfaceIcon("cross");//.ConvertToDisabled();
+	m_disabledCloseBmp  = icons::getInterfaceIcon("cross");
 
 	m_activeLeftBmp   = icons::getInterfaceIcon("arrow-left");
-	m_disabledLeftBmp = icons::getInterfaceIcon("arrow-left");//.ConvertToDisabled();
+	m_disabledLeftBmp = icons::getInterfaceIcon("arrow-left");
 
 	m_activeRightBmp   = icons::getInterfaceIcon("arrow-right");
-	m_disabledRightBmp = icons::getInterfaceIcon("arrow-right");//.ConvertToDisabled();
+	m_disabledRightBmp = icons::getInterfaceIcon("arrow-right");
 
 	m_activeWindowListBmp   = icons::getInterfaceIcon("arrow-down");
-	m_disabledWindowListBmp = icons::getInterfaceIcon("arrow-down");//.ConvertToDisabled();
+	m_disabledWindowListBmp = icons::getInterfaceIcon("arrow-down");
 #else
 	m_activeCloseBmp    = icons::getInterfaceIcon("cross");
 	close_bitmap_white_ = icons::getInterfaceIcon("cross", -1, icons::Dark);
@@ -391,11 +391,7 @@ void SAuiTabArt::DrawTab(
 	{
 #if wxCHECK_VERSION(3, 1, 6)
 		const auto& bmp = page.bitmap.GetBitmapFor(wnd);
-		dc.DrawBitmap(
-			bmp,
-			tab_x + padding_,
-			drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2),
-			true);
+		dc.DrawBitmap(bmp, tab_x + padding_, drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2), true);
 #else
 		dc.DrawBitmap(
 			page.bitmap,
@@ -421,10 +417,10 @@ void SAuiTabArt::DrawTab(
 			offsetY = 1;
 
 #if wxCHECK_VERSION(3, 1, 6)
-		int close_button_width = m_activeCloseBmp.GetPreferredBitmapSizeFor(wnd).x;
+		int close_button_width  = m_activeCloseBmp.GetPreferredBitmapSizeFor(wnd).x;
 		int close_button_height = m_activeCloseBmp.GetPreferredBitmapSizeFor(wnd).y;
 #else
-		int close_button_width = m_activeCloseBmp.GetWidth();
+		int close_button_width  = m_activeCloseBmp.GetWidth();
 		int close_button_height = m_activeCloseBmp.GetHeight();
 #endif
 
@@ -455,7 +451,7 @@ void SAuiTabArt::DrawTab(
 		{
 			const auto& bmp = close_white ? close_bitmap_white_ : m_disabledCloseBmp;
 #if wxCHECK_VERSION(3, 1, 6)
-			dc.DrawBitmap(bmp.GetBitmapFor(wnd), rect.x, rect.y);
+			dc.DrawBitmap(bmp.GetBitmapFor(wnd).ConvertToDisabled(), rect.x, rect.y);
 #else
 			dc.DrawBitmap(bmp, rect.x, rect.y);
 #endif
@@ -480,13 +476,13 @@ wxSize SAuiTabArt::GetTabSize(
 	int*                  x_extent)
 #else
 wxSize SAuiTabArt::GetTabSize(
-	wxDC&           dc,
-	wxWindow*       WXUNUSED(wnd),
+	wxDC& dc,
+	wxWindow* WXUNUSED(wnd),
 	const wxString& caption,
 	const wxBitmap& bitmap,
-	bool            WXUNUSED(active),
-	int             close_button_state,
-	int*            x_extent)
+	bool WXUNUSED(active),
+	int close_button_state,
+	int* x_extent)
 #endif
 {
 	wxCoord measured_textx, measured_texty, tmp;
@@ -567,7 +563,7 @@ SAuiDockArt::SAuiDockArt()
 	caption_accent_colour_ = wxColor(r, g, b);
 
 	m_activeCloseBitmap   = icons::getInterfaceIcon("cross");
-	m_inactiveCloseBitmap = icons::getInterfaceIcon("cross");//.ConvertToDisabled();
+	m_inactiveCloseBitmap = icons::getInterfaceIcon("cross"); //.ConvertToDisabled();
 
 	if (global::win_version_major >= 10)
 		m_sashBrush = wxBrush(col_w10_bg);
@@ -618,18 +614,16 @@ void SAuiDockArt::DrawCaption(wxDC& dc, wxWindow* window, const wxString& text, 
 	if (icon.IsOk())
 	{
 #if wxCHECK_VERSION(3, 1, 0)
-	    // Ensure the icon fits into the title bar.
-	    wxSize iconSize = icon.GetSize();
-	    if (iconSize.y > rect.height)
-	    {
-	        iconSize *= static_cast<double>(rect.height) / iconSize.y;
-	    }
+		// Ensure the icon fits into the title bar.
+		wxSize iconSize = icon.GetSize();
+		if (iconSize.y > rect.height)
+		{
+			iconSize *= static_cast<double>(rect.height) / iconSize.y;
+		}
 
-	    // Draw the icon centered vertically
-	    int xOffset = window->FromDIP(2);
-	    dc.DrawBitmap(icon,
-	                  rect.x+xOffset, rect.y+(rect.height-icon.GetHeight())/2,
-	                  true);
+		// Draw the icon centered vertically
+		int xOffset = window->FromDIP(2);
+		dc.DrawBitmap(icon, rect.x + xOffset, rect.y + (rect.height - icon.GetHeight()) / 2, true);
 #else
 		DrawIcon(dc, rect, pane);
 #endif
@@ -681,6 +675,7 @@ void SAuiDockArt::DrawPaneButton(
 	wxBitmap bmp;
 #endif
 
+	bool active = true;
 	switch (button)
 	{
 	default:
@@ -688,13 +683,19 @@ void SAuiDockArt::DrawPaneButton(
 		if (pane.state & wxAuiPaneInfo::optionActive)
 			bmp = m_activeCloseBitmap;
 		else
-			bmp = m_inactiveCloseBitmap;
+		{
+			bmp    = m_inactiveCloseBitmap;
+			active = false;
+		}
 		break;
 	case wxAUI_BUTTON_PIN:
 		if (pane.state & wxAuiPaneInfo::optionActive)
 			bmp = m_activePinBitmap;
 		else
-			bmp = m_inactivePinBitmap;
+		{
+			bmp    = m_inactivePinBitmap;
+			active = false;
+		}
 		break;
 	case wxAUI_BUTTON_MAXIMIZE_RESTORE:
 		if (pane.IsMaximized())
@@ -702,14 +703,20 @@ void SAuiDockArt::DrawPaneButton(
 			if (pane.state & wxAuiPaneInfo::optionActive)
 				bmp = m_activeRestoreBitmap;
 			else
-				bmp = m_inactiveRestoreBitmap;
+			{
+				bmp    = m_inactiveRestoreBitmap;
+				active = false;
+			}
 		}
 		else
 		{
 			if (pane.state & wxAuiPaneInfo::optionActive)
 				bmp = m_activeMaximizeBitmap;
 			else
-				bmp = m_inactiveMaximizeBitmap;
+			{
+				bmp    = m_inactiveMaximizeBitmap;
+				active = false;
+			}
 		}
 		break;
 	}
@@ -717,11 +724,11 @@ void SAuiDockArt::DrawPaneButton(
 
 	wxRect rect = _rect;
 
-	int old_y   = rect.y;
+	int old_y = rect.y;
 #if wxCHECK_VERSION(3, 1, 6)
-	rect.y      = rect.y + (rect.height / 2) - (bmp.GetPreferredBitmapSizeFor(window).y / 2);
+	rect.y = rect.y + (rect.height / 2) - (bmp.GetPreferredBitmapSizeFor(window).y / 2);
 #else
-	rect.y      = rect.y + (rect.height / 2) - (bmp.GetHeight() / 2);
+	rect.y = rect.y + (rect.height / 2) - (bmp.GetHeight() / 2);
 #endif
 	rect.height = old_y + rect.height - rect.y - 1;
 
@@ -738,13 +745,15 @@ void SAuiDockArt::DrawPaneButton(
 		dc.SetBrush(wxBrush(drawing::lightColour(drawing::systemPanelBGColour(), 1.0f)));
 		dc.DrawRectangle(rect.x, rect.y, rect.width + 1, rect.width + 1);
 
-		bmp = m_activeCloseBitmap;
+		bmp    = m_activeCloseBitmap;
+		active = true;
 	}
 
 
 	// draw the button itself
 #if wxCHECK_VERSION(3, 1, 6)
-	dc.DrawBitmap(bmp.GetBitmapFor(window), rect.x, rect.y, true);
+	dc.DrawBitmap(
+		active ? bmp.GetBitmapFor(window) : bmp.GetBitmapFor(window).ConvertToDisabled(), rect.x, rect.y, true);
 #else
 	dc.DrawBitmap(bmp, rect.x, rect.y, true);
 #endif

--- a/src/UI/SAuiTabArt.cpp
+++ b/src/UI/SAuiTabArt.cpp
@@ -116,6 +116,12 @@ SAuiTabArt::SAuiTabArt(bool close_buttons, bool main_tabs) :
 {
 	m_normalFont    = *wxNORMAL_FONT;
 	m_selectedFont  = *wxNORMAL_FONT;
+
+#if wxCHECK_VERSION(3, 1, 6) && defined(__WXMSW__)
+	m_normalFont.SetPointSize(ui::scalePx(m_normalFont.GetPointSize()));
+	m_selectedFont.SetPointSize(ui::scalePx(m_selectedFont.GetPointSize()));
+#endif
+
 	m_measuringFont = m_selectedFont;
 	m_fixedTabWidth = ui::scalePx(100);
 	m_tabCtrlHeight = 0;
@@ -131,6 +137,20 @@ SAuiTabArt::SAuiTabArt(bool close_buttons, bool main_tabs) :
 	m_baseColourPen   = wxPen(m_baseColour);
 	m_baseColourBrush = wxBrush(m_baseColour);
 
+#if wxCHECK_VERSION(3, 1, 6)
+	m_activeCloseBmp    = icons::getInterfaceIcon("cross");
+	close_bitmap_white_ = icons::getInterfaceIcon("cross", -1, icons::Dark);
+	m_disabledCloseBmp  = icons::getInterfaceIcon("cross");//.ConvertToDisabled();
+
+	m_activeLeftBmp   = icons::getInterfaceIcon("arrow-left");
+	m_disabledLeftBmp = icons::getInterfaceIcon("arrow-left");//.ConvertToDisabled();
+
+	m_activeRightBmp   = icons::getInterfaceIcon("arrow-right");
+	m_disabledRightBmp = icons::getInterfaceIcon("arrow-right");//.ConvertToDisabled();
+
+	m_activeWindowListBmp   = icons::getInterfaceIcon("arrow-down");
+	m_disabledWindowListBmp = icons::getInterfaceIcon("arrow-down");//.ConvertToDisabled();
+#else
 	m_activeCloseBmp    = icons::getInterfaceIcon("cross");
 	close_bitmap_white_ = icons::getInterfaceIcon("cross", -1, icons::Dark);
 	m_disabledCloseBmp  = icons::getInterfaceIcon("cross").ConvertToDisabled();
@@ -143,6 +163,7 @@ SAuiTabArt::SAuiTabArt(bool close_buttons, bool main_tabs) :
 
 	m_activeWindowListBmp   = icons::getInterfaceIcon("arrow-down");
 	m_disabledWindowListBmp = icons::getInterfaceIcon("arrow-down").ConvertToDisabled();
+#endif
 
 	m_flags = 0;
 }
@@ -368,11 +389,20 @@ void SAuiTabArt::DrawTab(
 	// draw icon if set
 	if (page.bitmap.IsOk())
 	{
+#if wxCHECK_VERSION(3, 1, 6)
+		const auto& bmp = page.bitmap.GetBitmapFor(wnd);
+		dc.DrawBitmap(
+			bmp,
+			tab_x + padding_,
+			drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2),
+			true);
+#else
 		dc.DrawBitmap(
 			page.bitmap,
 			tab_x + padding_,
 			drawn_tab_yoff + (drawn_tab_height / 2) - (page.bitmap.GetHeight() / 2),
 			true);
+#endif
 	}
 
 	// draw tab text
@@ -386,17 +416,21 @@ void SAuiTabArt::DrawTab(
 	// draw close button if necessary
 	if (close_button_state != wxAUI_BUTTON_STATE_HIDDEN)
 	{
-		int close_button_width = m_activeCloseBmp.GetWidth();
-
-		wxBitmap bmp = m_disabledCloseBmp;
-
 		int offsetY = tab_y;
 		if (m_flags & wxAUI_NB_BOTTOM)
 			offsetY = 1;
 
+#if wxCHECK_VERSION(3, 1, 6)
+		int close_button_width = m_activeCloseBmp.GetPreferredBitmapSizeFor(wnd).x;
+		int close_button_height = m_activeCloseBmp.GetPreferredBitmapSizeFor(wnd).y;
+#else
+		int close_button_width = m_activeCloseBmp.GetWidth();
+		int close_button_height = m_activeCloseBmp.GetHeight();
+#endif
+
 		wxRect rect(
 			tab_x + tab_width - close_button_width - padding_,
-			offsetY + (tab_height / 2) - (bmp.GetHeight() / 2),
+			offsetY + (tab_height / 2) - (close_button_height / 2),
 			close_button_width,
 			tab_height);
 
@@ -408,15 +442,23 @@ void SAuiTabArt::DrawTab(
 		{
 			dc.SetPen(wxPen(drawing::darkColour(close_white ? bluetab_colour : bgcol, 2.0f)));
 			dc.SetBrush(wxBrush(drawing::lightColour(close_white ? bluetab_colour : bgcol, 1.0f)));
-			dc.DrawRectangle(rect.x, rect.y + 1, rect.width - 1, rect.width - px2);
+			dc.DrawRectangle(rect.x, rect.y, rect.width, rect.width);
 
-			bmp = close_white ? close_bitmap_white_ : m_activeCloseBmp;
+			const auto& bmp = close_white ? close_bitmap_white_ : m_activeCloseBmp;
+#if wxCHECK_VERSION(3, 1, 6)
+			dc.DrawBitmap(bmp.GetBitmapFor(wnd), rect.x, rect.y);
+#else
 			dc.DrawBitmap(bmp, rect.x, rect.y);
+#endif
 		}
 		else
 		{
-			bmp = close_white ? close_bitmap_white_ : m_disabledCloseBmp;
+			const auto& bmp = close_white ? close_bitmap_white_ : m_disabledCloseBmp;
+#if wxCHECK_VERSION(3, 1, 6)
+			dc.DrawBitmap(bmp.GetBitmapFor(wnd), rect.x, rect.y);
+#else
 			dc.DrawBitmap(bmp, rect.x, rect.y);
+#endif
 		}
 
 		*out_button_rect = rect;
@@ -427,6 +469,16 @@ void SAuiTabArt::DrawTab(
 	dc.DestroyClippingRegion();
 }
 
+#if wxCHECK_VERSION(3, 1, 6)
+wxSize SAuiTabArt::GetTabSize(
+	wxDC&                 dc,
+	wxWindow*             wnd,
+	const wxString&       caption,
+	const wxBitmapBundle& bitmap,
+	bool                  WXUNUSED(active),
+	int                   close_button_state,
+	int*                  x_extent)
+#else
 wxSize SAuiTabArt::GetTabSize(
 	wxDC&           dc,
 	wxWindow*       WXUNUSED(wnd),
@@ -435,6 +487,7 @@ wxSize SAuiTabArt::GetTabSize(
 	bool            WXUNUSED(active),
 	int             close_button_state,
 	int*            x_extent)
+#endif
 {
 	wxCoord measured_textx, measured_texty, tmp;
 
@@ -447,6 +500,21 @@ wxSize SAuiTabArt::GetTabSize(
 	wxCoord tab_width  = measured_textx;
 	wxCoord tab_height = measured_texty;
 
+#if wxCHECK_VERSION(3, 1, 6)
+	// if close buttons are enabled, add space for one
+	if (close_buttons_)
+		tab_width += m_activeCloseBmp.GetPreferredBitmapSizeFor(wnd).x + padding_;
+
+	// if there's a bitmap, add space for it
+	if (bitmap.IsOk())
+	{
+		tab_width += bitmap.GetPreferredBitmapSizeFor(wnd).x;
+		tab_width += padding_; // right side bitmap padding
+		tab_height = wxMax(tab_height, bitmap.GetPreferredBitmapSizeFor(wnd).y);
+	}
+	else if (tabs_condensed)
+		tab_width += (padding_ * 2); // a bit extra padding if there isn't an icon in condensed mode
+#else
 	// if close buttons are enabled, add space for one
 	if (close_buttons_)
 		tab_width += m_activeCloseBmp.GetWidth() + padding_;
@@ -460,6 +528,7 @@ wxSize SAuiTabArt::GetTabSize(
 	}
 	else if (tabs_condensed)
 		tab_width += (padding_ * 2); // a bit extra padding if there isn't an icon in condensed mode
+#endif
 
 	// add padding
 	tab_width += (padding_ * 2);
@@ -498,7 +567,7 @@ SAuiDockArt::SAuiDockArt()
 	caption_accent_colour_ = wxColor(r, g, b);
 
 	m_activeCloseBitmap   = icons::getInterfaceIcon("cross");
-	m_inactiveCloseBitmap = icons::getInterfaceIcon("cross").ConvertToDisabled();
+	m_inactiveCloseBitmap = icons::getInterfaceIcon("cross");//.ConvertToDisabled();
 
 	if (global::win_version_major >= 10)
 		m_sashBrush = wxBrush(col_w10_bg);
@@ -539,12 +608,18 @@ void SAuiDockArt::DrawCaption(wxDC& dc, wxWindow* window, const wxString& text, 
 	dc.SetBrush(wxBrush(sepCol));
 	dc.DrawRectangle(rect.x, rect.y, rect.width, rect.height + 1);
 
+#if wxCHECK_VERSION(3, 1, 6)
+	const auto& icon = pane.icon.GetBitmap(wxDefaultSize);
+#else
+	const auto& icon = pane.icon;
+#endif
+
 	int caption_offset = 0;
-	if (pane.icon.IsOk())
+	if (icon.IsOk())
 	{
-#if wxMAJOR_VERSION >= 3 && wxMINOR_VERSION >= 1
+#if wxCHECK_VERSION(3, 1, 0)
 	    // Ensure the icon fits into the title bar.
-	    wxSize iconSize = pane.icon.GetSize();
+	    wxSize iconSize = icon.GetSize();
 	    if (iconSize.y > rect.height)
 	    {
 	        iconSize *= static_cast<double>(rect.height) / iconSize.y;
@@ -552,13 +627,13 @@ void SAuiDockArt::DrawCaption(wxDC& dc, wxWindow* window, const wxString& text, 
 
 	    // Draw the icon centered vertically
 	    int xOffset = window->FromDIP(2);
-	    dc.DrawBitmap(pane.icon,
-	                  rect.x+xOffset, rect.y+(rect.height-pane.icon.GetHeight())/2,
+	    dc.DrawBitmap(icon,
+	                  rect.x+xOffset, rect.y+(rect.height-icon.GetHeight())/2,
 	                  true);
 #else
 		DrawIcon(dc, rect, pane);
 #endif
-		caption_offset += pane.icon.GetWidth() + px3;
+		caption_offset += icon.GetWidth() + px3;
 	}
 
 	dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
@@ -594,13 +669,18 @@ void SAuiDockArt::DrawCaption(wxDC& dc, wxWindow* window, const wxString& text, 
 
 void SAuiDockArt::DrawPaneButton(
 	wxDC&          dc,
-	wxWindow*      WXUNUSED(window),
+	wxWindow*      window,
 	int            button,
 	int            button_state,
 	const wxRect&  _rect,
 	wxAuiPaneInfo& pane)
 {
+#if wxCHECK_VERSION(3, 1, 6)
+	wxBitmapBundle bmp;
+#else
 	wxBitmap bmp;
+#endif
+
 	switch (button)
 	{
 	default:
@@ -638,7 +718,11 @@ void SAuiDockArt::DrawPaneButton(
 	wxRect rect = _rect;
 
 	int old_y   = rect.y;
+#if wxCHECK_VERSION(3, 1, 6)
+	rect.y      = rect.y + (rect.height / 2) - (bmp.GetPreferredBitmapSizeFor(window).y / 2);
+#else
 	rect.y      = rect.y + (rect.height / 2) - (bmp.GetHeight() / 2);
+#endif
 	rect.height = old_y + rect.height - rect.y - 1;
 
 
@@ -659,5 +743,9 @@ void SAuiDockArt::DrawPaneButton(
 
 
 	// draw the button itself
+#if wxCHECK_VERSION(3, 1, 6)
+	dc.DrawBitmap(bmp.GetBitmapFor(window), rect.x, rect.y, true);
+#else
 	dc.DrawBitmap(bmp, rect.x, rect.y, true);
+#endif
 }

--- a/src/UI/SAuiTabArt.h
+++ b/src/UI/SAuiTabArt.h
@@ -49,6 +49,16 @@ public:
 		wxRect*                  outButtonRect,
 		int*                     xExtent) override;
 
+#if wxCHECK_VERSION(3, 1, 6)
+	wxSize GetTabSize(
+		wxDC&                 dc,
+		wxWindow*             wnd,
+		const wxString&       caption,
+		const wxBitmapBundle& bitmap,
+		bool                  active,
+		int                   closeButtonState,
+		int*                  xExtent) override;
+#else
 	wxSize GetTabSize(
 		wxDC&           dc,
 		wxWindow*       wnd,
@@ -57,6 +67,7 @@ public:
 		bool            active,
 		int             closeButtonState,
 		int*            xExtent) override;
+#endif
 
 	int GetIndentSize() override { return 2; }
 
@@ -65,7 +76,12 @@ protected:
 	wxColour inactive_tab_colour_;
 	bool     main_tabs_;
 	int      padding_;
+
+#if wxCHECK_VERSION(3, 1, 6)
+	wxBitmapBundle close_bitmap_white_;
+#else
 	wxBitmap close_bitmap_white_;
+#endif
 };
 
 class SAuiDockArt : public wxAuiDefaultDockArt

--- a/src/UI/SToolBar/SToolBarButton.cpp
+++ b/src/UI/SToolBar/SToolBarButton.cpp
@@ -353,7 +353,13 @@ void SToolBarButton::onPaint(wxPaintEvent& e)
 		gc->DrawRoundedRectangle(pad_outer_, pad_outer_, width, height, ui::scalePxU(1));
 	}
 
-	if (icon_.IsOk())
+#if wxCHECK_VERSION(3, 1, 6)
+	auto icon = icon_.GetBitmap(wxDefaultSize);
+#else
+	const auto& icon = icon_;
+#endif
+
+	if (icon.IsOk())
 	{
 		// Draw disabled icon if disabled
 		if (!IsEnabled())
@@ -367,12 +373,12 @@ void SToolBarButton::onPaint(wxPaintEvent& e)
 
 			// Draw disabled icon
 			gc->DrawBitmap(
-				icon_.ConvertToDisabled(r), pad_outer_ + pad_inner_, pad_outer_ + pad_inner_, icon_size_, icon_size_);
+				icon.ConvertToDisabled(r), pad_outer_ + pad_inner_, pad_outer_ + pad_inner_, icon_size_, icon_size_);
 		}
 
 		// Otherwise draw normal icon
 		else
-			gc->DrawBitmap(icon_, pad_outer_ + pad_inner_, pad_outer_ + pad_inner_, icon_size_, icon_size_);
+			gc->DrawBitmap(icon, pad_outer_ + pad_inner_, pad_outer_ + pad_inner_, icon_size_, icon_size_);
 	}
 
 	if (show_name_)
@@ -384,7 +390,11 @@ void SToolBarButton::onPaint(wxPaintEvent& e)
 
 	if (menu_dropdown_)
 	{
+#if wxCHECK_VERSION(3, 1, 6)
+		static auto arrow_down = icons::getInterfaceIcon("arrow-down", icon_size_ * 0.75).GetBitmap(wxDefaultSize);
+#else
 		static auto arrow_down = icons::getInterfaceIcon("arrow-down", icon_size_ * 0.75);
+#endif
 
 		gc->DrawBitmap(
 			arrow_down,

--- a/src/UI/SToolBar/SToolBarButton.h
+++ b/src/UI/SToolBar/SToolBarButton.h
@@ -40,10 +40,14 @@ private:
 	};
 
 	SAction* action_ = nullptr;
+#if wxCHECK_VERSION(3, 1, 6)
+	wxBitmapBundle icon_;
+#else
 	wxBitmap icon_;
-	State    state_         = State::Normal;
-	bool     show_name_     = false;
-	wxMenu*  menu_dropdown_ = nullptr;
+#endif
+	State   state_         = State::Normal;
+	bool    show_name_     = false;
+	wxMenu* menu_dropdown_ = nullptr;
 
 	// For non-SAction buttons
 	wxString action_id_;

--- a/src/UI/WxUtils.cpp
+++ b/src/UI/WxUtils.cpp
@@ -103,6 +103,18 @@ wxImageList* wxutil::createSmallImageList()
 }
 
 // -----------------------------------------------------------------------------
+// Adds [icon] of [icon_type] to the given image [list]
+// -----------------------------------------------------------------------------
+int wxutil::addImageListIcon(wxImageList* list, int icon_type, string_view icon)
+{
+#if wxCHECK_VERSION(3, 1, 6)
+	return list->Add(icons::getIcon(static_cast<icons::Type>(icon_type), icon).GetBitmap(list->GetSize()));
+#else
+	return list->Add(icons::getIcon(static_cast<icons::Type>(icon_type), icon));
+#endif
+}
+
+// -----------------------------------------------------------------------------
 // Creates a wxPanel and places [control] on it, with [pad] padding around it
 // -----------------------------------------------------------------------------
 wxPanel* wxutil::createPadPanel(wxWindow* parent, wxWindow* control, int pad)
@@ -343,8 +355,13 @@ wxRect wxutil::scaledRect(int x, int y, int width, int height)
 // -----------------------------------------------------------------------------
 void wxutil::setWindowIcon(wxTopLevelWindow* window, string_view icon)
 {
+#if wxCHECK_VERSION(3, 1, 6)
+	auto wx_icon = icons::getIcon(icons::General, icon).GetIconFor(window);
+#else
 	wxIcon wx_icon;
 	wx_icon.CopyFromBitmap(icons::getIcon(icons::General, icon));
+#endif
+
 	window->SetIcon(wx_icon);
 }
 

--- a/src/UI/WxUtils.h
+++ b/src/UI/WxUtils.h
@@ -12,6 +12,7 @@ wxMenuItem* createMenuItem(
 	const wxString& icon = wxEmptyString);
 wxFont       monospaceFont(wxFont base);
 wxImageList* createSmallImageList();
+int          addImageListIcon(wxImageList* list, int icon_type, string_view icon);
 wxPanel*     createPadPanel(wxWindow* parent, wxWindow* control, int pad = -1);
 wxSpinCtrl*  createSpinCtrl(wxWindow* parent, int value, int min, int max);
 


### PR DESCRIPTION
Whew, what a mess.

wx3.1.6 introduces wxBitmapBundle and a bunch of its own DPI handling, which completely broke a bunch of SLADE's custom handling.

Luckily it mostly seems limited to icon/image stuff, so changing getIcon to return a wxBitmapBundle and updating code to work with that seems to work for most things from what I can tell.

Resolves #1341 