### PR TITLE
Disable Mirror Horizontally/Vertically during Edit Objects

### DIFF
--- a/src/MapEditor/MapEditContext.cpp
+++ b/src/MapEditor/MapEditContext.cpp
@@ -1837,15 +1837,23 @@ bool MapEditContext::handleAction(string_view id)
 	// Mirror Y
 	else if (id == "mapw_mirror_y")
 	{
-		edit_2d_.mirror(false);
-		return true;
+		// Mirroring sectors breaks Edit Objects functionality
+		if (input_.mouseState() != mapeditor::Input::MouseState::ObjectEdit)
+		{
+			edit_2d_.mirror(false);
+			return true;
+		}
 	}
 
 	// Mirror X
 	else if (id == "mapw_mirror_x")
 	{
-		edit_2d_.mirror(true);
-		return true;
+		// Mirroring sectors breaks Edit Objects functionality
+		if (input_.mouseState() != mapeditor::Input::MouseState::ObjectEdit)
+		{
+			edit_2d_.mirror(true);
+			return true;
+		}
 	}
 
 	// Increment grid


### PR DESCRIPTION
Triggering the Mirror Horizontally or Mirror Vertically actions during Edit Objects seems to put things into a weird state where if you commit the Edit Object changes, the sectors are completely broken and cannot be fixed with Undo. Since Edit Objects already handles mirroring the objects in its own way, it makes sense to disable these actions that will break your map if used.