### PR TITLE
[3d_floors_eevee_adapted] Fix editing of 3d floors properties not being correctly forwarded to the control sector

### DIFF
--- a/src/MapEditor/MapEditor.cpp
+++ b/src/MapEditor/MapEditor.cpp
@@ -103,7 +103,7 @@ MapSide* mapeditor::Item::asSide(const SLADEMap& map) const
 {
 	if (type == ItemType::Side || type == ItemType::WallBottom || type == ItemType::WallMiddle
 		|| type == ItemType::WallTop)
-		return real_index >= 0 ? map.side(real_index) : map.side(index);
+		return map.side(index);
 
 	return nullptr;
 }
@@ -115,7 +115,7 @@ MapSide* mapeditor::Item::asSide(const SLADEMap& map) const
 MapSector* mapeditor::Item::asSector(const SLADEMap& map) const
 {
 	if (type == ItemType::Sector || type == ItemType::Ceiling || type == ItemType::Floor)
-		return real_index >= 0 ? map.sector(real_index) : map.sector(index);
+		return map.sector(index);
 
 	return nullptr;
 }

--- a/src/MapEditor/Renderer/MapRenderer3D.cpp
+++ b/src/MapEditor/Renderer/MapRenderer3D.cpp
@@ -278,7 +278,7 @@ MapRenderer3D::Quad* MapRenderer3D::getQuad(mapeditor::Item item)
 		return nullptr;
 
 	// Get side
-	auto side = item.asSide(*map_);
+	auto side = map_->side(item.real_index >= 0 ? item.real_index : item.index);
 	if (!side)
 		return nullptr;
 
@@ -1357,7 +1357,7 @@ void MapRenderer3D::renderFlatSelection(const ItemSelection& selection, float al
 			continue;
 
 		// Get sector
-		auto sector = item.asSector(*map_);
+		auto sector = map_->sector(item.real_index >= 0 ? item.real_index : item.index);
 		if (!sector)
 			return;
 
@@ -2341,7 +2341,7 @@ void MapRenderer3D::renderWallSelection(const ItemSelection& selection, float al
 			continue;
 
 		// Get side
-		auto side = item.asSide(*map_);
+		auto side = map_->side(item.real_index >= 0 ? item.real_index : item.index);
 		if (!side)
 			continue;
 
@@ -3388,7 +3388,7 @@ void MapRenderer3D::renderHilight(mapeditor::Item hilight, float alpha)
 		|| hilight.type == mapeditor::ItemType::WallTop /*|| hilight.type == MapEditor::ItemType::Wall3DFloor*/)
 	{
 		// Get side
-		auto side = hilight.asSide(*map_);
+		auto side = map_->side(hilight.real_index >= 0 ? hilight.real_index : hilight.index);
 		if (!side)
 			return;
 
@@ -3464,7 +3464,7 @@ void MapRenderer3D::renderHilight(mapeditor::Item hilight, float alpha)
 	if (hilight.type == mapeditor::ItemType::Floor || hilight.type == mapeditor::ItemType::Ceiling)
 	{
 		// Get sector
-		auto sector = hilight.asSector(*map_);
+		auto sector = map_->sector(hilight.real_index >= 0 ? hilight.real_index : hilight.index);
 		if (!sector)
 			return;
 


### PR DESCRIPTION
It was actually being forwarded to the target sector from the control sector, causing ambiguous issues like when you changing the 3d floor height/textures you were changing the ones in the sector it was over instead.