### PR TITLE
Add wxWidget verison checks to lower min required version

### DIFF
--- a/src/General/UI.cpp
+++ b/src/General/UI.cpp
@@ -83,7 +83,9 @@ void ui::init(double scale)
 {
 	splash_window = std::make_unique<SplashWindow>();
 
+#if wxCHECK_VERSION(3, 1, 4)
 	scale = splash_window->GetDPIScaleFactor();
+#endif
 
 	ui::scale    = scale;
 	px_pad_small = 8 * scale;

--- a/src/UI/Controls/ConsolePanel.cpp
+++ b/src/UI/Controls/ConsolePanel.cpp
@@ -156,7 +156,11 @@ void ConsolePanel::update()
 		text_log_->MarginSetStyle(line_no, wxSTC_STYLE_LINENUMBER);
 
 		// Set line colour depending on message type
-		text_log_->StartStyling(text_log_->GetLineEndPosition(line_no) - text_log_->GetLineLength(line_no));
+		text_log_->StartStyling(text_log_->GetLineEndPosition(line_no) - text_log_->GetLineLength(line_no)
+#if !wxCHECK_VERSION(3, 1, 1) /* Prior to wxWidgets 3.1.1 StartStyling took 2 arguments, no overload exists for compatibility */
+			, 0
+#endif
+		);
 		switch (log[a].type)
 		{
 		case log::MessageType::Error: text_log_->SetStyling(text_log_->GetLineLength(line_no), 200); break;


### PR DESCRIPTION
`GetDPIScaleFactor` was only introduced in 3.1.4

`StartStyling` had its argument count reduced from 2 to 1 in 3.1.1 (no overload exists, despite being possible in C++)