### PR TITLE
Fix mirroring actions to only apply once with keyboard shortcut

### DIFF
--- a/src/MapEditor/Edit/Input.cpp
+++ b/src/MapEditor/Edit/Input.cpp
@@ -896,12 +896,6 @@ void Input::handleKeyBind2d(string_view name)
 				context_.addEditorMessage("Selection numbers disabled");
 		}
 
-		// Mirror
-		else if (name == "me2d_mirror_x")
-			context_.edit2D().mirror(true);
-		else if (name == "me2d_mirror_y")
-			context_.edit2D().mirror(false);
-
 		// Object Properties
 		else if (name == "me2d_object_properties")
 			context_.edit2D().editObjectProperties();


### PR DESCRIPTION
I noticed that if I use the keyboard shortcuts in 2D map edit mode to mirror selection, it would apply the action twice. You have to use Undo to see that it was mirrored twice, otherwise it looks like nothing happened. This doesn't happen when you use the menu. The action in either case is triggered from the MapEditContext::handleAction method, so this code in Input::handleKeyBind2d is superfluous and just causes it to be applied twice when using the shortcuts. After removing these lines, the keyboard shortcuts became usable, just triggering the action once.