### PR TITLE
Update linux CI workflow to 24.04

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -17,18 +17,18 @@ jobs:
           }
         - {
             name: "Linux GCC",
-            os: ubuntu-22.04,
+            os: ubuntu-24.04,
             deps_cmdline: "sudo apt install \
-                           libfluidsynth-dev libfreeimage-dev libwebkit2gtk-4.0-dev \
+                           libfluidsynth-dev libfreeimage-dev libwebkit2gtk-4.1-dev \
                            libftgl-dev libgtk-3-dev liblua5.3-dev libmpg123-dev libsfml-dev \
                            libwxgtk3.2-dev libwxgtk-webview3.2-dev"
           }
         - {
             name: "Linux Clang",
-            os: ubuntu-22.04,
+            os: ubuntu-24.04,
             extra_options: "-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++",
             deps_cmdline: "sudo apt install \
-                           libfluidsynth-dev libfreeimage-dev libwebkit2gtk-4.0-dev \
+                           libfluidsynth-dev libfreeimage-dev libwebkit2gtk-4.1-dev \
                            libftgl-dev libgtk-3-dev liblua5.3-dev libmpg123-dev libsfml-dev \
                            libwxgtk3.2-dev libwxgtk-webview3.2-dev"
           }

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -17,24 +17,20 @@ jobs:
           }
         - {
             name: "Linux GCC",
-            os: ubuntu-20.04,
-            deps_cmdline: "sudo apt-key adv --fetch-keys https://repos.codelite.org/CodeLite.asc && \
-						   sudo apt-add-repository 'deb https://repos.codelite.org/wx3.1.5/ubuntu/ focal universe' && \
-						   sudo apt update && sudo apt install \
+            os: ubuntu-22.04,
+            deps_cmdline: "sudo apt install \
                            libfluidsynth-dev libfreeimage-dev libwebkit2gtk-4.0-dev \
                            libftgl-dev libgtk-3-dev liblua5.3-dev libmpg123-dev libsfml-dev \
-                           libwxgtk3.1unofficial-dev libwxgtk-webview3.1unofficial-dev"
+                           libwxgtk3.2-dev libwxgtk-webview3.2-dev"
           }
         - {
             name: "Linux Clang",
-            os: ubuntu-20.04,
+            os: ubuntu-22.04,
             extra_options: "-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++",
-            deps_cmdline: "sudo apt-key adv --fetch-keys https://repos.codelite.org/CodeLite.asc && \
-						   sudo apt-add-repository 'deb https://repos.codelite.org/wx3.1.5/ubuntu/ focal universe' && \
-						   sudo apt update && sudo apt install \
+            deps_cmdline: "sudo apt install \
                            libfluidsynth-dev libfreeimage-dev libwebkit2gtk-4.0-dev \
                            libftgl-dev libgtk-3-dev liblua5.3-dev libmpg123-dev libsfml-dev \
-                           libwxgtk3.1unofficial-dev libwxgtk-webview3.1unofficial-dev"
+                           libwxgtk3.2-dev libwxgtk-webview3.2-dev"
           }
 
     steps:


### PR DESCRIPTION
Update linux CI workflow to Ubuntu 24.04 LTS (since we need wxWidgets 3.2+ now)