### PR TITLE
initialize object edit panel mirror checkboxes properly

### DIFF
--- a/src/MapEditor/UI/ObjectEditPanel.cpp
+++ b/src/MapEditor/UI/ObjectEditPanel.cpp
@@ -112,6 +112,8 @@ void ObjectEditPanel::init(ObjectEditGroup* group)
 	text_scalex_->SetValue(wxString::Format("%d", 100));
 	text_scaley_->SetValue(wxString::Format("%d", 100));
 	combo_rotation_->Select(0);
+	cb_mirror_x_->SetValue(false);
+	cb_mirror_y_->SetValue(false);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
If you use the Edit Object(s) functionality and apply a change with Mirror X or Mirror Y selected, those checkboxes don't get initialized properly and remain checked when you enter Edit Object(s) mode again, and you have to click them twice to actually mirror the object. This code change fixes that.