### PR TITLE
ensure map objects call setModified in copy method to play nicely with Undo

### DIFF
--- a/src/SLADEMap/MapObject/MapLine.cpp
+++ b/src/SLADEMap/MapObject/MapLine.cpp
@@ -966,6 +966,9 @@ void MapLine::copy(MapObject* c)
 	if (objType() != c->objType())
 		return;
 
+	// Update modified time
+	setModified();
+
 	MapObject::copy(c);
 
 	auto l = dynamic_cast<MapLine*>(c);

--- a/src/SLADEMap/MapObject/MapObject.cpp
+++ b/src/SLADEMap/MapObject/MapObject.cpp
@@ -111,12 +111,12 @@ void MapObject::setModified()
 // -----------------------------------------------------------------------------
 void MapObject::copy(MapObject* c)
 {
-	// Update modified time
-	setModified();
-
 	// Can't copy an object of a different type
 	if (c->type_ != type_)
 		return;
+
+	// Update modified time
+	setModified();
 
 	// Reset properties
 	properties_.clear();

--- a/src/SLADEMap/MapObject/MapSector.cpp
+++ b/src/SLADEMap/MapObject/MapSector.cpp
@@ -113,6 +113,7 @@ void MapSector::copy(MapObject* obj)
 	if (obj->objType() != Type::Sector)
 		return;
 
+	// Update modified time
 	setModified();
 
 	// Update texture counts (decrement previous)

--- a/src/SLADEMap/MapObject/MapSide.cpp
+++ b/src/SLADEMap/MapObject/MapSide.cpp
@@ -120,6 +120,9 @@ void MapSide::copy(MapObject* c)
 	if (c->objType() != Type::Side)
 		return;
 
+	// Update modified time
+	setModified();
+
 	// Copy properties
 	auto side = dynamic_cast<MapSide*>(c);
 	setTexLower(side->tex_lower_, false);

--- a/src/SLADEMap/MapObject/MapThing.cpp
+++ b/src/SLADEMap/MapObject/MapThing.cpp
@@ -228,6 +228,9 @@ void MapThing::copy(MapObject* c)
 	if (c->objType() != Type::Thing)
 		return;
 
+	// Update modified time
+	setModified();
+
 	// Basic variables
 	auto thing  = dynamic_cast<MapThing*>(c);
 	position_.x = thing->position_.x;


### PR DESCRIPTION
These copy methods are used by the "paste properties" action and this resolves some bugs with using Undo after those actions, including https://github.com/sirjuddington/SLADE/issues/1587 which I filed earlier.