### PR TITLE
Some more zdoom texture managment tools

### DIFF
--- a/dist/res/actions/arch.cfg
+++ b/dist/res/actions/arch.cfg
@@ -76,6 +76,18 @@ action arch_clean_zdoom_textures
 	help_text	= "Remove any unused textures, flats, and patches in a zdoom archive.";
 }
 
+action arch_check_zdoom_texture_duplicates
+{
+    text        = "Check Duplicate &Zdoom Texture Entry Names";
+    help_text    = "Checks the archive for any textures/flats/texture definitions in a zdoom archive.";
+}
+
+action arch_check_zdoom_patch_duplicates
+{
+    text        = "Check Duplicate &Zdoom Patch Entry Names";
+    help_text    = "Checks the archive for any patches and patch table entries in a zdoom archive.";
+}
+
 action arch_check_duplicates
 {
 	text		= "Check Duplicate Entry Names";

--- a/dist/res/actions/arch.cfg
+++ b/dist/res/actions/arch.cfg
@@ -72,20 +72,20 @@ action arch_clean_flats
 
 action arch_clean_zdoom_textures
 {
-	text		= "Remove Unused &Zdoom Textures";
-	help_text	= "Remove any unused textures, flats, and patches in a zdoom archive.";
+	text		= "Remove Unused &ZDoom Textures";
+	help_text	= "Remove any unused textures, flats, and patches in a ZDoom archive.";
 }
 
 action arch_check_zdoom_texture_duplicates
 {
-    text        = "Check Duplicate &Zdoom Texture Entry Names";
-    help_text    = "Checks the archive for any textures/flats/texture definitions in a zdoom archive.";
+    text        = "Check Duplicate &ZDoom Texture Entry Names";
+    help_text    = "Checks the archive for any duplicate textures/flats/texture definitions in a ZDoom archive.";
 }
 
 action arch_check_zdoom_patch_duplicates
 {
-    text        = "Check Duplicate &Zdoom Patch Entry Names";
-    help_text    = "Checks the archive for any patches and patch table entries in a zdoom archive.";
+    text        = "Check Duplicate &ZDoom Patch Entry Names";
+    help_text    = "Checks the archive for any duplicate patches and patch table entries in a ZDoom archive.";
 }
 
 action arch_check_duplicates

--- a/src/MainEditor/ArchiveOperations.cpp
+++ b/src/MainEditor/ArchiveOperations.cpp
@@ -1484,7 +1484,8 @@ bool archiveoperations::checkDuplicateZDoomTextures(Archive* archive)
 
 			auto texture = texture_list.texture(texture_index);
 
-			string texture_name = strutil::upperIP(string(texture->name()));
+			string texture_name = string(texture->name());
+			texture_name = strutil::upperIP(texture_name);
 
 			if (found_entries.find(texture_name) != found_entries.end())
 			{
@@ -1594,7 +1595,8 @@ bool archiveoperations::checkDuplicateZDoomPatches(Archive* archive)
 
 		for (const PatchTable::Patch& patch_entry : ptable.patches())
 		{
-			string entry_name = strutil::upperIP(string(patch_entry.name));
+			string entry_name = string(patch_entry.name);
+			entry_name = strutil::upperIP(entry_name);
 
 			if (found_entries.find(entry_name) != found_entries.end())
 			{

--- a/src/MainEditor/ArchiveOperations.cpp
+++ b/src/MainEditor/ArchiveOperations.cpp
@@ -1449,6 +1449,214 @@ void archiveoperations::removeUnusedZDoomTextures(Archive* archive)
 	app::archiveManager().closeArchive(archive);
 }
 
+bool archiveoperations::checkDuplicateZDoomTextures(Archive* archive) 
+{
+	std::unordered_multimap<string, ArchiveEntry*> found_entries;
+	std::set<string> found_duplicates;
+
+	auto process_entries = [&found_entries, &found_duplicates](const vector<ArchiveEntry*> archive_entries)
+	{
+		for (auto& archive_entry : archive_entries)
+		{
+			// Skip markers
+			if (archive_entry->size() == 0)
+				continue;
+
+			string entry_name{archive_entry->upperNameNoExt()};
+
+			if (found_entries.find(entry_name) != found_entries.end())
+			{
+				found_duplicates.insert(entry_name);
+			}
+
+			found_entries.emplace(entry_name, archive_entry);
+		}
+	};
+
+	auto process_texture_list = [&found_entries, &found_duplicates](
+									ArchiveEntry* texture_archive_entry, TextureXList& texture_list)
+	{
+		for (unsigned texture_index = 0; texture_index < texture_list.size(); texture_index++)
+		{
+			// Skip markers
+			if (texture_archive_entry->size() == 0)
+				continue;
+
+			auto texture = texture_list.texture(texture_index);
+
+			string texture_name = strutil::upperIP(string(texture->name()));
+
+			if (found_entries.find(texture_name) != found_entries.end())
+			{
+				found_duplicates.insert(texture_name);
+			}
+
+			found_entries.emplace(texture_name, texture_archive_entry);
+		}
+	};
+
+	// Find all textures
+	{ 
+		Archive::SearchOptions search_opt;
+		search_opt.match_namespace = "textures";
+		process_entries(archive->findAll(search_opt));
+	}
+
+	// Find all flats
+	{
+		Archive::SearchOptions search_opt;
+		search_opt.match_namespace = "flats";
+		process_entries(archive->findAll(search_opt));
+	}
+
+	Archive::SearchOptions pnames_opt;
+	pnames_opt.match_type = EntryType::fromId("pnames");
+	auto pnames           = archive->findLast(pnames_opt);
+
+	// Load patch table	
+	if (pnames)
+	{
+		PatchTable ptable;
+		ptable.loadPNAMES(pnames);
+
+		// Load all Texturex entries
+		Archive::SearchOptions texturexopt;
+		texturexopt.match_type = EntryType::fromId("texturex");
+
+		for (ArchiveEntry* texturexentry : archive->findAll(texturexopt))
+		{
+			TextureXList texture_list;
+			texture_list.readTEXTUREXData(texturexentry, ptable, true);
+
+			process_texture_list(texturexentry, texture_list);
+		}
+	}
+
+	// Load all zdtextures entries
+	{
+		Archive::SearchOptions zdtexturesopt;
+		zdtexturesopt.match_type = EntryType::fromId("zdtextures");
+
+		for (ArchiveEntry* texturesentry : archive->findAll(zdtexturesopt))
+		{
+			TextureXList texture_list;
+			texture_list.readTEXTURESData(texturesentry);
+
+			process_texture_list(texturesentry, texture_list);
+		}
+	}
+
+	if (found_duplicates.empty()) 
+	{
+		wxMessageBox("No duplicated textures exist");
+		return false;
+	}
+
+	wxString dups = "";
+
+	for (string duplicate_entry : found_duplicates) 
+	{
+		dups += wxString::Format("\n%s", duplicate_entry);
+
+		auto duplicated_entries_range = found_entries.equal_range(duplicate_entry);
+
+		for (auto entry_iter = duplicated_entries_range.first; entry_iter != duplicated_entries_range.second;
+			 ++entry_iter) 
+		{
+			ArchiveEntry* duplicated_entry = entry_iter->second;
+			dups += wxString::Format("\n\t%s%s", duplicated_entry->path(), duplicated_entry->name());
+		}
+	}
+
+	// Display list of duplicate entry names
+	ExtMessageDialog msg(theMainWindow, "Duplicate Entries");
+	msg.setExt(dups);
+	msg.setMessage("The following entry data are duplicated:");
+	msg.ShowModal();
+
+	return true;
+}
+
+bool archiveoperations::checkDuplicateZDoomPatches(Archive* archive)
+{
+	std::unordered_multimap<string, ArchiveEntry*> found_entries;
+	std::set<string>                               found_duplicates;
+
+	Archive::SearchOptions pnames_opt;
+	pnames_opt.match_type = EntryType::fromId("pnames");
+	auto pnames           = archive->findLast(pnames_opt);
+
+	// Load patch table
+	if (pnames)
+	{
+		PatchTable ptable;
+		ptable.loadPNAMES(pnames);
+
+		for (const PatchTable::Patch& patch_entry : ptable.patches())
+		{
+			string entry_name = strutil::upperIP(string(patch_entry.name));
+
+			if (found_entries.find(entry_name) != found_entries.end())
+			{
+				found_duplicates.insert(entry_name);
+			}
+
+			found_entries.emplace(entry_name, pnames);
+		}
+	}
+
+	// Find all patches
+	{
+		Archive::SearchOptions search_opt;
+		search_opt.match_namespace = "patches";
+
+		for (auto& archive_entry : archive->findAll(search_opt))
+		{
+			// Skip markers
+			if (archive_entry->size() == 0)
+				continue;
+
+			string entry_name{ archive_entry->upperNameNoExt() };
+
+			if (found_entries.find(entry_name) != found_entries.end())
+			{
+				found_duplicates.insert(entry_name);
+			}
+
+			found_entries.emplace(entry_name, archive_entry);
+		}
+	}
+
+	if (found_duplicates.empty())
+	{
+		wxMessageBox("No duplicated textures exist");
+		return false;
+	}
+
+	wxString dups = "";
+
+	for (string duplicate_entry : found_duplicates)
+	{
+		dups += wxString::Format("\n%s", duplicate_entry);
+
+		auto duplicated_entries_range = found_entries.equal_range(duplicate_entry);
+
+		for (auto entry_iter = duplicated_entries_range.first; entry_iter != duplicated_entries_range.second;
+			 ++entry_iter)
+		{
+			ArchiveEntry* duplicated_entry = entry_iter->second;
+			dups += wxString::Format("\n\t%s%s", duplicated_entry->path(), duplicated_entry->name());
+		}
+	}
+
+	// Display list of duplicate entry names
+	ExtMessageDialog msg(theMainWindow, "Duplicate Entries");
+	msg.setExt(dups);
+	msg.setMessage("The following entry data are duplicated:");
+	msg.ShowModal();
+
+	return true;
+}
 
 CONSOLE_COMMAND(test_cleantex, 0, false)
 {

--- a/src/MainEditor/ArchiveOperations.cpp
+++ b/src/MainEditor/ArchiveOperations.cpp
@@ -1632,7 +1632,7 @@ bool archiveoperations::checkDuplicateZDoomPatches(Archive* archive)
 
 	if (found_duplicates.empty())
 	{
-		wxMessageBox("No duplicated textures exist");
+		wxMessageBox("No duplicated patches exist");
 		return false;
 	}
 

--- a/src/MainEditor/ArchiveOperations.h
+++ b/src/MainEditor/ArchiveOperations.h
@@ -13,6 +13,8 @@ bool checkDuplicateEntryContent(const Archive* archive);
 void removeUnusedTextures(Archive* archive);
 void removeUnusedFlats(Archive* archive);
 void removeUnusedZDoomTextures(Archive* archive);
+bool checkDuplicateZDoomTextures(Archive* archive);
+bool checkDuplicateZDoomPatches(Archive* archive);
 void removeEntriesUnchangedFromIWAD(Archive* archive);
 
 // Search and replace in maps

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -3188,6 +3188,12 @@ bool ArchivePanel::handleAction(string_view id)
 	else if (id == "arch_check_duplicates2")
 		archiveoperations::checkDuplicateEntryContent(archive.get());
 
+	else if (id == "arch_check_zdoom_texture_duplicates")
+		archiveoperations::checkDuplicateZDoomTextures(archive.get());
+
+	else if (id == "arch_check_zdoom_patch_duplicates")
+		archiveoperations::checkDuplicateZDoomPatches(archive.get());
+
 	// Archive->Maintenance->Check Duplicate Entry Names
 	else if (id == "arch_clean_iwaddupes")
 		archiveoperations::removeEntriesUnchangedFromIWAD(archive.get());
@@ -3438,6 +3444,8 @@ wxMenu* ArchivePanel::createMaintenanceMenu()
 	SAction::fromId("arch_clean_iwaddupes")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_duplicates")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_duplicates2")->addToMenu(menu_clean);
+	SAction::fromId("arch_check_zdoom_texture_duplicates")->addToMenu(menu_clean);
+	SAction::fromId("arch_check_zdoom_patch_duplicates")->addToMenu(menu_clean);
 	SAction::fromId("arch_replace_maps")->addToMenu(menu_clean);
 	return menu_clean;
 }


### PR DESCRIPTION
Added some tools to find duplicate texture and patch entries in zdoom.  This will help manage large texture packs.  It'll check across Texture entries, texture files themselves, and flats.  The patch tool will detect duplicate patch names across the ptable and all the patch files that can exist in an archive.

Other types of duplicate entries should be easy to detect using the existing find duplicate named entries tool.