### PR TITLE
Add keywords to .desktop file

### DIFF
--- a/net.mancubus.SLADE.desktop
+++ b/net.mancubus.SLADE.desktop
@@ -7,3 +7,5 @@ Comment=It's a Doom editor
 Icon=net.mancubus.SLADE
 Terminal=false
 MimeType=application/x-doom-wad;
+Keywords=modding;mapping;doom;map-editor;doom-editor;wad;map;
+Keywords[de]=modden;karten-erstellung;doom;karten-editor;doom-editor;wad;karte;


### PR DESCRIPTION
Keywords taken from Github topics

Adds keywords as specified here: https://webcache.googleusercontent.com/search?q=cache:https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

These are also used by Flathub, KDE Discover and Gnome Software.

As an example, check the Ghidra .desktop file and Flathub page:
https://github.com/flathub/org.ghidra_sre.Ghidra/blob/master/org.ghidra_sre.Ghidra.desktop
```
Keywords=reverse-engineering;disassembler;disassembly;assembler;assembly;asm;decompile;decompilation;software-analysis;security;
```
https://flathub.org/apps/org.ghidra_sre.Ghidra
![image](https://github.com/keepassxreboot/keepassxc/assets/3226457/93075692-6d37-4ac8-ac82-aff80ece9262)
