### PR TITLE
Update net.mancubus.SLADE.desktop

### DIFF
--- a/net.mancubus.SLADE.desktop
+++ b/net.mancubus.SLADE.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=SLADE
-Exec=slade 
+Exec=slade %F
 Type=Application
 Categories=Development
 Comment=It's a Doom editor
 Icon=net.mancubus.SLADE
 Terminal=false
+MimeType=application/x-doom-wad;


### PR DESCRIPTION
Adding a MimeType  of "application/x-doom-wad" (following convention on the trailing semicolon) and specifying that one or more files can be opened with it "%F" on the Exec line. This should help with file type association in Nautilus File Browser.