### PR TITLE
Replace deprecated wxBitmap methods (fix build on wxWidgets 3.3)

### DIFF
--- a/src/TextEditor/UI/SCallTip.cpp
+++ b/src/TextEditor/UI/SCallTip.cpp
@@ -60,7 +60,8 @@ CVAR(Bool, txed_calltips_dim_optional, true, CVar::Flag::Save)
 // -----------------------------------------------------------------------------
 // SCallTip class constructor
 // -----------------------------------------------------------------------------
-SCallTip::SCallTip(wxWindow* parent) : wxPopupWindow(parent), buffer_{ 1000, 1000, 32 }, font_{ GetFont() }
+SCallTip::SCallTip(wxWindow* parent) : wxPopupWindow(parent),
+	scratch_{ 1000, 1000, 32 }, buffer_{ 1, 1, 32 }, font_{ GetFont() }
 {
 	wxPopupWindow::Show(false);
 
@@ -591,13 +592,12 @@ wxSize SCallTip::drawCallTip(wxDC& dc, int xoff, int yoff)
 // -----------------------------------------------------------------------------
 void SCallTip::updateBuffer()
 {
-	buffer_.SetWidth(1000);
-	buffer_.SetHeight(1000);
-
-	wxMemoryDC dc(buffer_);
-	auto       size = drawCallTip(dc);
-	buffer_.SetWidth(size.GetWidth());
-	buffer_.SetHeight(size.GetHeight());
+	wxSize     size;
+	{
+		wxMemoryDC dc(scratch_);
+		size = drawCallTip(dc);
+	} // The bitmap needs to be released from the DC before calling GetSubBitmap()
+	buffer_ = scratch_.GetSubBitmap(size);
 }
 
 

--- a/src/TextEditor/UI/SCallTip.h
+++ b/src/TextEditor/UI/SCallTip.h
@@ -47,7 +47,7 @@ private:
 	wxRect        rect_btn_up_;
 	wxRect        rect_btn_down_;
 	int           btn_mouse_over_ = 0;
-	wxBitmap      buffer_;
+	wxBitmap      scratch_, buffer_;
 	wxFont        font_;
 
 	void loadContext(unsigned long index);


### PR DESCRIPTION
Stop using some deprecated `wxBitmap` methods (`wxBitmap::SetWidth`, `wxBitmap::SetHeight`) which have been deprecated since
wxWidgets 3.1.2 and are removed in the current v3.3 development trunk.

With this SLADE builds fine on the current wxWidgets 3.3 development trunk.
I also verified the changes against wxWidgets (wxGTK) 3.0.5 and 3.2.4.