### PR TITLE
Don't reset fluid_synth in MIDIPlayer.cpp stop()

### DIFF
--- a/src/Audio/MIDIPlayer.cpp
+++ b/src/Audio/MIDIPlayer.cpp
@@ -259,7 +259,7 @@ public:
 		if (fs_initialised_)
 		{
 			fluid_player_stop(fs_player_);
-			fluid_synth_system_reset(fs_synth_);
+			// fluid_synth_system_reset(fs_synth_); // Breaks soundfont on play/pause/stop
 			stopped = true;
 		}
 


### PR DESCRIPTION
This call causes the soundfont to reset to default if a MIDI entry is played and any of the Play, Pause or Stop buttons get pressed after playback has already started. This results in all instruments being reset back to a default piano once playback resumes for the selected MIDI entry.

This patch addresses the issue I experienced in https://github.com/sirjuddington/SLADE/issues/1737 where playing a MIDI entry works fine, but the soundfont disappears after the Play, Pause or Stop buttons are clicked.

The `stop()` function calls out to `fluid_synth_system_reset(fs_synth_)` which breaks the soundfont for the selected MIDI entry. Once playback is resumed, all instruments other than the drumkit have been reset to default MIDI pianos.