### PR TITLE
Create data dir for InstanceChecker if it does not exist

### DIFF
--- a/src/Application/SLADEWxApp.cpp
+++ b/src/Application/SLADEWxApp.cpp
@@ -44,6 +44,7 @@
 #include "Utility/Parser.h"
 #include "Utility/StringUtils.h"
 #include <wx/statbmp.h>
+#include <wx/filefn.h>
 #undef BOOL
 #ifdef UPDATEREVISION
 #include "gitinfo.h"
@@ -380,9 +381,12 @@ IMPLEMENT_APP(SLADEWxApp)
 // -----------------------------------------------------------------------------
 bool SLADEWxApp::singleInstanceCheck()
 {
+	auto data_dir = wxStandardPaths::Get().GetUserDataDir();
+	if (!wxDirExists(data_dir))
+		wxMkdir(data_dir);
+
 	single_instance_checker_ = new wxSingleInstanceChecker;
-	single_instance_checker_->Create(
-		wxString::Format("SLADE-%s", app::version().toString()), wxStandardPaths::Get().GetUserDataDir());
+	single_instance_checker_->Create(wxString::Format("SLADE-%s", app::version().toString()), data_dir);
 
 	if (argc == 1)
 		return true;


### PR DESCRIPTION
`wxSingleInstanceChecker::Create` cannot create a lock in a directory that does not exist, so we check it if doesn't and make it.