### PR TITLE
Add < and > keybinds to rotate things in 2D Map Edit (things) mode

### DIFF
--- a/src/General/KeyBind.cpp
+++ b/src/General/KeyBind.cpp
@@ -642,6 +642,8 @@ void KeyBind::initBinds()
 	group = "Map Editor 2D Things Mode";
 	addBind("me2d_thing_change_type", Keypress("T", KPM_CTRL), "Change type", group);
 	addBind("me2d_thing_quick_angle", Keypress("D"), "Quick angle edit", group);
+	addBind("me2d_thing_rotate_clockwise", Keypress("."), "Rotate clockwise", group);
+	addBind("me2d_thing_rotate_counterclockwise", Keypress(","), "Rotate counterclockwise", group);
 
 	// Map Editor 3D (me3d*)
 	group = "Map Editor 3D Mode";

--- a/src/MapEditor/Edit/Input.cpp
+++ b/src/MapEditor/Edit/Input.cpp
@@ -959,6 +959,26 @@ void Input::handleKeyBind2d(string_view name)
 					mouse_state_ = MouseState::ThingAngle;
 				}
 			}
+
+			// Rotate Clockwise
+			else if(name == "me2d_thing_rotate_clockwise")
+			{
+				auto things = context_.selection().selectedThings(true);
+				for (auto& thing : things)
+				{
+					thing->setAngle((thing->angle() - 45) % 360);
+				}
+			}
+
+			// Rotate Counterclockwise
+			else if(name == "me2d_thing_rotate_counterclockwise")
+			{
+				auto things = context_.selection().selectedThings(true);
+				for (auto& thing : things)
+				{
+					thing->setAngle((thing->angle() + 45) % 360);
+				}
+			}
 		}
 
 

--- a/src/MapEditor/Edit/Input.cpp
+++ b/src/MapEditor/Edit/Input.cpp
@@ -963,17 +963,29 @@ void Input::handleKeyBind2d(string_view name)
 			// Rotate Clockwise
 			else if(name == "me2d_thing_rotate_clockwise")
 			{
+				context_.beginUndoRecord("Rotate Things Clockwise", true, false, false);
 				auto things = context_.selection().selectedThings(true);
+				bool success = false;
 				for (auto& thing : things)
+				{
 					thing->setAngle((thing->angle() - 45) % 360);
+					success = true;
+				}
+				context_.endUndoRecord(success);
 			}
 
 			// Rotate Counterclockwise
 			else if(name == "me2d_thing_rotate_counterclockwise")
 			{
+				context_.beginUndoRecord("Rotate Things Counterclockwise", true, false, false);
 				auto things = context_.selection().selectedThings(true);
+				bool success = false;
 				for (auto& thing : things)
+				{
 					thing->setAngle((thing->angle() + 45) % 360);
+					success = true;
+				}
+				context_.endUndoRecord(success);
 			}
 		}
 

--- a/src/MapEditor/Edit/Input.cpp
+++ b/src/MapEditor/Edit/Input.cpp
@@ -965,9 +965,7 @@ void Input::handleKeyBind2d(string_view name)
 			{
 				auto things = context_.selection().selectedThings(true);
 				for (auto& thing : things)
-				{
 					thing->setAngle((thing->angle() - 45) % 360);
-				}
 			}
 
 			// Rotate Counterclockwise
@@ -975,9 +973,7 @@ void Input::handleKeyBind2d(string_view name)
 			{
 				auto things = context_.selection().selectedThings(true);
 				for (auto& thing : things)
-				{
 					thing->setAngle((thing->angle() + 45) % 360);
-				}
 			}
 		}
 

--- a/src/MapEditor/Edit/Input.cpp
+++ b/src/MapEditor/Edit/Input.cpp
@@ -968,7 +968,7 @@ void Input::handleKeyBind2d(string_view name)
 				bool success = false;
 				for (auto& thing : things)
 				{
-					short angle = (thing->angle() - 45) % 360;
+					short angle = thing->angle() - 45;
 					if (angle < 0)
 						angle += 360;
 					thing->setAngle(angle);

--- a/src/MapEditor/Edit/Input.cpp
+++ b/src/MapEditor/Edit/Input.cpp
@@ -968,7 +968,10 @@ void Input::handleKeyBind2d(string_view name)
 				bool success = false;
 				for (auto& thing : things)
 				{
-					thing->setAngle((thing->angle() - 45) % 360);
+					short angle = (thing->angle() - 45) % 360;
+					if (angle < 0)
+						angle += 360;
+					thing->setAngle(angle);
 					success = true;
 				}
 				context_.endUndoRecord(success);


### PR DESCRIPTION
This adds a feature in 2D Map (things) mode to rotate selected things with the < and > (comma and period) keys. It resolves this request: https://github.com/sirjuddington/SLADE/issues/1568 except not using the suggested [ and ] keys because those are already used to change grid size. Edit: I added Undo support.