### PR TITLE
Fix compiling for clang and gcc version 9 and greater

### DIFF
--- a/cmake/unix.cmake
+++ b/cmake/unix.cmake
@@ -186,7 +186,7 @@ target_link_libraries(slade
 	${MPG123_LIBRARIES}
 )
 
-if(LINUX)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION LESS 9)
 	target_link_libraries(slade -lstdc++fs)
 endif()
 


### PR DESCRIPTION
Should make [this](https://github.com/sirjuddington/SLADE/issues/1633#issuecomment-1865962537) unneeded.
