### PR TITLE
Add support for Doom 32X map format

### DIFF
--- a/msvc/SLADE.vcxproj
+++ b/msvc/SLADE.vcxproj
@@ -327,6 +327,7 @@
     <ClCompile Include="..\src\Scripting\Export\Graphics.cpp" />
     <ClCompile Include="..\src\Scripting\Export\MapEditor.cpp" />
     <ClCompile Include="..\src\Scripting\Export\UI.cpp" />
+    <ClCompile Include="..\src\SLADEMap\MapFormat\Doom32XMapFormat.cpp" />
     <ClCompile Include="..\src\UI\Controls\Splitter.cpp" />
     <ClCompile Include="..\src\UI\Controls\ZoomControl.cpp" />
     <ClCompile Include="..\src\UI\Dialogs\DirArchiveUpdateDialog.cpp" />
@@ -690,6 +691,7 @@
     <ClInclude Include="..\src\Graphics\Graphics.h" />
     <ClInclude Include="..\src\OpenGL\View.h" />
     <ClInclude Include="..\src\Scripting\Export\Export.h" />
+    <ClInclude Include="..\src\SLADEMap\MapFormat\Doom32XMapFormat.h" />
     <ClInclude Include="..\src\UI\Controls\Splitter.h" />
     <ClInclude Include="..\src\UI\Controls\ZoomControl.h" />
     <ClInclude Include="..\src\UI\Dialogs\DirArchiveUpdateDialog.h" />

--- a/msvc/SLADE.vcxproj.filters
+++ b/msvc/SLADE.vcxproj.filters
@@ -1011,6 +1011,9 @@
     <ClCompile Include="..\src\OpenGL\View.cpp">
       <Filter>OpenGL</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\SLADEMap\MapFormat\Doom32XMapFormat.cpp">
+      <Filter>SLADEMap\MapFormat</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\thirdparty\zreaders\files.h">
@@ -1933,6 +1936,9 @@
     </ClInclude>
     <ClInclude Include="..\src\OpenGL\View.h">
       <Filter>OpenGL</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\SLADEMap\MapFormat\Doom32XMapFormat.h">
+      <Filter>SLADEMap\MapFormat</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/Archive/Archive.cpp
+++ b/src/Archive/Archive.cpp
@@ -330,6 +330,7 @@ void Archive::MapDesc::updateMapFormatHints() const
 	case MapFormat::Hexen: fmt_name = "hexen"; break;
 	case MapFormat::Doom64: fmt_name = "doom64"; break;
 	case MapFormat::UDMF: fmt_name = "udmf"; break;
+	case MapFormat::Doom32X: fmt_name = "doom32x"; break;
 	case MapFormat::Unknown:
 	default: fmt_name = "unknown"; break;
 	}

--- a/src/Archive/Formats/WadArchive.cpp
+++ b/src/Archive/Formats/WadArchive.cpp
@@ -81,6 +81,7 @@ string map_lumps[] = { "THINGS",   "VERTEXES", "LINEDEFS", "SIDEDEFS", "SECTORS"
 					   "BLOCKMAP", "REJECT",   "SCRIPTS",  "BEHAVIOR", "LEAFS",   "LIGHTS",  "MACROS",   "GL_MAP01",
 					   "GL_VERT",  "GL_SEGS",  "GL_SSECT", "GL_NODES", "GL_PVS",  "TEXTMAP", "ZNODES" };
 
+
 // Special namespaces (at the moment these are just mapping to zdoom's "zip as wad" namespace folders)
 // http://zdoom.org/wiki/Using_ZIPs_as_WAD_replacement#How_to
 struct SpecialNS
@@ -1002,7 +1003,15 @@ Archive::MapDesc WadArchive::mapDesc(ArchiveEntry* maphead)
 		map.format = MapFormat::Doom64;
 	// Otherwise it's doom format
 	else
-		map.format = MapFormat::Doom;
+	{
+		Archive::SearchOptions opt;
+		opt.match_name = "playpals";
+		auto match     = findFirst(opt);
+		if (match)
+			map.format = MapFormat::Doom32X;
+		else
+			map.format = MapFormat::Doom;
+	}
 
 	return map;
 }
