### PR TITLE
dereference null pointer directly in crash command

### DIFF
--- a/src/Application/SLADEWxApp.cpp
+++ b/src/Application/SLADEWxApp.cpp
@@ -771,7 +771,7 @@ CONSOLE_COMMAND(crash, 0, false)
 		== wxYES)
 	{
 		uint8_t* test = nullptr;
-		test[123]     = 5;
+		*test         = 5;
 	}
 }
 


### PR DESCRIPTION
`test[123]` would result in `*(test+123)`, which may point to valid memory that we modify. Instead dereference the null pointer directly to ensure we actually crash