### PR TITLE
Adding iwad override printout checks

### DIFF
--- a/dist/res/actions/arch.cfg
+++ b/dist/res/actions/arch.cfg
@@ -112,10 +112,10 @@ action arch_check_iwadoverrides
 	help_text	= "Checks entries of the same name from the base resource archive. Also checks texture definitions. This helps know what your archive overrides.";
 }
 
-action arch_check_zdoomiwadoverrides
+action arch_check_zdoomiwadtexoverrides
 {
-	text		= "Check ZDoom Entries Overridden from IWAD";
-	help_text	= "Checks entries of the same name from the base resource archive. Also checks texture definitions. This helps know what your archive overrides. This is a ZDoom version that has additional behavior for checking across flats, patches, and other assets.";
+	text		= "Check ZDoom Texture Entries Overridden from IWAD";
+	help_text	= "This finds what Zdoom textures your archive overrides from the iwad. Since this is for zdoom, it checks across flats, patches, and other assets. The Check Entries Overridden from IWAD tool checks general overrides.";
 }
 
 action arch_replace_maps

--- a/dist/res/actions/arch.cfg
+++ b/dist/res/actions/arch.cfg
@@ -106,6 +106,18 @@ action arch_clean_iwaddupes
 	help_text	= "Remove entries that are exact duplicates of entries from the base resource archive";
 }
 
+action arch_check_iwadoverrides
+{
+	text		= "Check Entries Overridden from IWAD";
+	help_text	= "Checks entries of the same name from the base resource archive. Also checks texture definitions. This helps know what your archive overrides.";
+}
+
+action arch_check_zdoomiwadoverrides
+{
+	text		= "Check ZDoom Entries Overridden from IWAD";
+	help_text	= "Checks entries of the same name from the base resource archive. Also checks texture definitions. This helps know what your archive overrides. This is a ZDoom version that has additional behavior for checking across flats, patches, and other assets.";
+}
+
 action arch_replace_maps
 {
 	text		= "Replace in Maps";

--- a/msvc/SLADE.vcxproj
+++ b/msvc/SLADE.vcxproj
@@ -36,7 +36,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc/ThirdPartyLib.vcxproj
+++ b/msvc/ThirdPartyLib.vcxproj
@@ -731,7 +731,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/MainEditor/ArchiveOperations.cpp
+++ b/src/MainEditor/ArchiveOperations.cpp
@@ -529,7 +529,7 @@ bool archiveoperations::checkOverriddenEntriesInIWAD(Archive* archive)
 				if (other_texture_index >= 0)
 				{
 					// Other texture with this name found
-					log::info(wxString::Format("Found Duplicate Texture: %s.", this_texture->name()));
+					log::info(wxString::Format("Found Overridden Texture: %s.", this_texture->name()));
 					found_duplicate_textures.insert(this_texture->name());
 					duplicate_texture_entries.emplace(this_texture->name(), std::make_pair(textureEntry, iter.first));
 				}
@@ -736,7 +736,7 @@ bool archiveoperations::checkZDoomOverriddenEntriesInIWAD(Archive* archive)
 
 			auto iter = archiveTexEntries.find(patch_name);
 
-			// If the pnames ptr is the same, we loaded pnames from the bra
+			// If the pnames ptr is the same, we loaded pnames from the bra, so don't mark it as overridden
 			if (iter != archiveTexEntries.end() && iter->second != pnames_entry)
 			{
 				overiddenBraTexEntries.emplace(patch_name, pnames_entry);
@@ -836,6 +836,13 @@ bool archiveoperations::checkZDoomOverriddenEntriesInIWAD(Archive* archive)
 			for (auto entry_iter = entries_range.first; entry_iter != entries_range.second; ++entry_iter)
 			{
 				ArchiveEntry* entry = entry_iter->second;
+
+				// skip BRA pnames, we don't want to print that as if it's our archive's asset
+				if (entry == braPnames)
+				{
+					continue;
+				}
+
 				dups += wxString::Format("\n\tThis Archive Asset Path: %s%s", entry->path(), entry->name());
 			}
 		}
@@ -852,9 +859,9 @@ bool archiveoperations::checkZDoomOverriddenEntriesInIWAD(Archive* archive)
 	}
 
 	// Display list of duplicate entry names
-	ExtMessageDialog msg(theMainWindow, "Duplicate Entries");
+	ExtMessageDialog msg(theMainWindow, "iWad Overridden Entries");
 	msg.setExt(dups);
-	msg.setMessage("The following entry data are duplicated:");
+	msg.setMessage("The following entry data is overridden from the iWad:");
 	msg.ShowModal();
 
 	return true;