@@ -1019,6 +1028,14 @@ vector<Archive::MapDesc> WadArchive::detectMaps()
 	auto entry_count         = numEntries();
 	auto entry               = rootDir()->sharedEntryAt(index);
 	bool lastentryismapentry = false;
+	bool playpals            = false;
+
+	Archive::SearchOptions opt;
+	opt.match_name = "playpals";
+	auto match     = findFirst(opt);
+	if (match)
+		playpals = true;
+
 	while (entry)
 	{
 		// UDMF format map check ********************************************************
@@ -1122,6 +1139,8 @@ vector<Archive::MapDesc> WadArchive::detectMaps()
 					existing_map_lumps[LUMP_LEAFS] && existing_map_lumps[LUMP_LIGHTS]
 					&& existing_map_lumps[LUMP_MACROS])
 					md.format = MapFormat::Doom64;
+				else if (playpals)
+					md.format = MapFormat::Doom32X;
 				// Otherwise it's doom format
 				else
 					md.format = MapFormat::Doom;

--- a/src/Game/Configuration.cpp
+++ b/src/Game/Configuration.cpp
@@ -346,6 +346,10 @@ void Configuration::readGameSection(ParseTreeNode* node_game, bool port_section)
 				{
 					map_formats_[MapFormat::Doom64] = true;
 				}
+				else if (strutil::equalCI(node->stringValue(v), "doom32x"))
+				{
+					map_formats_[MapFormat::Doom32X] = true;
+				}
 				else if (strutil::equalCI(node->stringValue(v), "udmf"))
 				{
 					map_formats_[MapFormat::UDMF] = true;
@@ -551,6 +555,7 @@ bool Configuration::readConfiguration(
 	case MapFormat::Doom: parser.define("MAP_DOOM"); break;
 	case MapFormat::Hexen: parser.define("MAP_HEXEN"); break;
 	case MapFormat::Doom64: parser.define("MAP_DOOM64"); break;
+	case MapFormat::Doom32X: parser.define("MAP_DOOM32X"); break;
 	case MapFormat::UDMF: parser.define("MAP_UDMF"); break;
 	default: parser.define("MAP_UNKNOWN"); break;
 	}

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -116,6 +116,8 @@ bool GameDef::parse(MemChunk& mc)
 					supported_formats[MapFormat::Hexen] = true;
 				else if (strutil::equalCI(str_val, "doom64"))
 					supported_formats[MapFormat::Doom64] = true;
+				else if (strutil::equalCI(str_val, "doom32x"))
+					supported_formats[MapFormat::Doom32X] = true;
 				else if (strutil::equalCI(str_val, "udmf"))
 					supported_formats[MapFormat::UDMF] = true;
 			}
@@ -202,6 +204,8 @@ bool PortDef::parse(MemChunk& mc)
 					supported_formats[MapFormat::Hexen] = true;
 				else if (strutil::equalCI(str_val, "doom64"))
 					supported_formats[MapFormat::Doom64] = true;
+				else if (strutil::equalCI(str_val, "doom32x"))
+					supported_formats[MapFormat::Doom32X] = true;
 				else if (strutil::equalCI(str_val, "udmf"))
 					supported_formats[MapFormat::UDMF] = true;
 			}

--- a/src/General/Defs.h
+++ b/src/General/Defs.h
@@ -11,6 +11,7 @@ enum class MapFormat
 	Hexen,
 	Doom64,
 	UDMF,
+	Doom32X,
 	Unknown, // Needed for maps in zip archives
 };
 }

--- a/src/MainEditor/ArchiveOperations.cpp
+++ b/src/MainEditor/ArchiveOperations.cpp
@@ -43,6 +43,7 @@
 #include "SLADEMap/MapFormat/Doom64MapFormat.h"
 #include "SLADEMap/MapFormat/DoomMapFormat.h"
 #include "SLADEMap/MapFormat/HexenMapFormat.h"
