### PR TITLE
transfer selection from sectors to things in the map editor

### DIFF
--- a/src/MapEditor/ItemSelection.cpp
+++ b/src/MapEditor/ItemSelection.cpp
@@ -710,7 +710,11 @@ void ItemSelection::migrate(Mode from_edit_mode, Mode to_edit_mode)
 			// To things mode
 			else if (to_edit_mode == Mode::Things)
 			{
-				// TODO this is much harder
+				for (auto& thing : context_->map().things())
+				{
+					if (sector->containsPoint(thing->position()))
+						new_selection.insert({ (int)thing->index(), ItemType::Thing });
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In the map editor when switching from sector mode to things mode, it will select any things that are inside the formerly selected sectors. It resolves https://github.com/sirjuddington/SLADE/issues/392