### PR TITLE
Fixed build under aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.3...3.26)
 project(Slade3 VERSION 3.2.0)
 
 if(COMMAND cmake_policy)
@@ -11,7 +11,7 @@ if(COMMAND cmake_policy)
 	endif(POLICY CMP0072)
 endif(COMMAND cmake_policy)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 if (NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,7 +171,12 @@ if(APPLE)
 endif(APPLE)
 
 # Enable SSE instructions for dumb library
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_USE_SSE -msse")
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-msse HAVE_SSE)
+if(HAVE_SSE)
+	add_compile_options(-msse)
+	add_definitions(-D_USE_SSE)
+endif()
 
 # Enable debug symbols for glib (so gdb debugging works properly with strings etc.)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_GLIBCXX_DEBUG")

--- a/src/Utility/Colour.h
+++ b/src/Utility/Colour.h
@@ -94,7 +94,7 @@ struct ColRGBA
 		if (na < 0)
 			na = 0;
 
-		return { (uint8_t)nr, (uint8_t)ng, (uint8_t)nb, (uint8_t)na, -1 };
+		return { (uint8_t)nr, (uint8_t)ng, (uint8_t)nb, (uint8_t)na };
 	}
 
 	// Amplify/fade colour components by factors
@@ -122,7 +122,7 @@ struct ColRGBA
 		if (na < 0)
 			na = 0;
 
-		return { (uint8_t)nr, (uint8_t)ng, (uint8_t)nb, (uint8_t)na, -1 };
+		return { (uint8_t)nr, (uint8_t)ng, (uint8_t)nb, (uint8_t)na };
 	}
 
 	void write(uint8_t* ptr) const


### PR DESCRIPTION
Alternate take on #1208 since original author has not responded.  This addressing the narrowing conversion error a different way (is ColRGBA supposed to have an unused blend parameter?), and keeps the sse compile option functioning on x86.

Plus a couple of tiny CMakeLists changes to allow CMAKE_MODULE_PATH to be modified by the builder (allows some flexibility in build environments) and indicate that project is tested compatible with CMake 3.26.