+#include "SLADEMap/MapFormat/Doom32XMapFormat.h"
 #include "SLADEMap/MapObject/MapSector.h"
 #include "UI/Dialogs/ExtMessageDialog.h"
 #include "UI/WxUtils.h"

--- a/src/MainEditor/UI/EntryPanel/DataEntryPanel.h
+++ b/src/MainEditor/UI/EntryPanel/DataEntryPanel.h
@@ -14,6 +14,8 @@ public:
 	{
 		IntSigned,
 		IntUnsigned,
+		IntBESigned,
+		IntBEUnsigned,
 		Fixed,
 		String,
 		Boolean,

--- a/src/SLADEMap/MapFormat/Doom32XMapFormat.cpp
+++ b/src/SLADEMap/MapFormat/Doom32XMapFormat.cpp
@@ -1,0 +1,83 @@
+
+// -----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2022 Simon Judd, Victor Luchits
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    DoomMapFormat.cpp
+// Description: MapFormatHandler specialization to handle Doom format maps
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// -----------------------------------------------------------------------------
+
+
+// -----------------------------------------------------------------------------
+//
+// Includes
+//
+// -----------------------------------------------------------------------------
+#include "Main.h"
+#include "Doom32XMapFormat.h"
+#include "General/UI.h"
+#include "SLADEMap/MapObject/MapLine.h"
+#include "SLADEMap/MapObject/MapSector.h"
+#include "SLADEMap/MapObject/MapVertex.h"
+#include "SLADEMap/MapObjectCollection.h"
+#include "Utility/StringUtils.h"
+
+using namespace slade;
+
+
+// -----------------------------------------------------------------------------
+//
+// Doom32XMapFormat Class Functions
+//
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+// Reads Doom32X-format VERTEXES data from [entry] into [map_data]
+// -----------------------------------------------------------------------------
+bool Doom32XMapFormat::readVERTEXES(ArchiveEntry* entry, MapObjectCollection& map_data) const
+{
+	if (!entry)
+	{
+		global::error = "Map has no VERTEXES entry!";
+		log::info(global::error);
+		return false;
+	}
+
+	// Check for empty entry
+	if (entry->size() < sizeof(Vertex32BE))
+	{
+		log::info(3, "Read 0 vertices");
+		return true;
+	}
+
+	auto     vert_data = (Vertex32BE*)entry->rawData(true);
+	unsigned nv        = entry->size() / sizeof(Vertex32BE);
+	float    p         = ui::getSplashProgress();
+	for (size_t a = 0; a < nv; a++)
+	{
+		ui::setSplashProgress(p + ((float)a / nv) * 0.2f);
+		map_data.addVertex(std::make_unique<MapVertex>(Vec2d{
+			(double)wxUINT32_SWAP_ON_LE(vert_data[a].x) / 65536.0f,
+			(double)wxUINT32_SWAP_ON_LE(vert_data[a].y) / 65536.0f }));
+	}
+
+	log::info(3, "Read {} vertices", map_data.vertices().size());
+
+	return true;
+}

--- a/src/SLADEMap/MapFormat/Doom32XMapFormat.h
+++ b/src/SLADEMap/MapFormat/Doom32XMapFormat.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "MapFormatHandler.h"
+#include "DoomMapFormat.h"
+
+namespace slade
+{
+class ThingList;
+class SectorList;
+class LineList;
+class SideList;
+class VertexList;
+
+class Doom32XMapFormat : public DoomMapFormat
+{
+public:
+	struct Vertex32BE
+	{
+		int32_t x;
+		int32_t y;
+	};
+
+protected:
+	virtual bool readVERTEXES(ArchiveEntry* entry, MapObjectCollection& map_data) const;
+};
+} // namespace slade

--- a/src/SLADEMap/MapFormat/MapFormatHandler.cpp
+++ b/src/SLADEMap/MapFormat/MapFormatHandler.cpp
@@ -35,6 +35,7 @@
 #include "Doom64MapFormat.h"
 #include "DoomMapFormat.h"
 #include "HexenMapFormat.h"
+#include "Doom32XMapFormat.h"
 #include "UniversalDoomMapFormat.h"
 
 using namespace slade;
@@ -79,6 +80,7 @@ unique_ptr<MapFormatHandler> MapFormatHandler::get(MapFormat format)
 	case MapFormat::Hexen: return std::make_unique<HexenMapFormat>();
 	case MapFormat::UDMF: return std ::make_unique<UniversalDoomMapFormat>();
 	case MapFormat::Doom64: return std::make_unique<Doom64MapFormat>();
+	case MapFormat::Doom32X: return std::make_unique<Doom32XMapFormat>();
 	default: return std::make_unique<NoMapFormat>();
 	}
 }

