### PR TITLE
Edit Objects: scale things the same way vertices are scaled, from center of bounding box

### DIFF
--- a/src/MapEditor/Edit/ObjectEdit.cpp
+++ b/src/MapEditor/Edit/ObjectEdit.cpp
@@ -520,8 +520,8 @@ void ObjectEditGroup::doAll(
 		}
 
 		// Scale
-		thing.position.x = original_bbox_.min.x + ((thing.position.x - original_bbox_.min.x) * xscale);
-		thing.position.y = original_bbox_.min.y + ((thing.position.y - original_bbox_.min.y) * yscale);
+		thing.position.x = original_bbox_.midX() + (thing.position.x - original_bbox_.midX()) * xscale;
+		thing.position.y = original_bbox_.midY() + (thing.position.y - original_bbox_.midY()) * yscale;
 
 		// Move
 		thing.position.x += xoff;


### PR DESCRIPTION
When scaling a selection of things in Edit Objects mode, and clicking the Preview button, the locations of the things are scaled from a corner of the bounding box instead of the center, this actually puts things outside the scaled bounding box. This code change brings the scaling of thing positions to match that of vertices.