### PR TITLE
Change split line shortcut to Shift-S to avoid clash with Map Save As

### DIFF
--- a/src/General/KeyBind.cpp
+++ b/src/General/KeyBind.cpp
@@ -595,7 +595,7 @@ void KeyBind::initBinds()
 	addBind("me2d_mode_sectors", Keypress("S"), "Sectors mode", group);
 	addBind("me2d_mode_things", Keypress("T"), "Things mode", group);
 	addBind("me2d_flat_type", Keypress("F", KPM_CTRL), "Cycle flat type", group);
-	addBind("me2d_split_line", Keypress("S", KPM_CTRL | KPM_SHIFT), "Split nearest line", group);
+	addBind("me2d_split_line", Keypress("S", KPM_SHIFT), "Split nearest line", group);
 	addBind("me2d_lock_hilight", Keypress("H", KPM_CTRL), "Lock/unlock hilight", group);
 	addBind("me2d_begin_linedraw", Keypress("space"), "Begin line drawing", group);
 	addBind("me2d_begin_shapedraw", Keypress("space", KPM_SHIFT), "Begin shape drawing", group);


### PR DESCRIPTION
The default keyboard shortcut for Split Nearest Line in the map editor is Ctrl-Shift-S which is also the key shortcut for Map Save As. If you press Ctrl-Shift-S in the map editor, it will split the nearest line and simultaneously open the Map Save As dialog. If you are just trying to split a line, this is inconvenient. If you are trying to save the map under a different name, you will probably not notice that you also split a line. Nothing is bound to Shift-S, so this changes the default binding for the Split Nearest Line action to Shift-S.