--- a/src/UI/Canvas/MapPreviewCanvas.cpp
+++ b/src/UI/Canvas/MapPreviewCanvas.cpp
@@ -42,6 +42,7 @@
 #include "SLADEMap/MapFormat/Doom64MapFormat.h"
 #include "SLADEMap/MapFormat/DoomMapFormat.h"
 #include "SLADEMap/MapFormat/HexenMapFormat.h"
+#include "SLADEMap/MapFormat/Doom32XMapFormat.h"
 #include "SLADEMap/MapObject/MapThing.h"
 #include "Utility/Tokenizer.h"
 
@@ -443,6 +444,19 @@ bool MapPreviewCanvas::readVertices(ArchiveEntry* map_head, ArchiveEntry* map_en
 			addVertex((double)v.x / 65536, (double)v.y / 65536);
 		}
 	}
+	else if (map_format == MapFormat::Doom32X)
+	{
+		Doom32XMapFormat::Vertex32BE v;
+		while (true)
+		{
+			// Read vertex
+			if (!mc.read(&v, 8))
+				break;
+
+			// Add vertex
+			addVertex((double)wxINT32_SWAP_ON_LE(v.x) / 65536, (double)wxINT32_SWAP_ON_LE(v.y) / 65536);
+		}
+	}
 	else
 	{
 		DoomMapFormat::Vertex v;
@@ -490,7 +504,7 @@ bool MapPreviewCanvas::readLines(ArchiveEntry* map_head, ArchiveEntry* map_end, 
 	// Read line data
 	auto& mc = linedefs->data();
 	mc.seek(0, SEEK_SET);
-	if (map_format == MapFormat::Doom)
+	if (map_format == MapFormat::Doom || map_format == MapFormat::Doom32X)
 	{
 		while (true)
 		{
@@ -591,7 +605,7 @@ bool MapPreviewCanvas::readThings(ArchiveEntry* map_head, ArchiveEntry* map_end,
 		return false;
 
 	// Read things data
-	if (map_format == MapFormat::Doom)
+	if (map_format == MapFormat::Doom || map_format == MapFormat::Doom32X)
 	{
 		auto     thng_data = (DoomMapFormat::Thing*)things->rawData(true);
 		unsigned nt        = things->size() / sizeof(DoomMapFormat::Thing);

--- a/src/UI/Dialogs/MapEditorConfigDialog.cpp
+++ b/src/UI/Dialogs/MapEditorConfigDialog.cpp
@@ -62,7 +62,8 @@ struct MapFormatDef
 MapFormatDef map_formats[] = { { MapFormat::Doom, "Doom", "D" },
 							   { MapFormat::Hexen, "Hexen", "H" },
 							   { MapFormat::Doom64, "Doom64", "64" },
-							   { MapFormat::UDMF, "UDMF", "U" } };
+							   { MapFormat::UDMF, "UDMF", "U" },
+							   { MapFormat::Doom32X, "Doom32X", "32X" } };
 } // namespace
 
 


### PR DESCRIPTION
We go from this:

![image](https://user-images.githubusercontent.com/1173058/174490810-5109141e-4d42-40d2-90c6-08598c393fb7.png)

to this:

![image](https://user-images.githubusercontent.com/1173058/174490820-b7c375ca-adee-4393-82e8-79fb1840895c.png)

The format is detected by the presence of the "PLAYPALS" lump. which is unique to 32X WADs.