### PR TITLE
Fix SLADE on Linux

### DIFF
--- a/src/Application/SLADEWxApp.cpp
+++ b/src/Application/SLADEWxApp.cpp
@@ -189,7 +189,7 @@ public:
 		img.LoadFile(app::path("STFDEAD0.png", app::Dir::Temp));
 		img.Rescale(img.GetWidth(), img.GetHeight(), wxIMAGE_QUALITY_NEAREST);
 		auto picture = new wxStaticBitmap(this, -1, wxBitmap(img));
-		hbox->Add(picture, 0, wxALIGN_CENTER_HORIZONTAL | wxLEFT | wxTOP | wxBOTTOM, 10);
+		hbox->Add(picture, 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxTOP | wxBOTTOM, 10);
 
 		// Add general crash message
 		string message =
@@ -198,7 +198,7 @@ public:
 			"issue details, along with a description of what you were doing at the time of the "
 			"crash.";
 		auto label = new wxStaticText(this, -1, message);
-		hbox->Add(label, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 10);
+		hbox->Add(label, 0, wxALIGN_CENTER_VERTICAL | wxALL, 10);
 		label->Wrap(480 - 20 - picture->GetSize().x);
 
 		// Add stack trace text area

--- a/src/Game/Configuration.cpp
+++ b/src/Game/Configuration.cpp
@@ -1404,7 +1404,7 @@ void Configuration::linkDoomEdNums()
 			// Editor number found, copy the definition to thing types map
 			thing_types_[ednum].define(ednum, parsed.name(), parsed.group());
 			thing_types_[ednum].copy(parsed);
-			log::info(2, "Linked parsed class {} to DoomEdNum %d", parsed.className(), ednum);
+			log::info(2, "Linked parsed class {} to DoomEdNum {}", parsed.className(), ednum);
 		}
 	}
 }

--- a/src/MapEditor/UI/MapCanvas.cpp
+++ b/src/MapEditor/UI/MapCanvas.cpp
@@ -100,7 +100,7 @@ MapCanvas::MapCanvas(wxWindow* parent, int id, MapEditContext* context) :
 	Bind(wxEVT_IDLE, &MapCanvas::onIdle, this);
 #endif
 
-	timer_.Start(map_bg_ms, true);
+	timer_.Start(map_bg_ms);
 }
 
 // -----------------------------------------------------------------------------
@@ -517,8 +517,6 @@ void MapCanvas::onRTimer(wxTimerEvent& e)
 		last_time_ = (sf_clock_.getElapsedTime().asMilliseconds());
 		Refresh();
 	}
-
-	timer_.Start(map_bg_ms, true);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/UI/Controls/ConsolePanel.cpp
+++ b/src/UI/Controls/ConsolePanel.cpp
@@ -156,7 +156,7 @@ void ConsolePanel::update()
 		text_log_->MarginSetStyle(line_no, wxSTC_STYLE_LINENUMBER);
 
 		// Set line colour depending on message type
-		text_log_->StartStyling(text_log_->GetLineEndPosition(line_no) - text_log_->GetLineLength(line_no), 0);
+		text_log_->StartStyling(text_log_->GetLineEndPosition(line_no) - text_log_->GetLineLength(line_no));
 		switch (log[a].type)
 		{
 		case log::MessageType::Error: text_log_->SetStyling(text_log_->GetLineLength(line_no), 200); break;

--- a/src/UI/Controls/ConsolePanel.cpp
+++ b/src/UI/Controls/ConsolePanel.cpp
@@ -75,7 +75,15 @@ void ConsolePanel::initLayout()
 	// Create and add the message log textbox
 	text_log_ = new wxStyledTextCtrl(this, -1, wxDefaultPosition, wxDefaultSize);
 	text_log_->SetEditable(false);
+#ifdef __WXGTK__
+	// workaround for an extremely convoluted wxGTK bug that causes a resource
+	// leak that makes SLADE unusable on linux (!) -- see:
+	// https://github.com/sirjuddington/SLADE/issues/1016
+	// https://github.com/wxWidgets/wxWidgets/issues/23364
+	text_log_->SetWrapMode(wxSTC_WRAP_NONE);
+#else
 	text_log_->SetWrapMode(wxSTC_WRAP_WORD);
+#endif
 	text_log_->SetSizeHints(wxSize(-1, 0));
 	vbox->Add(text_log_, 1, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, ui::pad());
 

--- a/src/UI/SToolBar/SToolBarButton.cpp
+++ b/src/UI/SToolBar/SToolBarButton.cpp
@@ -219,7 +219,7 @@ bool SToolBarButton::updateState()
 {
 	auto prev_state = state_;
 
-	if (GetScreenRect().Contains(wxGetMousePosition()) && IsEnabled())
+	if (IsShownOnScreen() && IsEnabled() && GetScreenRect().Contains(wxGetMousePosition()))
 	{
 		if (wxGetMouseState().LeftIsDown())
 			state_ = State::MouseDown;


### PR DESCRIPTION
You won't believe how!  It's by turning off word wrap in the console (on wxGTK only; no reason to do it for anyone else).  See #1016 and wxWidgets/wxWidgets#23364.

This is a kludge until...  someone else fixes it for real.  But the drawback is pretty minor, considering I haven't been able to use SLADE for mapping at all for five and a half years.

The rest of this fixes some assertion failures and stderr spam.  Not sure why the map editor window's toolbar buttons are getting mouse events when it's not even open...