### PR TITLE
For the purpose of syntax highlighting, recognize files in `modeldefs…

### DIFF
--- a/dist/res/config/entry_types/types_text.txt
+++ b/dist/res/config/entry_types/types_text.txt
@@ -208,6 +208,13 @@ entry_types
 		text_language = "z_modeldef";
 	}
 
+	modeldefs_ns : text
+	{
+		name = "3D model defs";
+		section = "modeldefs";
+		text_language = "z_modeldef";
+	}
+
 	voxeldefs : text
 	{
 		name = "Voxel defs";
@@ -307,6 +314,14 @@ entry_types
 	{
 		name = "Texture definitions";
 		match_name = "textures", "hirestex";
+		icon = "e_texturex";
+		text_language = "z_textures";
+	}
+
+	zdtextures_ns : text
+	{
+		name = "Texture definitions";
+		section = "texturedefs";
 		icon = "e_texturex";
 		text_language = "z_textures";
 	}


### PR DESCRIPTION
…/` and `texturedef/` directories as MODELDEF and TEXTURES, respectively.

Support for includes in both [MODELDEF](https://github.com/coelckers/gzdoom/blob/g4.8.0/src/r_data/models.cpp#L725-L739) and [TEXTURES](https://github.com/coelckers/gzdoom/blob/g4.8.0/src/common/textures/texturemanager.cpp#L850-L864) has been there since GZDoom 3.4.0.