### PR TITLE
Extend the Jaguar image format and add conversion option

### DIFF
--- a/dist/res/config/entry_types/gfx_doom.cfg
+++ b/dist/res/config/entry_types/gfx_doom.cfg
@@ -146,6 +146,17 @@ gfx_doom_jaguar : gfx_base
 	reliability = 65;
 }
 
+gfx_doom_jaguar_colmajor : gfx_base
+{
+	name = "Graphic (Jaguar CM)";
+	format = img_doom_jaguar_colmajor;
+	editor = gfx;
+	extra = image;
+	export_ext = "lmp";
+	image_format = "doom_jaguar_colmajor";
+	reliability = 65;
+}
+
 gfx_doom_psx : gfx_base
 {
 	name = "Graphic (PSX)";

--- a/src/Archive/EntryType/DataFormats/ImageFormats.h
+++ b/src/Archive/EntryType/DataFormats/ImageFormats.h
@@ -542,11 +542,10 @@ public:
 class DoomJaguarDataFormat : public EntryDataFormat
 {
 public:
-	DoomJaguarDataFormat() : EntryDataFormat("img_doom_jaguar"){};
+	DoomJaguarDataFormat(int colmajor = 0, string_view id = "img_doom_jaguar") :
+		EntryDataFormat(id), colmajor(colmajor){};
 	~DoomJaguarDataFormat() = default;
 
-	/* This format is used in the Jaguar Doom IWAD.
-	 */
 	int isThisFormat(MemChunk& mc) override
 	{
 		if (mc.size() < sizeof(gfx::JagPicHeader))
@@ -554,17 +553,20 @@ public:
 
 		const uint8_t*           data   = mc.data();
 		const gfx::JagPicHeader* header = (const gfx::JagPicHeader*)data;
-		int                      width, height, depth, size;
-		width  = wxINT16_SWAP_ON_LE(header->width);
-		height = wxINT16_SWAP_ON_LE(header->height);
-		depth  = wxINT16_SWAP_ON_LE(header->depth);
+		int                      width  = wxINT16_SWAP_ON_LE(header->width);
+		int                      height = wxINT16_SWAP_ON_LE(header->height);
+		int                      depth  = wxINT16_SWAP_ON_LE(header->depth);
+		int                      flags  = wxINT16_SWAP_ON_LE(header->flags);
+
+		if ((flags & 1) != colmajor)
+			return MATCH_FALSE;
 
 		// Check header values are 'sane'
 		if (!(height > 0 && height < 4096 && width > 0 && width < 4096 && (depth == 2 || depth == 3)))
 			return MATCH_FALSE;
 
 		// Check the size matches
-		size = width * height;
+		int size = width * height;
 		if (depth == 2)
 			size >>= 1;
 		if (mc.size() < (sizeof(gfx::JagPicHeader) + size))
@@ -572,6 +574,16 @@ public:
 
 		return MATCH_TRUE;
 	}
+
+private:
+	int colmajor;
+};
+
+class DoomJaguarColMajorDataFormat : public DoomJaguarDataFormat
+{
+public:
+	DoomJaguarColMajorDataFormat() : DoomJaguarDataFormat(1, "img_doom_jaguar_colmajor"){};
+	~DoomJaguarColMajorDataFormat() final = default;
 };
 
 class DoomJagTexDataFormat : public EntryDataFormat

--- a/src/Archive/EntryType/DataFormats/ImageFormats.h
+++ b/src/Archive/EntryType/DataFormats/ImageFormats.h
@@ -587,7 +587,7 @@ public:
 	{
 		size_t size = mc.size();
 		// Smallest pic size 832 (32x16), largest pic size 33088 (256x128)
-		if (size < 640 || size % 32 || size > 33088)
+		if (size < 832 || size % 32 || size > 33088)
 			return MATCH_FALSE;
 
 		// Verify duplication of content

--- a/src/Archive/EntryType/EntryDataFormat.cpp
+++ b/src/Archive/EntryType/EntryDataFormat.cpp
@@ -218,6 +218,7 @@ void EntryDataFormat::initBuiltinFormats()
 	registerDataFormat<DoomArahDataFormat>();
 	registerDataFormat<DoomPSXDataFormat>();
 	registerDataFormat<DoomJaguarDataFormat>();
+	registerDataFormat<DoomJaguarColMajorDataFormat>();
 	registerDataFormat<DoomJagTexDataFormat>();
 	registerDataFormat<DoomJagSpriteDataFormat>();
 	registerDataFormat<ShadowCasterSpriteFormat>();

--- a/src/Graphics/GameFormats.h
+++ b/src/Graphics/GameFormats.h
@@ -27,7 +27,8 @@ struct JagPicHeader
 	short height;
 	short depth;
 	short palshift;
-	char  padding[8];
+	short flags;
+	char  padding[6];
 };
 
 // The header of a PSX Doom-format gfx image

--- a/src/Graphics/SImage/Formats/SIFDoom.h
+++ b/src/Graphics/SImage/Formats/SIFDoom.h
@@ -826,9 +826,20 @@ protected:
 		int height = wxINT16_SWAP_ON_LE(header.height);
 		int depth  = wxINT16_SWAP_ON_LE(header.depth);
 		int shift  = wxINT16_SWAP_ON_LE(header.palshift);
+		int flags  = wxINT16_SWAP_ON_LE(header.flags);
 
 		// Create image
-		image.create(width, height, SImage::Type::PalMask);
+		if (flags & 1)
+		{
+			// the format is column-major, so swap width and height
+			// and then rotate and mirror the image in order to 
+			// convert it to row-major format
+			image.create(height, width, SImage::Type::PalMask);
+		}
+		else
+		{
+			image.create(width, height, SImage::Type::PalMask);
+		}
 		auto img_data = imageData(image);
 		auto img_mask = imageMask(image);
 
@@ -852,6 +863,12 @@ protected:
 		}
 		else
 			return false;
+
+		if (flags & 1)
+		{
+			image.rotate(90);
+			image.mirror(false);
+		}
 
 		// Mark palette index 0 as transparent
 		for (int p = 0; p < width * height; ++p)

--- a/src/Graphics/SImage/SIFormat.cpp
+++ b/src/Graphics/SImage/SIFormat.cpp
@@ -525,6 +525,7 @@ void SIFormat::initFormats()
 	new SIFDoomArah();
 	new SIFDoomSnea();
 	new SIFDoomJaguar();
+	new SIFDoomJaguarColMajor();
 	new SIFDoomPSX();
 
 	// Hexen formats


### PR DESCRIPTION
I would like to use the Jaguar image format for wall textures for the next version of Doom 32X Resurrection, hence the change. The "standard" texture format in JagDoom is rather silly since there's no header at all and the only way to auto-detect it is by checking if the 320-byte footer in the lump matches the initial 320 bytes. With 100 textures, that would require roughly 32KB of ROM space, which is just too wasteful, since the data in the footer is redundant to begin with.

So my plan is to re-use the JaguarImage format used for 2D gfx for wall textures, but also extend it by adding two new flags in the unused padding space of the header:
- bitflag of 1 indicates the column-major format

Before:
![Screenshot from 2023-11-06 21-04-20](https://github.com/sirjuddington/SLADE/assets/1173058/4dd9fef1-523c-4b07-8463-ad2a0968cb06)

After:
![Screenshot from 2023-11-06 21-03-06](https://github.com/sirjuddington/SLADE/assets/1173058/c7ee4bea-726a-49e6-b6ee-42f1ce94d92f)
