### PR TITLE
ACS upper case HUD

### DIFF
--- a/dist/res/config/languages/acs.txt
+++ b/dist/res/config/languages/acs.txt
@@ -906,9 +906,9 @@ acs_z : acs
 		SetFogDensity = "int tag, int amount";
 		SetFont = "str fontlump";
 		SetGravity = "fixed amount";
-		SetHUDClipRect = "int x, int y, int width, int height, [int wrapwidth], [bool aspectratio]";
-		SetHUDSize = "int width, int height, bool statusbar";
-		SetHUDWrapWidth = "int wrapwidth";
+		SetHudClipRect = "int x, int y, int width, int height, [int wrapwidth], [bool aspectratio]";
+		SetHudSize = "int width, int height, bool statusbar";
+		SetHudWrapWidth = "int wrapwidth";
 		SetLineActivation = "int lineid, int activation, [int repeat]";
 		SetLineBlocking = "int lineid, int setting";
 		SetLineMonsterBlocking = "int lineid, int setting";


### PR DESCRIPTION
Correction for spelling SetHudClipRect, SetHudSize and SetHudWrapWidth, so Function Link works.

ACS demo code:
```
#include "zcommon.acs"
script 1 (void)
{
	// url does not work
	SetHUDSize(320, 200, true);
	SetHUDClipRect(10, 10, 180, 180, 90, true);
	SetHUDWrapWidth(100);

	// corrected
	SetHudSize(320, 200, true);
	SetHudClipRect(10, 10, 180, 180, 90, true);
	SetHudWrapWidth(100);
}

```