### PR TITLE
Backport missing lunasvg imports

### DIFF
--- a/thirdparty/lunasvg/include/lunasvg.h
+++ b/thirdparty/lunasvg/include/lunasvg.h
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 #if defined(_MSC_VER) && defined(LUNASVG_SHARED)
 #ifdef LUNASVG_EXPORT

--- a/thirdparty/lunasvg/source/property.h
+++ b/thirdparty/lunasvg/source/property.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <array>
+#include <cstdint>
 
 namespace lunasvg {
 


### PR DESCRIPTION
No release has been made with these, so this is a simple backport Upstream https://github.com/sammycage/lunasvg/commit/db27b7c0ef987f222a87e24f4feec507cfe9635d

These includes are required, since the specific integer types are otherwise never declared.