### PR TITLE
Added Quick Run button

### DIFF
--- a/dist/res/actions/mapw_general.cfg
+++ b/dist/res/actions/mapw_general.cfg
@@ -176,6 +176,14 @@ action mapw_run_map
 	shortcut	= "Ctrl+Shift+R";
 }
 
+action mapw_quick_run_map
+{
+	text		= "Quick Run Map";
+	icon		= "run_quick";
+	help_text	= "Run the current map without opening the configuration dialog";
+	shortcut	= "Ctrl+R";
+}
+
 action mapw_draw_lines
 {
 	text		= "Draw Lines";

--- a/dist/res/icons.cfg
+++ b/dist/res/icons.cfg
@@ -93,6 +93,7 @@ general
 		icon_svg right = "icons/general/right.svg";
 		icon_svg rotate = "icons/general/rotate.svg";
 		icon_svg run = "icons/general/run.svg";
+		icon_svg run_quick = "icons/general/run_quick.svg";
 		icon_svg save = "icons/general/save.svg";
 		icon_svg saveall = "icons/general/saveall.svg";
 		icon_svg saveas = "icons/general/saveas.svg";

--- a/dist/res/icons/general/run_quick.svg
+++ b/dist/res/icons/general/run_quick.svg
@@ -1,0 +1,16 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="16px"
+    height="16px"
+    viewBox="0 0 24 24">
+    <g transform="scale(1.6, 1.5)">
+        <path
+            d="M10 8.64L15.27 12L10 15.36V8.64M8 5v14l11-7L8 5z"
+            fill="#A8009B"
+            stroke="#A8009B"
+            stroke-width="0.5"
+            transform="translate(-5, -4)"
+        />
+    </g>
+</svg>

--- a/src/MapEditor/UI/MapEditorWindow.cpp
+++ b/src/MapEditor/UI/MapEditorWindow.cpp
@@ -222,6 +222,7 @@ void MapEditorWindow::setupMenu()
 	SAction::fromId("mapw_backup")->addToMenu(menu_map);
 	menu_map->AppendSeparator();
 	SAction::fromId("mapw_run_map")->addToMenu(menu_map);
+	SAction::fromId("mapw_quick_run_map")->addToMenu(menu_map);
 	menu->Append(menu_map, "&Map");
 
 	// Edit menu
@@ -343,6 +344,7 @@ void MapEditorWindow::setupLayout()
 	// Extra toolbar
 	auto tbg_misc = new SToolBarGroup(toolbar_, "_Misc");
 	tbg_misc->addActionButton("mapw_run_map");
+	tbg_misc->addActionButton("mapw_quick_run_map");
 	toolbar_->addGroup(tbg_misc);
 
 	// Add toolbar
@@ -1349,13 +1351,13 @@ bool MapEditorWindow::handleAction(string_view id)
 	}
 
 	// Run Map
-	else if (id == "mapw_run_map" || id == "mapw_run_map_here")
+	else if (id == "mapw_run_map" || id == "mapw_run_map_here" || id == "mapw_quick_run_map")
 	{
 		Archive* archive = nullptr;
 		if (auto head = mdesc_current.head.lock())
 			archive = head->parent();
 		RunDialog dlg(this, archive, id == "mapw_run_map");
-		if (dlg.ShowModal() == wxID_OK)
+		if (id == "mapw_quick_run_map" || dlg.ShowModal() == wxID_OK)
 		{
 			auto& edit_context = mapeditor::editContext();
 			// Move player 1 start if needed


### PR DESCRIPTION
Added a purple "Quick Run" button to the map editor toolbar that runs the current map without opening the run dialog. Quick Running a map uses the configuration options provided the last time the map was run.

![Screenshot from 2023-06-17 20-05-25](https://github.com/sirjuddington/SLADE/assets/55370376/893e8dbf-e3b9-4d60-9406-168e159384ad)