--- a/src/MainEditor/ArchiveOperations.cpp
+++ b/src/MainEditor/ArchiveOperations.cpp
@@ -1632,7 +1632,7 @@ bool archiveoperations::checkDuplicateZDoomPatches(Archive* archive)
 
 	if (found_duplicates.empty())
 	{
-		wxMessageBox("No duplicated textures exist");
+		wxMessageBox("No duplicated patches exist");
 		return false;
 	}
 

--- a/src/MainEditor/ArchiveOperations.h
+++ b/src/MainEditor/ArchiveOperations.h
@@ -16,6 +16,8 @@ void removeUnusedZDoomTextures(Archive* archive);
 bool checkDuplicateZDoomTextures(Archive* archive);
 bool checkDuplicateZDoomPatches(Archive* archive);
 void removeEntriesUnchangedFromIWAD(Archive* archive);
+bool checkOverriddenEntriesInIWAD(Archive* archive);
+bool checkZDoomOverriddenEntriesInIWAD(Archive* archive);
 
 // Search and replace in maps
 size_t replaceThings(Archive* archive, int oldtype, int newtype);

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -3198,6 +3198,12 @@ bool ArchivePanel::handleAction(string_view id)
 	else if (id == "arch_clean_iwaddupes")
 		archiveoperations::removeEntriesUnchangedFromIWAD(archive.get());
 
+	else if (id == "arch_check_iwadoverrides")
+		archiveoperations::checkOverriddenEntriesInIWAD(archive.get());
+
+	else if (id == "arch_check_zdoomiwadoverrides")
+		archiveoperations::checkZDoomOverriddenEntriesInIWAD(archive.get());
+
 	// Archive->Maintenance->Replace in Maps
 	else if (id == "arch_replace_maps")
 	{
@@ -3442,6 +3448,8 @@ wxMenu* ArchivePanel::createMaintenanceMenu()
 	SAction::fromId("arch_clean_flats")->addToMenu(menu_clean);
 	SAction::fromId("arch_clean_zdoom_textures")->addToMenu(menu_clean);
 	SAction::fromId("arch_clean_iwaddupes")->addToMenu(menu_clean);
+	SAction::fromId("arch_check_iwadoverrides")->addToMenu(menu_clean);
+	SAction::fromId("arch_check_zdoomiwadoverrides")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_duplicates")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_duplicates2")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_zdoom_texture_duplicates")->addToMenu(menu_clean);

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -3201,7 +3201,7 @@ bool ArchivePanel::handleAction(string_view id)
 	else if (id == "arch_check_iwadoverrides")
 		archiveoperations::checkOverriddenEntriesInIWAD(archive.get());
 
-	else if (id == "arch_check_zdoomiwadoverrides")
+	else if (id == "arch_check_zdoomiwadtexoverrides")
 		archiveoperations::checkZDoomOverriddenEntriesInIWAD(archive.get());
 
 	// Archive->Maintenance->Replace in Maps
@@ -3449,7 +3449,7 @@ wxMenu* ArchivePanel::createMaintenanceMenu()
 	SAction::fromId("arch_clean_zdoom_textures")->addToMenu(menu_clean);
 	SAction::fromId("arch_clean_iwaddupes")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_iwadoverrides")->addToMenu(menu_clean);
-	SAction::fromId("arch_check_zdoomiwadoverrides")->addToMenu(menu_clean);
+	SAction::fromId("arch_check_zdoomiwadtexoverrides")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_duplicates")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_duplicates2")->addToMenu(menu_clean);
 	SAction::fromId("arch_check_zdoom_texture_duplicates")->addToMenu(menu_clean);


### PR DESCRIPTION
This adds tools that print out which entries your archive overrides from the iwad.

One version is for checking generic wads/archives.

The other version is specific to zdoom texture assets and checks across flats, patches, textures, etc...  This makes it easy to tell if you accidentally overwrote a patch from Doom with some texture name from one of your texture packs you're managing.

Here the generic EXIT1 patch is being overridden by some texture named EXIT1 and this will help catch all such cases.
![Exit](https://user-images.githubusercontent.com/173169/200254491-d4dbd95f-e09e-4646-9787-1cef72dfb783.png)

Here's a printout of the conflicting entry name.  Turns out a texture from Chasm was also called EXIT1 and it's overriding the EXIT1 patch from Doom2.wad.  Time to rename it, and fix every other conflict in this printout.
![Overrides](https://user-images.githubusercontent.com/173169/200479239-7473354c-ed1d-45d1-9c99-1363d7da01d2.png)

