### PR TITLE
Fixed 3D Camera spinning issue on Linux with High-DPI

### DIFF
--- a/src/MapEditor/UI/MapCanvas.cpp
+++ b/src/MapEditor/UI/MapCanvas.cpp
@@ -170,8 +170,9 @@ void MapCanvas::mouseLook3d()
 		auto overlay_current = context_->currentOverlay();
 		if (!overlay_current || !overlay_current->isActive() || (overlay_current && overlay_current->allow3dMlook()))
 		{
-			// Get relative mouse movement (scale with dpi on macOS)
-			const double scale     = app::platform() == app::MacOS ? GetContentScaleFactor() : 1.;
+			// Get relative mouse movement (scale with dpi on macOS and Linux)
+			const bool   useScaleFactor = (app::platform() == app::MacOS || app::platform() == app::Linux); 
+			const double scale = useScaleFactor ? GetContentScaleFactor() : 1.;
 			const double threshold = scale - 1.0;
 
 			wxRealPoint mouse_pos = wxGetMousePosition();


### PR DESCRIPTION
On Linux with high DPI I had the same issue as #891. I tried out the fix for Mac and it worked for Linux as well.

Also tested and it works with fractional scaling and with no scaling.