### PR TITLE
Recognize ZScript files by extension

### DIFF
--- a/dist/res/config/entry_types/text.cfg
+++ b/dist/res/config/entry_types/text.cfg
@@ -608,6 +608,8 @@ zscript : text
 {
 	name = "ZScript";
 	match_name = "zscript";
+	match_ext = "zs", "zsc", "zc";
+	match_extorname = 1;
 	text_language = "zscript";
 	icon = "code";
 }


### PR DESCRIPTION
Files with the .zs, .zsc or .zc are now recognized as ZScript files.

https://forum.zdoom.org/viewtopic.php?p=1249322#p1249322