### PR TITLE
CMake cleanup and fixes

### DIFF
--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -7,10 +7,10 @@ string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
   if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-    exec_program(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" -E remove "$ENV{DESTDIR}${file}"
       OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
+      RESULT_VARIABLE rm_retval
       )
     if(NOT "${rm_retval}" STREQUAL 0)
       message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")

--- a/cmake/unix.cmake
+++ b/cmake/unix.cmake
@@ -215,9 +215,11 @@ else(APPLE)
 			RUNTIME DESTINATION bin
 			)
 
+if (BUILD_PK3)
 		install(FILES "${SLADE_OUTPUT_DIR}/slade.pk3"
 			DESTINATION share/slade3
 			)
+endif()
 
 		install(FILES "${PROJECT_SOURCE_DIR}/dist/res/logo_icon.png"
 			DESTINATION share/icons/

--- a/cmake/unix.cmake
+++ b/cmake/unix.cmake
@@ -242,7 +242,7 @@ if(NOT TARGET uninstall)
         IMMEDIATE @ONLY)
 
     add_custom_target(uninstall
-        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake COMMENT "Uninstall the project...")
 endif()
 
 if (NOT NO_COTIRE)


### PR DESCRIPTION
 - Replace calls to deprecated exec_program with execute_process when using uninstall target
 - Add comment for uninstall target
 - Only install slade.pk3 if BUILD_PK3 is enabled (fixes #1641)