### PR TITLE
Fix SRB2 fading mask detection in a zip archive

### DIFF
--- a/dist/res/config/entry_types/types_misc.txt
+++ b/dist/res/config/entry_types/types_misc.txt
@@ -203,7 +203,7 @@ entry_types
 	{
 		name = "Fading Mask";
 		icon = "gfx";
-		section = "fa";
+		section = "fa", "fades";
 		format = img_raw;
 		image_format = "raw_flat";
 		export_ext = "raw";


### PR DESCRIPTION
Fixes fading masks lumps being incorrectly detected as "Graphic (Jaguar Tx)"