### PR TITLE
Add support for flags 2 and 4 for 4-bit Jaguar Images

### DIFF
--- a/src/Graphics/SImage/Formats/SIFDoom.h
+++ b/src/Graphics/SImage/Formats/SIFDoom.h
@@ -991,17 +991,11 @@ protected:
 		// Write the image data
 		if (colmajor)
 		{
-			SImage cmimage;
-			image.copyImage(&cmimage);
+			image.mirror(false);
+			image.rotate(270);
+		}
 
-			cmimage.mirror(false);
-			cmimage.rotate(270);
-			cmimage.putIndexedData(out);
-		}
-		else
-		{
-			image.putIndexedData(out);
-		}
+		image.putIndexedData(out);
 
 		return true;
 	}

--- a/src/Graphics/SImage/Formats/SIFDoom.h
+++ b/src/Graphics/SImage/Formats/SIFDoom.h
@@ -937,12 +937,21 @@ protected:
 		}
 		else if (depth == 2)
 		{
+			int pixshift = 0;
+
 			if (shift == 0)
 				shift = 40;
+			shift <<= 1;
+
+			if (flags & 2)
+				shift++;
+			if (flags & 4)
+				pixshift++;
+
 			for (int p = 0; p < width * height / 2; ++p)
 			{
-				img_data[p * 2]     = ((data[16 + p] & 0xF0) >> 4) + (shift << 1);
-				img_data[p * 2 + 1] = (data[16 + p] & 0x0F) + (shift << 1);
+				img_data[p * 2]     = shift + (((data[16 + p] & 0xF0) >> 4) << pixshift);
+				img_data[p * 2 + 1] = shift + ((data[16 + p] & 0x0F) << pixshift);
 			}
 		}
 		else


### PR DESCRIPTION
The new values for the 'flags' are supposed to extend functionality of the 4-bit images.

Enabled bit 1 indicates that the base palette index is odd.
If bit 2 is enabled, palette indices must be doubled. This allows creating images with more contrast.

The status bar on the screenshot has only 16 unique colors and uses both new flags to achieve good visual results:
![Screenshot from 2023-11-25 21-05-00](https://github.com/sirjuddington/SLADE/assets/1173058/839f1eb8-cfad-4f6d-be53-ef5e9d9b6e46)
