### PR TITLE
Add support for the k8vavoom vWad archive format

### DIFF
--- a/dist/res/config/archive_formats.cfg
+++ b/dist/res/config/archive_formats.cfg
@@ -43,6 +43,17 @@ archive_formats
 		}
 	}
 
+	vwad
+	{
+		name = "VWad";
+		supports_dirs = true;
+		names_extensions = true;
+		entry_format = "archive_vwad";
+		create = true;
+		allow_duplicate_names = false;
+		extensions { vwad = "k8Vavoom vWAD"; }
+	}
+
 	adat
 	{
 		name = "Anachronox DAT";

--- a/dist/res/config/entry_types/archives.cfg
+++ b/dist/res/config/entry_types/archives.cfg
@@ -9,6 +9,15 @@ zip
 	category = "Archives";
 }
 
+vwad
+{
+	name = "VWad Archive";
+	format = archive_vwad;
+	export_ext = "vwad";
+	icon = "e_zip";
+	category = "Archives";
+}
+
 gzip
 {
 	name = "GZip Archive";

--- a/dist/res/scripts/archive/Archive Info.lua
+++ b/dist/res/scripts/archive/Archive Info.lua
@@ -35,6 +35,25 @@ end
 function Execute(archive)
    -- Archive format info
    AddOutputLine("Format: " .. archive.format.name)
+
+   if archive.format.name == "VWad" then
+      local author = Archives.VWad.GetAuthor(archive)
+      local title = Archives.VWad.GetTitle(archive)
+      local comment = Archives.VWad.GetComment(archive)
+      if author == "" then author = "N/A" end
+      if title == "" then title = "N/A" end
+      if comment == "" then comment = "N/A" end
+	   AddOutputLine("Author: " .. author)
+	   AddOutputLine("Title: " .. title)
+	   AddOutputLine("Comment: " .. comment)
+	   if Archives.VWad.IsSigned(archive) then
+	     AddOutputLine("Signed: YES")
+		  AddOutputLine("Public Key: " .. Archives.VWad.GetPublicKey(archive))
+	   else
+	     AddOutputLine("Signed: NO")
+	   end
+   end
+
    AddOutputLine("Supports directories: " .. YesNo(archive.format.supportsDirs))
    AddOutputLine("Entry names have extensions: " .. YesNo(archive.format.hasExtensions))
    if archive.format.maxNameLength > 0 then

--- a/dist/res/scripts/general/Examples/General/Generate VWad Signing Key.lua
+++ b/dist/res/scripts/general/Examples/General/Generate VWad Signing Key.lua
@@ -1,0 +1,13 @@
+-- Generate a new ASCII-encoded Public/Private key pair and present it to the user
+local privkey = Archives.VWad.CreatePrivateKey()
+local output = "Private Key: " .. privkey .. "\n"
+
+function AddOutputLine(line)
+   output = output .. line .. "\n"
+end
+
+AddOutputLine("Public Key: " .. Archives.VWad.DerivePublicKey(privkey) .. "\n")
+AddOutputLine("Paste the Private Key into vwad_private_key (under SLADE Advanced Settings) to sign all VWads with it when saving.\n")
+AddOutputLine("Share ONLY the Public Key with others!")
+
+UI.MessageBox("New VWad Signing Key", output)

--- a/dist/res/scripts/general/Examples/General/Get Public VWad Signing Key.lua
+++ b/dist/res/scripts/general/Examples/General/Get Public VWad Signing Key.lua
@@ -1,0 +1,5 @@
+-- Get the ASCII-encoded public key for the provided ASCII-encoded private key
+
+local privkey = UI.PromptString("Derive Public VWad Key", "Enter Private VWad Key", "")
+
+UI.MessageBox("Public VWad Key For " .. privkey, Archives.VWad.DerivePublicKey(privkey))

--- a/msvc/SLADE.vcxproj
+++ b/msvc/SLADE.vcxproj
@@ -311,6 +311,7 @@
     <ClCompile Include="..\src\Archive\Formats\RffArchive.cpp" />
     <ClCompile Include="..\src\Archive\Formats\SiNArchive.cpp" />
     <ClCompile Include="..\src\Archive\Formats\TarArchive.cpp" />
+    <ClCompile Include="..\src\Archive\Formats\VWadArchive.cpp" />
     <ClCompile Include="..\src\Archive\Formats\Wad2Archive.cpp" />
     <ClCompile Include="..\src\Archive\Formats\WadArchive.cpp" />
     <ClCompile Include="..\src\Archive\Formats\WadJArchive.cpp" />
@@ -677,6 +678,7 @@
     <ClInclude Include="..\src\Archive\Formats\RffArchive.h" />
     <ClInclude Include="..\src\Archive\Formats\SiNArchive.h" />
     <ClInclude Include="..\src\Archive\Formats\TarArchive.h" />
+    <ClInclude Include="..\src\Archive\Formats\VWadArchive.h" />
     <ClInclude Include="..\src\Archive\Formats\Wad2Archive.h" />
     <ClInclude Include="..\src\Archive\Formats\WadArchive.h" />
     <ClInclude Include="..\src\Archive\Formats\WadJArchive.h" />

--- a/msvc/SLADE.vcxproj.filters
+++ b/msvc/SLADE.vcxproj.filters
@@ -336,6 +336,9 @@
     <ClCompile Include="..\src\Archive\Formats\TarArchive.cpp">
       <Filter>Archive\Formats</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\Archive\Formats\VWadArchive.cpp">
+      <Filter>Archive\Formats</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\Archive\Formats\Wad2Archive.cpp">
       <Filter>Archive\Formats</Filter>
     </ClCompile>
@@ -1224,6 +1227,9 @@
       <Filter>Archive\Formats</Filter>
     </ClInclude>
     <ClInclude Include="..\src\Archive\Formats\TarArchive.h">
+      <Filter>Archive\Formats</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\Archive\Formats\VWadArchive.h">
       <Filter>Archive\Formats</Filter>
     </ClInclude>
     <ClInclude Include="..\src\Archive\Formats\Wad2Archive.h">

--- a/msvc/ThirdPartyLib.vcxproj
+++ b/msvc/ThirdPartyLib.vcxproj
@@ -46,6 +46,10 @@
     <ClInclude Include="..\thirdparty\fmt\include\fmt\xchar.h" />
     <ClInclude Include="..\thirdparty\glad\include\glad\glad.h" />
     <ClInclude Include="..\thirdparty\glad\include\KHR\khrplatform.h" />
+    <ClInclude Include="..\thirdparty\libvwad\vwadprng.h" />
+    <ClInclude Include="..\thirdparty\libvwad\vwadvfs.h" />
+    <ClInclude Include="..\thirdparty\libvwad\vwadwrite.h" />
+    <ClInclude Include="..\thirdparty\libvwad\vwadprng.h" />
     <ClInclude Include="..\thirdparty\lunasvg\3rdparty\plutovg\plutovg-private.h" />
     <ClInclude Include="..\thirdparty\lunasvg\3rdparty\plutovg\plutovg.h" />
     <ClInclude Include="..\thirdparty\lunasvg\3rdparty\software\sw_ft_math.h" />

--- a/msvc/ThirdPartyLib.vcxproj.filters
+++ b/msvc/ThirdPartyLib.vcxproj.filters
@@ -797,4 +797,15 @@
       <Filter>DUMB\helpers</Filter>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\thirdparty\libvwad\vwadprng.c">
+      <Filter>libvwad</Filter>
+    </ClCompile>
+    <ClCompile Include="..\thirdparty\libvwad\vwadvfs.c">
+      <Filter>libvwad</Filter>
+    </ClCompile>
+    <ClCompile Include="..\thirdparty\libvwad\vwadwrite.c">
+      <Filter>libvwad</Filter>
+    </ClCompile>
+  </ItemGroup>
 </Project>

--- a/src/Archive/ArchiveManager.cpp
+++ b/src/Archive/ArchiveManager.cpp
@@ -337,6 +337,8 @@ shared_ptr<Archive> ArchiveManager::openArchive(string_view filename, bool manag
 		new_archive = std::make_shared<ChasmBinArchive>();
 	else if (SiNArchive::isSiNArchive(std_fn))
 		new_archive = std::make_shared<SiNArchive>();
+	else if (VWadArchive::isVWadArchive(std_fn))
+		new_archive = std::make_shared<VWadArchive>();
 	else
 	{
 		// Unsupported format
@@ -442,6 +444,8 @@ shared_ptr<Archive> ArchiveManager::openArchive(ArchiveEntry* entry, bool manage
 		new_archive = std::make_shared<ChasmBinArchive>();
 	else if (SiNArchive::isSiNArchive(entry->data()))
 		new_archive = std::make_shared<SiNArchive>();
+	else if (VWadArchive::isVWadArchive(entry->data()))
+		new_archive = std::make_shared<VWadArchive>();
 	else
 	{
 		// Unsupported format
@@ -549,6 +553,8 @@ shared_ptr<Archive> ArchiveManager::newArchive(string_view format)
 		new_archive = std::make_shared<GrpArchive>();
 	else if (format == "pak")
 		new_archive = std::make_shared<PakArchive>();
+	else if (format == "vwad")
+		new_archive = std::make_shared<VWadArchive>();
 	else
 	{
 		global::error = fmt::format("Can not create archive of format: {}", format);

--- a/src/Archive/EntryType/DataFormats/ArchiveFormats.h
+++ b/src/Archive/EntryType/DataFormats/ArchiveFormats.h
@@ -18,6 +18,15 @@ public:
 	int isThisFormat(MemChunk& mc) override { return ZipArchive::isZipArchive(mc) ? MATCH_TRUE : MATCH_FALSE; }
 };
 
+class VWadDataFormat : public EntryDataFormat
+{
+public:
+	VWadDataFormat() : EntryDataFormat("archive_vwad") {}
+	~VWadDataFormat() = default;
+
+	int isThisFormat(MemChunk& mc) override { return VWadArchive::isVWadArchive(mc) ? MATCH_TRUE : MATCH_FALSE; }
+};
+
 class LibDataFormat : public EntryDataFormat
 {
 public:

--- a/src/Archive/EntryType/EntryDataFormat.cpp
+++ b/src/Archive/EntryType/EntryDataFormat.cpp
@@ -251,6 +251,7 @@ void EntryDataFormat::initBuiltinFormats()
 	// registerDataFormat<JediANIMFormat>();
 	registerDataFormat<WadDataFormat>();
 	registerDataFormat<ZipDataFormat>();
+	registerDataFormat<VWadDataFormat>();
 	registerDataFormat<LibDataFormat>();
 	registerDataFormat<DatDataFormat>();
 	registerDataFormat<ResDataFormat>();

--- a/src/Archive/Formats/All.h
+++ b/src/Archive/Formats/All.h
@@ -17,6 +17,7 @@
 #include "RffArchive.h"
 #include "SiNArchive.h"
 #include "TarArchive.h"
+#include "VWadArchive.h"
 #include "Wad2Archive.h"
 #include "WadArchive.h"
 #include "WadJArchive.h"

--- a/src/Archive/Formats/VWadArchive.cpp
+++ b/src/Archive/Formats/VWadArchive.cpp
@@ -1,0 +1,1014 @@
+
+// -----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2022 Simon Judd
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    VWadArchive.cpp
+// Description: VWadArchive, archive class to handle vwad format archives
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// -----------------------------------------------------------------------------
+
+
+// -----------------------------------------------------------------------------
+//
+// Includes
+//
+// -----------------------------------------------------------------------------
+#include "Main.h"
+#include "VWadArchive.h"
+#include "App.h"
+#include "General/Misc.h"
+#include "General/UI.h"
+#include "UI/WxUtils.h"
+#include "Utility/FileUtils.h"
+#include "Utility/StringUtils.h"
+#include "WadArchive.h"
+#include <vwadprng.h>
+#include <vwadvfs.h>
+#include <vwadwrite.h>
+
+using namespace slade;
+
+
+// -----------------------------------------------------------------------------
+//
+// Variables
+//
+// -----------------------------------------------------------------------------
+CVAR(Bool, vwad_allow_duplicate_names, false, CVar::Save)
+CVAR(String, vwad_private_key, "", CVar::Flag::Save)
+CVAR(String, vwad_author_name, "", CVar::Flag::Save)
+
+
+// -----------------------------------------------------------------------------
+//
+// External Variables
+//
+// -----------------------------------------------------------------------------
+EXTERN_CVAR(Bool, archive_load_data)
+EXTERN_CVAR(Int, max_entry_size_mb)
+
+
+// -----------------------------------------------------------------------------
+//
+// VWadArchive Class Functions
+//
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+// VWadArchive class constructor
+// -----------------------------------------------------------------------------
+VWadArchive::VWadArchive() : Archive("vwad")
+{
+	if (vwad_allow_duplicate_names)
+		rootDir()->allowDuplicateNames(true);
+}
+
+// -----------------------------------------------------------------------------
+// VWadArchive class destructor
+// -----------------------------------------------------------------------------
+VWadArchive::~VWadArchive()
+{
+	if (fileutil::fileExists(temp_file_))
+		fileutil::removeFile(temp_file_);
+}
+
+static int vwad_ioseek(vwad_iostream *strm, int pos)
+{
+    assert(pos >= 0);
+    FILE *fl = (FILE *)strm->udata;
+    assert(fl != NULL);
+    if (fseek(fl, pos, SEEK_SET) != 0)
+        return -1;
+    return 0;
+}
+
+static int vwad_ioread(vwad_iostream *strm, void *buf, int bufsize)
+{
+    assert(bufsize > 0);
+    FILE *fl = (FILE *)strm->udata;
+    assert(fl != NULL);
+    if (fread(buf, bufsize, 1, fl) != 1)
+        return -1;
+    return 0;
+}
+
+// -----------------------------------------------------------------------------
+// Reads vwad data from a file
+// Returns true if successful, false otherwise
+// -----------------------------------------------------------------------------
+bool VWadArchive::open(string_view filename)
+{
+	// Check the file exists
+	if (!fileutil::fileExists(filename))
+	{
+		global::error = "File does not exist";
+		return false;
+	}
+
+	// Copy the vwad to a temp file (for use when saving)
+	generateTempFileName(filename);
+	fileutil::copyFile(filename, temp_file_);
+
+	// Open the file
+	FILE *in = fopen(wxutil::strFromView(filename).c_str(), "rb");
+	if (!in)
+	{
+		global::error = "Unable to open file";
+		return false;
+	}
+
+	// Create vwad stream
+	vwad_iostream *vwad_stream = (vwad_iostream *)calloc(1, sizeof(vwad_iostream));
+	vwad_stream->udata = in;
+	vwad_stream->seek = vwad_ioseek;
+	vwad_stream->read = vwad_ioread;
+
+	// Create vwad handle using stream
+	vwad_handle *vwad_hndl = vwad_open_archive(vwad_stream, VWAD_OPEN_DEFAULT, NULL);
+
+	if (!vwad_hndl)
+	{
+		global::error = "Invalid vwad file";
+		return false;
+	}
+
+	// Stop announcements (don't want to be announcing modification due to entries being added etc)
+	const ArchiveModSignalBlocker sig_blocker{ *this };
+
+	// Check vwad properties (if applicable)
+	author_ = vwad_get_archive_author(vwad_hndl);
+	title_  = vwad_get_archive_title(vwad_hndl);
+	int comment_size = vwad_get_archive_comment_size(vwad_hndl);
+	if (comment_size > 0)
+	{
+		comment_.resize(comment_size + 1);
+		vwad_get_archive_comment(vwad_hndl, comment_.data(), comment_size + 1);
+	}
+	signed_ = (vwad_is_authenticated(vwad_hndl) && vwad_has_pubkey(vwad_hndl));
+	if (signed_)
+	{
+		vwad_public_key rawpubkey;
+		vwad_get_pubkey(vwad_hndl, rawpubkey);
+		vwad_z85_key z85_key;
+		vwad_z85_encode_key(rawpubkey, z85_key);
+		pubkey_ = std::string(z85_key);
+	}
+
+	// Go through all vwad entries
+	vwad_fidx entry_index = 0;
+	vwad_fidx total = vwad_get_archive_file_count(vwad_hndl);
+	string vwad_entry_filename; // used for libvwad path normalization
+	vwad_entry_filename.resize(256); // libvwad normalization max char limit
+	ui::setSplashProgressMessage("Reading vwad data");
+	for (; entry_index < total; entry_index++)
+	{
+		ui::setSplashProgress(-1.0f);
+
+		const char *entry_name = vwad_get_file_name(vwad_hndl, entry_index);
+
+		if (!entry_name)
+			continue;
+
+		memset(vwad_entry_filename.data(), 0, 256);
+
+		if (vwad_normalize_file_name(entry_name, vwad_entry_filename.data()) < 0)
+			continue;
+
+		// Since libvwad normalization retains the trailing slash for directories, check to see if
+		// the last character is a slash and if not consider it a file
+		if (vwad_entry_filename.back() != '/')
+		{
+			// Get the entry name as a Path (so we can break it up)
+			strutil::Path fn(vwad_entry_filename);
+
+			// Create entry
+			auto new_entry = std::make_shared<ArchiveEntry>(
+				misc::fileNameToLumpName(fn.fileName()), vwad_get_file_size(vwad_hndl, entry_index));
+
+			// Setup entry info
+			new_entry->setLoaded(false);
+			new_entry->exProp("VWadIndex") = entry_index;
+
+			// Add entry and directory to directory tree
+			auto ndir = createDir(fn.path(true));
+			ndir->addEntry(new_entry, true);
+
+			if (const auto ve_size = vwad_get_file_size(vwad_hndl, entry_index); ve_size < max_entry_size_mb * 1024 * 1024)
+			{
+				if (ve_size > 0)
+				{
+					vwad_fd vwad_entry_fd = vwad_open_fidx(vwad_hndl, entry_index);
+					if (vwad_entry_fd < 0)
+					{
+						global::error = fmt::format("Error getting vWad file descriptor for: {}", fn.fullPath());
+						return false;
+					}
+					vector<uint8_t> data(ve_size);
+					if (vwad_read(vwad_hndl, vwad_entry_fd, data.data(), ve_size) < 0)
+					{
+						global::error = fmt::format("Error importing vWad entry: {}", fn.fullPath());
+						vwad_fclose(vwad_hndl, vwad_entry_fd);
+						return false;
+					}
+					new_entry->importMem(data.data(), static_cast<uint32_t>(ve_size));
+					vwad_fclose(vwad_hndl, vwad_entry_fd);
+				}
+				new_entry->setLoaded(true);
+
+				// Determine its type
+				EntryType::detectEntryType(*new_entry);
+
+				// Unload data if needed
+				if (!archive_load_data)
+					new_entry->unloadData();
+			}
+			else
+			{
+				global::error = fmt::format("Entry too large: {} is {} mb", fn.fullPath(), ve_size / (1 << 20));
+				return false;
+			}
+		}
+		else
+		{
+			// VWad entry is a directory, add it to the directory tree
+			strutil::Path fn(vwad_entry_filename);
+			createDir(fn.path(true));
+		}
+	}
+	ui::updateSplash();
+
+	// Set all entries/directories to unmodified
+	vector<ArchiveEntry*> entry_list;
+	putEntryTreeAsList(entry_list);
+	for (auto& entry : entry_list)
+		entry->setState(ArchiveEntry::State::Unmodified);
+
+	// Enable announcements
+	sig_blocker.unblock();
+
+	// Setup variables
+	filename_      = filename;
+	file_modified_ = fileutil::fileModifiedTime(filename);
+	setModified(false);
+	on_disk_ = true;
+
+	ui::setSplashProgressMessage("");
+
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Reads vwad format data from a MemChunk
+// Returns true if successful, false otherwise
+// -----------------------------------------------------------------------------
+bool VWadArchive::open(MemChunk& mc)
+{
+	// Write the MemChunk to a temp file
+	const auto tempfile = app::path("slade-temp-open.vwad", app::Dir::Temp);
+	mc.exportFile(tempfile);
+
+	// Load the file
+	const bool success = open(tempfile);
+
+	// Clean up
+	fileutil::removeFile(tempfile);
+
+	return success;
+}
+
+// -----------------------------------------------------------------------------
+// Writes the vwad archive to a MemChunk
+// Returns true if successful, false otherwise
+// -----------------------------------------------------------------------------
+bool VWadArchive::write(MemChunk& mc, bool update)
+{
+	bool success = false;
+
+	// Write to a temporary file
+	const auto tempfile = app::path("slade-temp-write.vwad", app::Dir::Temp);
+	if (write(tempfile, true))
+	{
+		// Load file into MemChunk
+		success = mc.importFile(tempfile);
+	}
+
+	// Clean up
+	wxRemoveFile(tempfile);
+
+	return success;
+}
+
+// -----------------------------------------------------------------------------
+// Writes the vwad archive to a file
+// Returns true if successful, false otherwise
+// -----------------------------------------------------------------------------
+bool VWadArchive::write(string_view filename, bool update)
+{
+	// If no entries at all, do not attempt to make a vWAD
+	if (numEntries() == 0)
+	{
+		global::error = "Cannot write empty vWADs!";
+		return false;
+	}
+
+	// Check for entries with duplicate names (not allowed for vwads)
+	auto all_dirs = rootDir()->allDirectories();
+	all_dirs.insert(all_dirs.begin(), rootDir());
+	for (const auto& dir : all_dirs)
+	{
+		if (auto* dup_entry = dir->findDuplicateEntryName())
+		{
+			global::error = fmt::format("Multiple entries named {} found in {}", dup_entry->name(), dup_entry->path());
+			return false;
+		}
+	}
+
+	// Open old vwad for copying, from the temp file that was copied on opening.
+	// This is used to copy any entries that have been previously saved/compressed
+	// and are unmodified, to greatly speed up vwad file saving by not having to
+	// recompress unchanged entries
+	FILE *invwad = NULL;
+	vwad_iostream *invwad_stream = NULL;
+	vwad_handle *invwad_handle = NULL;
+	if (fileutil::fileExists(temp_file_))
+	{
+		invwad = fopen(temp_file_.c_str(), "rb");
+		if (invwad)
+		{
+			invwad_stream = (vwad_iostream *)calloc(1, sizeof(vwad_iostream));
+			invwad_stream->udata = invwad;
+			invwad_stream->seek = vwad_ioseek;
+			invwad_stream->read = vwad_ioread;
+			invwad_handle = vwad_open_archive(invwad_stream, VWAD_OPEN_DEFAULT, NULL);
+			if (!invwad_handle)
+			{
+				free(invwad_stream);
+				invwad_stream = NULL;
+				fclose(invwad);
+				invwad = NULL;
+			}
+		}
+	}
+
+	// Open the file
+	FILE *out = fopen(wxutil::strFromView(filename).c_str(), "wb+");
+	if (!out)
+	{
+		global::error = "Unable to open file for saving. Make sure it isn't in use by another program.";
+		return false;
+	}
+
+	// Open as vwad for writing
+	vwadwr_iostream *vwad = vwadwr_new_file_stream(out);
+	if (!vwad)
+	{
+		global::error = "Unable to create vwad for saving";
+		fclose(out);
+		return false;
+	}
+
+	vwadwr_secret_key privkey;
+	vwadwr_public_key pubkey;
+	vwadwr_uint archive_flag;
+
+	if (!vwad_private_key.empty())
+	{
+		if (vwadwr_z85_decode_key(vwad_private_key.value.c_str(), privkey) < 0)
+		{
+			global::error = "Unable to decode vwad_private_key (bad key?)";
+			vwadwr_close_file_stream(vwad);
+			return false;
+		}
+		if (!vwadwr_is_good_privkey(privkey))
+		{
+			global::error = "vwad_private_key is not sufficiently strong, generate a new one";
+			vwadwr_close_file_stream(vwad);
+			return false;
+		}
+		archive_flag = VWADWR_NEW_DEFAULT;
+	}
+	else //randomly generate signing key
+	{
+		do 
+		{
+			prng_randombytes(privkey, sizeof(vwadwr_secret_key));
+		} while (!vwadwr_is_good_privkey(privkey));
+		archive_flag = VWADWR_NEW_DONT_SIGN;
+	}
+
+	int vwad_error = 0;
+
+	vwadwr_archive *vwad_archive = vwadwr_new_archive(NULL, vwad, !vwad_author_name.empty() ? vwad_author_name.value.c_str() : 
+		(!author_.empty() ? author_.c_str() : NULL), !title_.empty() ? title_.c_str() : NULL, !comment_.empty() ? comment_.c_str() : NULL, 
+		archive_flag, privkey, pubkey, &vwad_error);
+
+	if (!vwad_archive)
+	{
+		global::error = "Unable to create vwad for saving";
+		vwadwr_close_file_stream(vwad);
+		fclose(out);
+		return false;
+	}
+
+	// Get a linear list of all entries in the archive
+	vector<ArchiveEntry*> entries;
+	putEntryTreeAsList(entries);
+
+	// Go through all entries
+	auto n_entries = entries.size();
+	ui::setSplashProgressMessage("Writing vwad entries");
+	ui::setSplashProgress(0.0f);
+	ui::updateSplash();
+	for (size_t a = 0; a < n_entries; a++)
+	{
+		ui::setSplashProgress(static_cast<float>(a) / static_cast<float>(n_entries));
+
+		// Can't write "just" a directory
+		if (entries[a]->type() == EntryType::folderType())
+		{
+			if (update)
+				entries[a]->setState(ArchiveEntry::State::Unmodified);
+			continue;
+		}
+		// Can't write nameless entires
+		if (entries[a]->name().empty())
+		{
+			if (update)
+				entries[a]->setState(ArchiveEntry::State::Unmodified);
+			log::error("Attempted to write vWAD entry with an empty name.");
+			continue;
+		}
+
+		// Get entry vwad index
+		int index = -1;
+		if (entries[a]->exProps().contains("VWadIndex"))
+			index = entries[a]->exProp<int>("VWadIndex");
+
+		auto saname = entries[a]->path() + entries[a]->name();
+
+		if (!invwad || entries[a]->state() != ArchiveEntry::State::Unmodified || index < 0
+			|| index >= vwad_get_archive_file_count(invwad_handle))
+		{
+			// If the current entry has been changed, or doesn't exist in the old vwad,
+			// (re)compress its data and write it to the vwad
+			vwadwr_fhandle vwad_hndl = vwadwr_create_file(vwad_archive, VWADWR_COMP_MEDIUM, saname.c_str(), 
+				NULL, std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+			if (vwad_hndl < 0)
+			{
+				global::error = fmt::format("Unable to write {} to vwad", saname);
+				if (invwad_handle)
+					vwad_close_archive(&invwad_handle);
+				vwadwr_finish_archive(&vwad_archive);
+				vwadwr_close_file_stream(vwad);
+				return false;
+			}
+			else
+			{
+				vwadwr_write(vwad_archive, vwad_hndl, entries[a]->rawData(), entries[a]->size());
+				vwadwr_close_file(vwad_archive, vwad_hndl);
+			}
+		}
+		else
+		{
+			vwadwr_fhandle vwad_hndl = vwadwr_create_raw_file(vwad_archive,
+														vwad_get_file_name(invwad_handle, index),
+														vwad_get_file_group_name(invwad_handle, index),
+														vwad_get_fcrc32(invwad_handle, index),
+														vwad_get_ftime(invwad_handle, index));
+			if (vwad_hndl < 0) 
+			{
+				global::error = fmt::format("Unable to copy {} to vwad", saname);
+				vwad_close_archive(&invwad_handle);
+				vwadwr_finish_archive(&vwad_archive);
+				vwadwr_close_file_stream(vwad);
+				return false;
+			}
+
+			const int entry_chunk_count = vwad_get_file_chunk_count(invwad_handle, index);
+			if (entry_chunk_count < 0) 
+			{
+				global::error = fmt::format("Unable to copy {} to vwad", saname);
+				vwad_close_archive(&invwad_handle);
+				vwadwr_close_file(vwad_archive, vwad_hndl);
+				vwadwr_finish_archive(&vwad_archive);
+				vwadwr_close_file_stream(vwad);
+				return false;
+			}
+
+			if (entry_chunk_count > 0)
+			{
+				char *buf = (char *)malloc(VWAD_MAX_RAW_CHUNK_SIZE);
+				int pksz, upksz;
+				vwad_bool packed;
+				vwad_result res;
+
+				for (int chunk = 0; chunk < entry_chunk_count; chunk++)
+				{
+					memset(buf, 0, VWAD_MAX_RAW_CHUNK_SIZE);
+					res = vwad_get_raw_file_chunk_info(invwad_handle, index, chunk, &pksz, &upksz, &packed);
+					if (res != VWAD_OK) 
+					{
+						global::error = fmt::format("Unable to copy {} to vwad", saname);
+						vwad_close_archive(&invwad_handle);
+						vwadwr_close_file(vwad_archive, vwad_hndl);
+						vwadwr_finish_archive(&vwad_archive);
+						vwadwr_close_file_stream(vwad);
+						free(buf);
+						return false;
+					}
+					res = vwad_read_raw_file_chunk(invwad_handle, index, chunk, buf);
+					if (res != VWAD_OK) 
+					{
+						global::error = fmt::format("Unable to copy {} to vwad", saname);
+						vwad_close_archive(&invwad_handle);
+						vwadwr_close_file(vwad_archive, vwad_hndl);
+						vwadwr_finish_archive(&vwad_archive);
+						vwadwr_close_file_stream(vwad);
+						free(buf);
+						return false;
+					}
+					res = vwadwr_write_raw_chunk(vwad_archive, vwad_hndl, buf, pksz, upksz, packed);
+					if (res != VWADWR_OK) 
+					{
+						global::error = fmt::format("Unable to copy {} to vwad", saname);
+						vwad_close_archive(&invwad_handle);
+						vwadwr_close_file(vwad_archive, vwad_hndl);
+						vwadwr_finish_archive(&vwad_archive);
+						vwadwr_close_file_stream(vwad);
+						free(buf);
+						return false;
+					}
+				}
+				free(buf);
+			}
+
+			if (vwadwr_close_file(vwad_archive, vwad_hndl) != VWADWR_OK) 
+			{
+				global::error = fmt::format("Unable to copy {} to vwad", saname);
+				vwad_close_archive(&invwad_handle);
+				vwadwr_finish_archive(&vwad_archive);
+				vwadwr_close_file_stream(vwad);
+				return false;
+			}
+		}
+
+		// Update entry info
+		if (update)
+		{
+			entries[a]->setState(ArchiveEntry::State::Unmodified);
+			entries[a]->exProp("VWadIndex") = static_cast<int>(a);
+		}
+	}
+
+	// Clean up
+	if (invwad_handle)
+		vwad_close_archive(&invwad_handle);
+	if (vwadwr_finish_archive(&vwad_archive) < 0)
+	{
+		vwadwr_close_file_stream(vwad);
+		return false;
+	}
+	else
+		vwadwr_close_file_stream(vwad);
+
+	// Update the temp file
+	if (temp_file_.empty())
+		generateTempFileName(filename);
+	fileutil::copyFile(filename, temp_file_);
+
+	ui::setSplashProgressMessage("");
+
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Loads an entry's data from the saved copy of the archive if any.
+// Returns false if the entry is invalid, doesn't belong to the archive or
+// doesn't exist in the saved copy, true otherwise.
+// -----------------------------------------------------------------------------
+bool VWadArchive::loadEntryData(ArchiveEntry* entry)
+{
+	// Check that the entry belongs to this archive
+	if (entry->parent() != this)
+	{
+		log::error("VWadArchive::loadEntryData: Entry {} attempting to load data from wrong parent!", entry->name());
+		return false;
+	}
+
+	// Do nothing if the entry's size is zero,
+	// or if it has already been loaded
+	if (entry->size() == 0 || entry->isLoaded())
+	{
+		entry->setLoaded();
+		return true;
+	}
+
+	// Check that the entry has a vwad index
+	int vwad_index;
+	if (entry->exProps().contains("VWadIndex"))
+		vwad_index = entry->exProp<int>("VWadIndex");
+	else
+	{
+		log::error("VWadArchive::loadEntryData: Entry {} has no vwad entry index!", entry->name());
+		return false;
+	}
+
+	// Open the file
+	FILE *in = fopen(filename_.c_str(), "rb");
+	if (!in)
+	{
+		log::error("VWadArchive::loadEntryData: Unable to open vwad file \"{}\"!", filename_);
+		return false;
+	}
+
+	// Create vwad stream
+	vwad_iostream *vwad_stream = (vwad_iostream *)calloc(1, sizeof(vwad_iostream));
+	vwad_stream->udata = in;
+	vwad_stream->seek = vwad_ioseek;
+	vwad_stream->read = vwad_ioread;
+
+	// Create vwad handle using stream
+	vwad_handle *vwad_hndl = vwad_open_archive(vwad_stream, VWAD_OPEN_DEFAULT, NULL);
+
+	if (!vwad_hndl)
+	{
+		log::error("VWadArchive::loadEntryData: Invalid vwad file \"{}\"!", filename_);
+		return false;
+	}
+
+	// Lock entry state
+	entry->lockState();
+
+	// Abort if entry doesn't exist in vwad (some kind of error)
+	vwad_fd ventry = vwad_open_fidx(vwad_hndl, vwad_index);
+	if (ventry < 0)
+	{
+		log::error("Error: VWadEntry for entry \"{}\" does not exist in vwad", entry->name());
+		return false;
+	}
+
+	// Read the data
+	int ventry_size = vwad_get_file_size(vwad_hndl, vwad_index);
+	vector<uint8_t> data(ventry_size);
+	if (vwad_read(vwad_hndl, ventry, data.data(), ventry_size) < 0)
+	{
+		log::error("Error: VWadEntry for entry \"{}\" encountered a read error", entry->name());
+		vwad_fclose(vwad_hndl, vwad_index);
+		vwad_close_archive(&vwad_hndl);
+		return false;
+	}
+	entry->importMem(data.data(), static_cast<uint32_t>(ventry_size));
+
+	// Set the entry to loaded
+	entry->setLoaded();
+	entry->unlockState();
+
+	// Clean up
+	vwad_fclose(vwad_hndl, vwad_index);
+	vwad_close_archive(&vwad_hndl);
+
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Adds [entry] to the end of the namespace matching [add_namespace].
+// If [copy] is true a copy of the entry is added.
+// Returns the added entry or NULL if the entry is invalid
+//
+// In a vwad archive, a namespace is simply a first-level directory, ie
+// <root>/<namespace>
+// -----------------------------------------------------------------------------
+shared_ptr<ArchiveEntry> VWadArchive::addEntry(shared_ptr<ArchiveEntry> entry, string_view add_namespace)
+{
+	// Check namespace
+	if (add_namespace.empty() || add_namespace == "global")
+		return Archive::addEntry(entry, 0xFFFFFFFF, nullptr);
+
+	// Get/Create namespace dir
+	const auto dir = createDir(strutil::lower(add_namespace));
+
+	// Add the entry to the dir
+	return Archive::addEntry(entry, 0xFFFFFFFF, dir.get());
+}
+
+// -----------------------------------------------------------------------------
+// Returns the mapdesc_t information about the map at [entry], if [entry] is
+// actually a valid map (ie. a wad archive in the maps folder)
+// -----------------------------------------------------------------------------
+Archive::MapDesc VWadArchive::mapDesc(ArchiveEntry* maphead)
+{
+	MapDesc map;
+
+	// Check entry
+	if (!checkEntry(maphead))
+		return map;
+
+	// Check entry type
+	if (maphead->type()->formatId() != "archive_wad")
+		return map;
+
+	// Check entry directory
+	if (maphead->parentDir()->parent() != rootDir() || maphead->parentDir()->name() != "maps")
+		return map;
+
+	// Setup map info
+	map.archive = true;
+	map.head    = maphead->getShared();
+	map.end     = maphead->getShared();
+	map.name    = maphead->upperNameNoExt();
+
+	return map;
+}
+
+// -----------------------------------------------------------------------------
+// Detects all the maps in the archive and returns a vector of information about
+// them.
+// -----------------------------------------------------------------------------
+vector<Archive::MapDesc> VWadArchive::detectMaps()
+{
+	vector<MapDesc> ret;
+
+	// Get the maps directory
+	const auto mapdir = dirAtPath("maps");
+	if (!mapdir)
+		return ret;
+
+	// Go through entries in map dir
+	for (unsigned a = 0; a < mapdir->numEntries(); a++)
+	{
+		auto entry = mapdir->sharedEntryAt(a);
+
+		// Maps can only be wad archives
+		if (entry->type()->formatId() != "archive_wad")
+			continue;
+
+		// Detect map format (probably kinda slow but whatever, no better way to do it really)
+		auto       format = MapFormat::Unknown;
+		WadArchive tempwad;
+		tempwad.open(entry->data());
+		auto emaps = tempwad.detectMaps();
+		if (!emaps.empty())
+			format = emaps[0].format;
+
+		// Add map description
+		MapDesc md;
+		md.head    = entry;
+		md.end     = entry;
+		md.archive = true;
+		md.name    = entry->upperNameNoExt();
+		md.format  = format;
+		ret.push_back(md);
+	}
+
+	return ret;
+}
+
+// -----------------------------------------------------------------------------
+// Returns the first entry matching the search criteria in [options], or null if
+// no matching entry was found
+// -----------------------------------------------------------------------------
+ArchiveEntry* VWadArchive::findFirst(SearchOptions& options)
+{
+	// Init search variables
+	auto dir = rootDir().get();
+
+	// Check for search directory (overrides namespace)
+	if (options.dir)
+	{
+		dir = options.dir;
+	}
+	// Check for namespace
+	else if (!options.match_namespace.empty())
+	{
+		dir = dirAtPath(options.match_namespace);
+
+		// If the requested namespace doesn't exist, return nothing
+		if (!dir)
+			return nullptr;
+		else
+			options.search_subdirs = true; // Namespace search always includes namespace subdirs
+	}
+
+	// Do default search
+	auto opt            = options;
+	opt.dir             = dir;
+	opt.match_namespace = "";
+	return Archive::findFirst(opt);
+}
+
+// -----------------------------------------------------------------------------
+// Returns the last entry matching the search criteria in [options], or null if
+// no matching entry was found
+// -----------------------------------------------------------------------------
+ArchiveEntry* VWadArchive::findLast(SearchOptions& options)
+{
+	// Init search variables
+	auto dir = rootDir().get();
+
+	// Check for search directory (overrides namespace)
+	if (options.dir)
+	{
+		dir = options.dir;
+	}
+	// Check for namespace
+	else if (!options.match_namespace.empty())
+	{
+		dir = dirAtPath(options.match_namespace);
+
+		// If the requested namespace doesn't exist, return nothing
+		if (!dir)
+			return nullptr;
+		else
+			options.search_subdirs = true; // Namespace search always includes namespace subdirs
+	}
+
+	// Do default search
+	auto opt            = options;
+	opt.dir             = dir;
+	opt.match_namespace = "";
+	return Archive::findLast(opt);
+}
+
+// -----------------------------------------------------------------------------
+// Returns all entries matching the search criteria in [options]
+// -----------------------------------------------------------------------------
+vector<ArchiveEntry*> VWadArchive::findAll(SearchOptions& options)
+{
+	// Init search variables
+	auto                  dir = rootDir().get();
+	vector<ArchiveEntry*> ret;
+
+	// Check for search directory (overrides namespace)
+	if (options.dir)
+	{
+		dir = options.dir;
+	}
+	// Check for namespace
+	else if (!options.match_namespace.empty())
+	{
+		dir = dirAtPath(options.match_namespace);
+
+		// If the requested namespace doesn't exist, return nothing
+		if (!dir)
+			return ret;
+		else
+			options.search_subdirs = true; // Namespace search always includes namespace subdirs
+	}
+
+	// Do default search
+	auto opt            = options;
+	opt.dir             = dir;
+	opt.match_namespace = "";
+	return Archive::findAll(opt);
+}
+
+// -----------------------------------------------------------------------------
+// Generates the temp file path to use, from [filename].
+// The temp file will be in the configured temp folder
+// -----------------------------------------------------------------------------
+void VWadArchive::generateTempFileName(string_view filename)
+{
+	const strutil::Path tfn(filename);
+	temp_file_ = app::path(tfn.fileName(), app::Dir::Temp);
+	if (wxFileExists(temp_file_))
+	{
+		// Make sure we don't overwrite an existing temp file
+		// (in case there are multiple vwads open with the same name)
+		int n = 1;
+		while (true)
+		{
+			temp_file_ = app::path(fmt::format("{}.{}", tfn.fileName(), n), app::Dir::Temp);
+			if (!wxFileExists(temp_file_))
+				break;
+
+			n++;
+		}
+	}
+}
+
+string VWadArchive::getAuthor()
+{
+	string ret = author_.empty() ? "" : author_;
+	return ret;
+}
+
+string VWadArchive::getTitle()
+{
+	string ret = title_.empty() ? "" : title_;
+	return ret;
+}
+
+string VWadArchive::getComment()
+{
+	string ret = comment_.empty() ? "" : comment_;
+	return ret;
+}
+
+bool   VWadArchive::isSigned()
+{
+	return signed_;
+}
+
+string VWadArchive::getPublicKey()
+{
+	string ret = pubkey_.empty() ? "" : pubkey_;
+	return ret;
+}
+
+// -----------------------------------------------------------------------------
+//
+// VWadArchive Class Static Functions
+//
+// -----------------------------------------------------------------------------
+
+
+// -----------------------------------------------------------------------------
+// Checks if the given data is a valid vwad archive
+// -----------------------------------------------------------------------------
+bool VWadArchive::isVWadArchive(MemChunk& mc)
+{
+	// Check size
+	if (mc.size() < 22)
+		return false;
+
+	// Read first 4 bytes
+	uint32_t sig;
+	mc.seek(0, SEEK_SET);
+	mc.read(&sig, sizeof(uint32_t));
+
+	// Check for signature
+	if (sig == 0x44415756) // File header
+		return true;
+
+	return false;
+}
+
+// -----------------------------------------------------------------------------
+// Checks if the file at [filename] is a valid vwad archive
+// -----------------------------------------------------------------------------
+bool VWadArchive::isVWadArchive(const string& filename)
+{
+	// Open the file for reading
+	wxFile file(filename);
+
+	// Check it opened
+	if (!file.IsOpened())
+		return false;
+
+	// Read first 4 bytes
+	uint32_t sig;
+	file.Read(&sig, sizeof(uint32_t));
+
+	// Check for signature
+	if (sig == 0x44415756) // File header
+		return true;
+
+	return false;
+}
+
+// -----------------------------------------------------------------------------
+// Generates an ASCII-encoded private key for vWAD signing
+// -----------------------------------------------------------------------------
+string vwad::generatePrivateKey()
+{
+	vwadwr_secret_key privkey;
+	do 
+	{
+		prng_randombytes(privkey, sizeof(vwadwr_secret_key));
+	} while (!vwadwr_is_good_privkey(privkey));
+	vwadwr_z85_key z85_key;
+	vwadwr_z85_encode_key(privkey, z85_key);
+	string encoded_key(z85_key);
+	return encoded_key;
+}
+
+// -----------------------------------------------------------------------------
+// Derives an ASCII-encoded public key from a provided ASCII-encoded private key
+// -----------------------------------------------------------------------------
+string vwad::derivePublicKey(string_view privkey)
+{
+	vwadwr_secret_key decoded_key;
+	vwadwr_z85_decode_key(wxutil::strFromView(privkey).c_str(), decoded_key);
+	vwadwr_public_key pubkey;
+	vwadwr_z85_get_pubkey(pubkey, decoded_key);
+	vwadwr_z85_key z85_key;
+	vwadwr_z85_encode_key(pubkey, z85_key);
+	string encoded_key(z85_key);
+	return encoded_key;
+}

--- a/src/Archive/Formats/VWadArchive.h
+++ b/src/Archive/Formats/VWadArchive.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "Archive/Archive.h"
+
+namespace slade
+{
+class VWadArchive : public Archive
+{
+public:
+	VWadArchive();
+	~VWadArchive() override;
+
+	// Opening
+	bool open(string_view filename) override; // Open from File
+	bool open(MemChunk& mc) override;         // Open from MemChunk
+
+	// Writing/Saving
+	bool write(MemChunk& mc, bool update = true) override;         // Write to MemChunk
+	bool write(string_view filename, bool update = true) override; // Write to File
+
+	// Misc
+	bool   loadEntryData(ArchiveEntry* entry) override;
+
+	// Entry addition/removal
+	shared_ptr<ArchiveEntry> addEntry(shared_ptr<ArchiveEntry> entry, string_view add_namespace) override;
+
+	// Detection
+	MapDesc         mapDesc(ArchiveEntry* maphead) override;
+	vector<MapDesc> detectMaps() override;
+
+	// Search
+	ArchiveEntry*         findFirst(SearchOptions& options) override;
+	ArchiveEntry*         findLast(SearchOptions& options) override;
+	vector<ArchiveEntry*> findAll(SearchOptions& options) override;
+
+	// Metadata
+	string getAuthor();
+	string getTitle();
+	string getComment();
+	bool   isSigned();
+	string getPublicKey();
+
+	// Static functions
+	static bool isVWadArchive(MemChunk& mc);
+	static bool isVWadArchive(const string& filename);
+
+private:
+	string temp_file_;
+	string author_;
+	string title_;
+	string comment_;
+	bool   signed_;
+	string pubkey_;
+
+	void generateTempFileName(string_view filename);
+};
+
+namespace vwad
+{
+	string generatePrivateKey();
+	string derivePublicKey(string_view privkey);
+}
+} // namespace slade

--- a/src/Scripting/Export/Archive.cpp
+++ b/src/Scripting/Export/Archive.cpp
@@ -216,6 +216,7 @@ void registerArchive(sol::state& lua)
 #define REGISTER_ARCHIVE(type) lua.new_usertype<type>(#type, sol::base_classes, sol::bases<Archive>())
 	REGISTER_ARCHIVE(WadArchive);
 	REGISTER_ARCHIVE(ZipArchive);
+	REGISTER_ARCHIVE(VWadArchive);
 	REGISTER_ARCHIVE(LibArchive);
 	REGISTER_ARCHIVE(DatArchive);
 	REGISTER_ARCHIVE(ResArchive);
@@ -389,6 +390,16 @@ void registerArchivesNamespace(sol::state& lua)
 	archives["AddBookmark"]    = [](ArchiveEntry* entry) { app::archiveManager().addBookmark(entry->getShared()); };
 	archives["RemoveBookmark"] = [](ArchiveEntry* entry) { app::archiveManager().deleteBookmark(entry); };
 	archives["EntryType"]      = &EntryType::fromId;
+
+	// Create a VWad namespace within the Archives namespace
+	auto vwad = archives.create_named("VWad");
+	vwad["CreatePrivateKey"] = []() { return vwad::generatePrivateKey(); };
+	vwad["DerivePublicKey"] = [](string_view privkey) { return vwad::derivePublicKey(privkey); };
+	vwad["GetAuthor"] = [](Archive& archive) { VWadArchive &vwad = (VWadArchive &)archive; return vwad.getAuthor(); };
+	vwad["GetTitle"] = [](Archive& archive) { VWadArchive &vwad = (VWadArchive &)archive; return vwad.getTitle(); };
+	vwad["GetComment"] = [](Archive& archive) { VWadArchive &vwad = (VWadArchive &)archive; return vwad.getComment(); };
+	vwad["GetPublicKey"] = [](Archive& archive) { VWadArchive &vwad = (VWadArchive &)archive; return vwad.getPublicKey(); };
+	vwad["IsSigned"] = [](Archive& archive) { VWadArchive &vwad = (VWadArchive &)archive; return vwad.isSigned(); };
 }
 
 // -----------------------------------------------------------------------------

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -19,6 +19,7 @@ set(EXTERNAL_SOURCES
 file(GLOB_RECURSE EXTERNAL_SOURCES
 	lzma/C/LzmaDec.c
 	glad/src/*.c
+	libvwad/*.c
 	${DUMB_SOURCES}
 	${SLADE_HEADERS}
 	)
@@ -49,3 +50,6 @@ if(USE_SYSTEM_DUMB)
 else()
 	target_include_directories(external PUBLIC ${CMAKE_CURRENT_LIST_DIR}/dumb)
 endif()
+
+# Expose libvwad headers
+target_include_directories(external PUBLIC ${CMAKE_CURRENT_LIST_DIR}/libvwad)

--- a/thirdparty/libvwad/LICENSE
+++ b/thirdparty/libvwad/LICENSE
@@ -1,0 +1,13 @@
+DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
+                    Version 2, December 2004 
+
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net> 
+
+ Everyone is permitted to copy and distribute verbatim or modified 
+ copies of this license document, and changing it is allowed as long 
+ as the name is changed. 
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE 
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION 
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.

--- a/thirdparty/libvwad/vwadprng.c
+++ b/thirdparty/libvwad/vwadprng.c
@@ -1,0 +1,413 @@
+/* coded by Ketmar Dark */
+/* public domain */
+/* get (almost) crypto-secure random bytes */
+/* this will try to use the best PRNG available */
+#include "vwadprng.h"
+
+/*#include <stdint.h>*/
+#include <stdlib.h>
+#include <string.h>
+#ifdef WIN32
+# include <windows.h>
+#else
+# include <unistd.h>
+# include <fcntl.h>
+# include <errno.h>
+# include <time.h>
+# include <sys/time.h>
+# if defined(__SWITCH__)
+#  include <switch/kernel/random.h> // for randomGet()
+/*
+# elif defined(__linux__) && !defined(ANDROID)
+#  include <sys/random.h>
+*/
+# endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+// this should be 8 bit (i hope so)
+typedef unsigned char xprng_ubyte;
+// this should be 32 bit (i hope so)
+typedef unsigned int xprng_uint;
+// this should be 64 bit (i hope so)
+typedef unsigned long long xprng_uint64;
+
+// size checks
+typedef char xprng_temp_typedef_check_ubyte[(sizeof(xprng_ubyte) == 1) ? 1 : -1];
+typedef char xprng_temp_typedef_check_uint[(sizeof(xprng_uint) == 4) ? 1 : -1];
+typedef char xprng_temp_typedef_check_uint64[(sizeof(xprng_uint64) == 8) ? 1 : -1];
+
+
+static int g_xrng_strong_seed = 0;
+
+
+/* turning off inlining saves ~5kb of binary code on x86 */
+#ifdef _MSC_VER
+# define XPRNG_INLINE  __forceinline
+#else
+# define XPRNG_INLINE  inline __attribute__((always_inline))
+#endif
+
+
+static XPRNG_INLINE xprng_uint isaac_rra (xprng_uint value, unsigned int count) { return (value>>count)|(value<<(32-count)); }
+static XPRNG_INLINE xprng_uint isaac_rla (xprng_uint value, unsigned int count) { return (value<<count)|(value>>(32-count)); }
+
+static XPRNG_INLINE void isaac_getu32 (xprng_ubyte *p, const xprng_uint v) {
+  p[0] = (xprng_ubyte)(v&0xffu);
+  p[1] = (xprng_ubyte)((v>>8)&0xffu);
+  p[2] = (xprng_ubyte)((v>>16)&0xffu);
+  p[3] = (xprng_ubyte)((v>>24)&0xffu);
+}
+
+/*
+ * ISAAC+ "variant", the paper is not clear on operator precedence and other
+ * things. This is the "first in, first out" option!
+ */
+typedef struct isaacp_state_t {
+  xprng_uint state[256];
+  xprng_ubyte buffer[1024];
+  union __attribute__((packed)) {
+    xprng_uint abc[3];
+    struct __attribute__((packed)) {
+      xprng_uint a, b, c;
+    };
+  };
+  size_t left;
+} isaacp_state;
+
+#define isaacp_step(offset,mix) \
+  x = mm[i+offset]; \
+  a = (a^(mix))+(mm[(i+offset+128u)&0xffu]); \
+  y = (a^b)+mm[(x>>2)&0xffu]; \
+  mm[i+offset] = y; \
+  b = (x+a)^mm[(y>>10)&0xffu]; \
+  isaac_getu32(out+(i+offset)*4u, b);
+
+static XPRNG_INLINE void isaacp_mix (isaacp_state *st) {
+  xprng_uint x, y;
+  xprng_uint a = st->a, b = st->b, c = st->c;
+  xprng_uint *mm = st->state;
+  xprng_ubyte *out = st->buffer;
+  c = c+1u;
+  b = b+c;
+  for (unsigned i = 0u; i < 256u; i += 4u) {
+    isaacp_step(0u, isaac_rla(a,13u))
+    isaacp_step(1u, isaac_rra(a, 6u))
+    isaacp_step(2u, isaac_rla(a, 2u))
+    isaacp_step(3u, isaac_rra(a,16u))
+  }
+  st->a = a;
+  st->b = b;
+  st->c = c;
+  st->left = 1024u;
+}
+
+static void isaacp_random (isaacp_state *st, void *p, size_t len) {
+  xprng_ubyte *c = (xprng_ubyte *)p;
+  while (len) {
+    const size_t use = (len > st->left ? st->left : len);
+    memcpy(c, st->buffer+(sizeof(st->buffer)-st->left), use);
+    st->left -= use;
+    c += use;
+    len -= use;
+    if (!st->left) isaacp_mix(st);
+  }
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// SplitMix; mostly used to generate 64-bit seeds
+static XPRNG_INLINE xprng_uint64 splitmix64_next (xprng_uint64 *state) {
+  xprng_uint64 result = *state;
+  *state = result+(xprng_uint64)0x9E3779B97f4A7C15ULL;
+  result = (result^(result>>30))*(xprng_uint64)0xBF58476D1CE4E5B9ULL;
+  result = (result^(result>>27))*(xprng_uint64)0x94D049BB133111EBULL;
+  return result^(result>>31);
+}
+
+static XPRNG_INLINE void splitmix64_seedU64 (xprng_uint64 *state, xprng_uint seed0, xprng_uint seed1) {
+  // hashU32
+  xprng_uint res = seed0;
+  res -= (res<<6);
+  res ^= (res>>17);
+  res -= (res<<9);
+  res ^= (res<<4);
+  res -= (res<<3);
+  res ^= (res<<10);
+  res ^= (res>>15);
+  xprng_uint64 n = res;
+  n <<= 32;
+  // hashU32
+  res += seed1; // `+=`!
+  res -= (res<<6);
+  res ^= (res>>17);
+  res -= (res<<9);
+  res ^= (res<<4);
+  res -= (res<<3);
+  res ^= (res<<10);
+  res ^= (res>>15);
+  n |= res;
+  *state = n;
+}
+
+
+#ifdef WIN32
+// ////////////////////////////////////////////////////////////////////////// //
+// use shitdoze `RtlGenRandom()` if possible
+typedef BOOLEAN WINAPI (*RtlGenRandomFn) (PVOID RandomBuffer, ULONG RandomBufferLength);
+
+static void RtlGenRandomX (PVOID RandomBuffer, ULONG RandomBufferLength) {
+  if (RandomBufferLength <= 0) return;
+  RtlGenRandomFn RtlGenRandomXX = NULL;
+  HMODULE libh = LoadLibraryA("advapi32.dll");
+  if (libh) {
+    RtlGenRandomXX = (RtlGenRandomFn)(void *)GetProcAddress(libh, "SystemFunction036");
+    //if (!RtlGenRandomXX) fprintf(stderr, "WARNING: `RtlGenRandom()` is not found!\n");
+    //else fprintf(stderr, "MESSAGE: `RtlGenRandom()` found!\n");
+    if (RtlGenRandomXX) {
+      BOOLEAN res = RtlGenRandomXX(RandomBuffer, RandomBufferLength);
+      FreeLibrary(libh);
+      if (res) {
+        g_xrng_strong_seed = 1;
+        return;
+      }
+      //fprintf(stderr, "WARNING: `RtlGenRandom()` fallback for %u bytes!\n", (unsigned)RandomBufferLength);
+    }
+  }
+  // use some semi-random shit to seed ISAAC+, and ask it for random numbers
+  isaacp_state rng;
+  // initialise ISAAC+ with some shit
+  xprng_uint smxseed0 = 0;
+  xprng_uint smxseed1 = (xprng_uint)GetCurrentProcessId();
+  SYSTEMTIME st;
+  FILETIME ft;
+  GetLocalTime(&st);
+  if (!SystemTimeToFileTime(&st, &ft)) {
+    //fprintf(stderr, "SHIT: `SystemTimeToFileTime()` failed!\n");
+    smxseed0 = (xprng_uint)(GetTickCount());
+  } else {
+    smxseed0 = (xprng_uint)(ft.dwLowDateTime);
+  }
+  // use SplitMix to generate ISAAC+ seed
+  xprng_uint64 smx;
+  splitmix64_seedU64(&smx, smxseed0, smxseed1);
+  for (unsigned n = 0; n < 256; ++n) rng.state[n] = splitmix64_next(&smx);
+  rng.a = splitmix64_next(&smx);
+  rng.b = splitmix64_next(&smx);
+  rng.c = splitmix64_next(&smx);
+  isaacp_mix(&rng);
+  isaacp_mix(&rng);
+  // generate random bytes with ISAAC+
+  isaacp_random(&rng, RandomBuffer, RandomBufferLength);
+}
+
+#elif defined(__linux__) && !defined(ANDROID)
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+/*#include <stdio.h>*/
+
+static ssize_t why_glibc_is_so_fucked_get_random (void *buf, size_t bufsize) {
+  #ifdef SYS_getrandom
+  # ifndef GRND_NONBLOCK
+  #  define GRND_NONBLOCK (1)
+  # endif
+  for (;;) {
+    ssize_t ret = syscall(SYS_getrandom, buf, bufsize, GRND_NONBLOCK);
+    if (ret >= 0) {
+      /*fprintf(stderr, "*** SYS_getrandom is here! read %u bytes out of %u\n", (unsigned)ret, (unsigned)bufsize);*/
+      return ret;
+    }
+    if (ret != -EINTR) break;
+  }
+  #endif
+  return -1;
+}
+#elif defined(__linux__) || defined(__SWITCH__)
+/* ok, do nothing */
+#else
+# error "unsupported OS!"
+#endif
+
+
+//==========================================================================
+//
+//  randombytes_init
+//
+//  initialize ISAAC+
+//
+//==========================================================================
+static void randombytes_init (isaacp_state *rng) {
+  xprng_uint xstate[256+3]; /* and `abc` */
+  for (unsigned f = 0u; f < 256u+3u; ++f) xstate[f] = f+666u;
+  memset(rng, 0, sizeof(isaacp_state));
+  #ifdef __SWITCH__
+  randomGet(xstate, sizeof(xstate));
+  g_xrng_strong_seed = 1; /* i hope so */
+  #elif defined(WIN32)
+  RtlGenRandomX(xstate, sizeof(xstate));
+  #else
+  size_t pos = 0;
+  #if defined(__linux__) && !defined(ANDROID)
+  /* try to use kernel syscall first */
+  while (pos < sizeof(xstate)) {
+    /* reads up to 256 bytes should not be interrupted by signals */
+    size_t len = sizeof(xstate)-pos;
+    if (len > 256) len = 256; /* maximum block for syscall; or at least i heard so */
+    ssize_t rd = why_glibc_is_so_fucked_get_random(((xprng_ubyte *)xstate)+pos, len);
+    if (rd < 0) break;
+    pos += (size_t)rd;
+  }
+  /* do not mix additional sources if we got all random bytes from kernel */
+  g_xrng_strong_seed = (pos == sizeof(xstate));
+  const unsigned mixother = (pos != sizeof(xstate));
+  #else
+  const unsigned mixother = 1u;
+  #endif
+  /* fill up what is left with "/dev/urandom" */
+  /* note that "/dev/urandom" is considered strong too, even if it is tampered */
+  if (pos < sizeof(xstate)) {
+    int fd = open("/dev/urandom", O_RDONLY/*|O_CLOEXEC*/);
+    if (fd >= 0) {
+      while (pos < sizeof(xstate)) {
+        size_t len = sizeof(xstate)-pos;
+        ssize_t rd = read(fd, ((xprng_ubyte *)xstate)+pos, len);
+        if (rd < 0) {
+          if (errno != EINTR) break;
+        } else {
+          pos += (size_t)rd;
+        }
+      }
+      close(fd);
+      g_xrng_strong_seed = (pos == sizeof(xstate));
+    }
+  }
+  /* mix some other random sources, just in case */
+  if (mixother) {
+    xprng_uint smxseed0 = 0;
+    xprng_uint smxseed1 = (xprng_uint)getpid();
+    #if defined(__linux__)
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+      smxseed0 = ts.tv_sec^ts.tv_nsec;
+    } else {
+      struct timeval tp;
+      struct timezone tzp;
+      gettimeofday(&tp, &tzp);
+      smxseed0 = tp.tv_sec^tp.tv_usec;
+    }
+    #else
+    struct timeval tp;
+    struct timezone tzp;
+    gettimeofday(&tp, &tzp);
+    smxseed0 = tp.tv_sec^tp.tv_usec;
+    #endif
+    isaacp_state rngtmp;
+    xprng_uint64 smx;
+    splitmix64_seedU64(&smx, smxseed0, smxseed1);
+    for (unsigned n = 0; n < 256u; ++n) rngtmp.state[n] = splitmix64_next(&smx);
+    rngtmp.a = splitmix64_next(&smx);
+    rngtmp.b = splitmix64_next(&smx);
+    rngtmp.c = splitmix64_next(&smx);
+    isaacp_mix(&rngtmp);
+    isaacp_mix(&rngtmp);
+    isaacp_random(&rngtmp, rng->state, sizeof(rng->state));
+    isaacp_random(&rngtmp, rng->abc, sizeof(rng->abc));
+  }
+  #endif
+  /* xor ISAAC+ state with random bytes for from various sources */
+  for (unsigned f = 0u; f < 256u; ++f) rng->state[f] ^= xstate[f];
+  for (unsigned f = 0u; f < 3u; ++f) rng->abc[f] ^= xstate[256u+f];
+  isaacp_mix(rng);
+  isaacp_mix(rng);
+}
+
+
+#ifdef WIN32
+static volatile LONG g_xrng_lock = 0;
+#elif defined(__linux__) || defined(__SWITCH__)
+static volatile unsigned g_xrng_lock = 0;
+#else
+# error "unsupported OS!"
+#endif
+
+static unsigned g_xrng_initialized = 0;
+static isaacp_state g_xrng;
+
+
+//==========================================================================
+//
+//  prng_is_strong_seed
+//
+//==========================================================================
+int prng_is_strong_seed () {
+  int res;
+
+  // spinlock
+  #ifdef WIN32
+  while (InterlockedCompareExchange(&g_xrng_lock, 1, 0)) {}
+  #else
+  while (__atomic_exchange_n(&g_xrng_lock, 1, __ATOMIC_SEQ_CST)) {}
+  #endif
+
+  if (!g_xrng_initialized) {
+    randombytes_init(&g_xrng);
+    g_xrng_initialized = 1;
+  }
+
+  res = g_xrng_strong_seed;
+
+  // release lock
+  #ifdef WIN32
+  // `g_xrng_lock` is definitely `1` here
+  (void)InterlockedCompareExchange(&g_xrng_lock, 0, 1);
+  #else
+  __atomic_store_n(&g_xrng_lock, 0, __ATOMIC_SEQ_CST);
+  #endif
+
+  return res;
+}
+
+
+//==========================================================================
+//
+//  prng_randombytes
+//
+//==========================================================================
+void prng_randombytes (void *p, unsigned len) {
+  if (!len || !p) return;
+
+  // spinlock
+  #ifdef WIN32
+  while (InterlockedCompareExchange(&g_xrng_lock, 1, 0)) {}
+  #else
+  while (__atomic_exchange_n(&g_xrng_lock, 1, __ATOMIC_SEQ_CST)) {}
+  #endif
+
+  if (!g_xrng_initialized) {
+    randombytes_init(&g_xrng);
+    g_xrng_initialized = 1;
+  }
+
+  isaacp_random(&g_xrng, p, len);
+
+  // release lock
+  #ifdef WIN32
+  // `g_xrng_lock` is definitely `1` here
+  (void)InterlockedCompareExchange(&g_xrng_lock, 0, 1);
+  #else
+  __atomic_store_n(&g_xrng_lock, 0, __ATOMIC_SEQ_CST);
+  #endif
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/thirdparty/libvwad/vwadprng.h
+++ b/thirdparty/libvwad/vwadprng.h
@@ -1,0 +1,33 @@
+/*
+  coded by Ketmar Dark, public domain
+
+  get (almost) crypto-secure random bytes.
+  this will try to use the best PRNG available.
+
+  what it really means is that it tries to use the best
+  PRNG from the underlying OS to seed ISAAC+ PRNG, and
+  then use ISAAC+ to generate random numbers. generated
+  values are always cryptographically strong (due to
+  ISAAC+ guarantees), but seed values may be weak.
+*/
+#ifndef VV_PRNG_RANDOMBYTES_HEADER
+#define VV_PRNG_RANDOMBYTES_HEADER
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+// return non-zero if used seed was strong.
+// this should be thread-safe.
+int prng_is_strong_seed ();
+
+// be sure to cast `sizeof(...)` to `unsigned`!
+// this should be thread-safe.
+void prng_randombytes (void *p, unsigned len);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/thirdparty/libvwad/vwadvfs.c
+++ b/thirdparty/libvwad/vwadvfs.c
@@ -1,0 +1,3686 @@
+/* coded by Ketmar // Invisible Vector (psyc://ketmar.no-ip.org/~Ketmar)
+ * Understanding is not required. Only obedience.
+ *
+ * This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar.
+ * See http://www.wtfpl.net/ for more details.
+ */
+#include <stdlib.h>
+#include <string.h>
+
+#include "vwadvfs.h"
+
+//#define VWAD_DEBUG_WILDPATH
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#define VWAD_PUBLIC
+
+// WARNING! THIS MUST BE `-1`!
+#define VWAD_ERROR  (-1)
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#define VWAD_NOFIDX     ((vwad_uint)0xffffffffU)
+#define VWAD_UNONE      ((vwad_uint)0xffffffffU)
+#define VWAD_BAD_CHUNK  ((vwad_uint)0xffffffffU)
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+/* turning off inlining saves ~5kb of binary code on x86 */
+#ifdef _MSC_VER
+# define CC25519_INLINE  __forceinline
+#else
+# define CC25519_INLINE  inline __attribute__((always_inline))
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// M$VC support modelled after Dasho code, thank you!
+#ifdef _MSC_VER
+# define vwad__builtin_expect(cond_val_,exp_val_)  (cond_val_)
+# define vwad__builtin_trap  abort
+# define vwad_packed_struct
+# define vwad_push_pack  __pragma(pack(push, 1))
+# define vwad_pop_pack   __pragma(pack(pop))
+#else
+# define vwad__builtin_expect  __builtin_expect
+# define vwad__builtin_trap    __builtin_trap
+# define vwad_packed_struct    __attribute__((packed))
+# define vwad_push_pack
+# define vwad_pop_pack
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+typedef vwad_ubyte ed25519_signature[64];
+typedef vwad_ubyte ed25519_public_key[32];
+typedef vwad_ubyte ed25519_secret_key[32];
+typedef vwad_ubyte ed25519_random_seed[32];
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static CC25519_INLINE void put_u32 (void *dest, vwad_uint u) {
+  ((vwad_ubyte *)dest)[0] = (vwad_ubyte)u;
+  ((vwad_ubyte *)dest)[1] = (vwad_ubyte)(u>>8);
+  ((vwad_ubyte *)dest)[2] = (vwad_ubyte)(u>>16);
+  ((vwad_ubyte *)dest)[3] = (vwad_ubyte)(u>>24);
+}
+
+
+static CC25519_INLINE vwad_uint64 get_u64 (const void *src) {
+  vwad_uint64 res = ((const vwad_ubyte *)src)[0];
+  res |= ((vwad_uint64)((const vwad_ubyte *)src)[1])<<8;
+  res |= ((vwad_uint64)((const vwad_ubyte *)src)[2])<<16;
+  res |= ((vwad_uint64)((const vwad_ubyte *)src)[3])<<24;
+  res |= ((vwad_uint64)((const vwad_ubyte *)src)[4])<<32;
+  res |= ((vwad_uint64)((const vwad_ubyte *)src)[5])<<40;
+  res |= ((vwad_uint64)((const vwad_ubyte *)src)[6])<<48;
+  res |= ((vwad_uint64)((const vwad_ubyte *)src)[7])<<56;
+  return res;
+}
+
+static CC25519_INLINE vwad_uint get_u32 (const void *src) {
+  vwad_uint res = ((const vwad_ubyte *)src)[0];
+  res |= ((vwad_uint)((const vwad_ubyte *)src)[1])<<8;
+  res |= ((vwad_uint)((const vwad_ubyte *)src)[2])<<16;
+  res |= ((vwad_uint)((const vwad_ubyte *)src)[3])<<24;
+  return res;
+}
+
+static CC25519_INLINE vwad_ushort get_u16 (const void *src) {
+  vwad_ushort res = ((const vwad_ubyte *)src)[0];
+  res |= ((vwad_ushort)((const vwad_ubyte *)src)[1])<<8;
+  return res;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static CC25519_INLINE vwad_uint hashU32 (vwad_uint v) {
+  v ^= v >> 16;
+  v *= 0x21f0aaadu;
+  v ^= v >> 15;
+  v *= 0x735a2d97u;
+  v ^= v >> 15;
+  return v;
+}
+
+static vwad_uint deriveSeed (vwad_uint seed, const vwad_ubyte *buf, vwad_uint buflen) {
+  for (vwad_uint f = 0; f < buflen; f += 1) {
+    seed = hashU32((seed + 0x9E3779B9u) ^ buf[f]);
+  }
+  // hash it again
+  return hashU32(seed + 0x9E3779B9u);
+}
+
+static void crypt_buffer (vwad_uint xseed, vwad_uint64 nonce, void *buf, vwad_uint bufsize) {
+  // use xoroshiro-derived PRNG, because i don't need cryptostrong xor at all
+  #define MB32X  do { \
+    /* 2 to the 32 divided by golden ratio; adding forms a Weyl sequence */ \
+    rval = (xseed += 0x9E3779B9u); \
+    rval ^= rval << 13; \
+    rval ^= rval >> 17; \
+    rval ^= rval << 5; \
+    /*rval = hashU32(xseed += 0x9E3779B9u); -- mulberry32*/ \
+  } while (0)
+
+  xseed += nonce;
+  vwad_uint rval;
+
+  vwad_uint *b32 = (vwad_uint *)buf;
+  while (bufsize >= 4) {
+    MB32X;
+    put_u32(b32, get_u32(b32) ^ rval);
+    ++b32;
+    bufsize -= 4;
+  }
+  if (bufsize) {
+    // final [1..3] bytes
+    MB32X;
+    vwad_uint n;
+    vwad_ubyte *b = (vwad_ubyte *)b32;
+    switch (bufsize) {
+      case 3:
+        n = b[0]|((vwad_uint)b[1]<<8)|((vwad_uint)b[2]<<16);
+        n ^= rval;
+        b[0] = (vwad_ubyte)n;
+        b[1] = (vwad_ubyte)(n>>8);
+        b[2] = (vwad_ubyte)(n>>16);
+        break;
+      case 2:
+        n = b[0]|((vwad_uint)b[1]<<8);
+        n ^= rval;
+        b[0] = (vwad_ubyte)n;
+        b[1] = (vwad_ubyte)(n>>8);
+        break;
+      case 1:
+        b[0] ^= rval;
+        break;
+    }
+  }
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#define crc32_init  (0xffffffffU)
+
+static const vwad_uint crctab[16] = {
+  0x00000000, 0x1db71064, 0x3b6e20c8, 0x26d930ac,
+  0x76dc4190, 0x6b6b51f4, 0x4db26158, 0x5005713c,
+  0xedb88320, 0xf00f9344, 0xd6d6a3e8, 0xcb61b38c,
+  0x9b64c2b0, 0x86d3d2d4, 0xa00ae278, 0xbdbdf21c,
+};
+
+
+#define CRC32BYTE(bt_)  do { \
+  crc32 ^= (vwad_ubyte)(bt_); \
+  crc32 = crctab[crc32&0x0f]^(crc32>>4); \
+  crc32 = crctab[crc32&0x0f]^(crc32>>4); \
+} while (0)
+
+
+static CC25519_INLINE vwad_uint crc32_part (vwad_uint crc32, const void *src, vwad_uint len) {
+  const vwad_ubyte *buf = (const vwad_ubyte *)src;
+  while (len--) {
+    CRC32BYTE(*buf++);
+  }
+  return crc32;
+}
+
+static CC25519_INLINE vwad_uint crc32_final (vwad_uint crc32) {
+  return crc32^0xffffffffU;
+}
+
+static CC25519_INLINE vwad_uint crc32_buf (const void *src, vwad_uint len) {
+  return crc32_final(crc32_part(crc32_init, src, len));
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// Z85 codec
+static const char *z85_enc_alphabet =
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG"
+  "HIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
+
+static const vwad_ubyte z85_dec_alphabet [96] = {
+  0x00, 0x44, 0x00, 0x54, 0x53, 0x52, 0x48, 0x00,
+  0x4B, 0x4C, 0x46, 0x41, 0x00, 0x3F, 0x3E, 0x45,
+  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+  0x08, 0x09, 0x40, 0x00, 0x49, 0x42, 0x4A, 0x47,
+  0x51, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A,
+  0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32,
+  0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A,
+  0x3B, 0x3C, 0x3D, 0x4D, 0x00, 0x4E, 0x43, 0x00,
+  0x00, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+  0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+  0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,
+  0x21, 0x22, 0x23, 0x4F, 0x00, 0x50, 0x00, 0x00
+};
+
+
+//==========================================================================
+//
+//  vwad_z85_encode_key
+//
+//==========================================================================
+void vwad_z85_encode_key (const vwad_public_key inkey, vwad_z85_key enkey) {
+  vwad_ubyte sdata[32 + 4];
+  memcpy(sdata, inkey, 32);
+  const vwad_uint crc32 = crc32_buf(sdata, 32);
+  put_u32(&sdata[32], crc32);
+  vwad_uint dpos = 0, spos = 0, value = 0;
+  while (spos < 32 + 4) {
+    value = value * 256u + sdata[spos++];
+    if (spos % 4u == 0) {
+      vwad_uint divisor = 85 * 85 * 85 * 85;
+      while (divisor) {
+        char ech = z85_enc_alphabet[value / divisor % 85u];
+        if (ech == '/') ech = '~';
+        enkey[dpos++] = ech;
+        divisor /= 85u;
+      }
+      value = 0;
+    }
+  }
+  if (dpos != (vwad_uint)sizeof(vwad_z85_key) - 1u) vwad__builtin_trap();
+  enkey[dpos] = 0;
+}
+
+
+//==========================================================================
+//
+//  vwad_z85_decode_key
+//
+//==========================================================================
+vwad_result vwad_z85_decode_key (const vwad_z85_key enkey, vwad_public_key outkey) {
+  if (enkey == NULL || outkey == NULL) return VWAD_ERROR;
+  vwad_ubyte ddata[32 + 4];
+  vwad_uint dpos = 0, spos = 0, value = 0;
+  while (spos < (vwad_uint)sizeof(vwad_z85_key) - 1) {
+    char inch = enkey[spos++];
+    switch (inch) {
+      case 0: return VWAD_ERROR;
+      case '\\': inch = '/'; break;
+      case '~': inch = '/'; break;
+      case '|': inch = '!'; break;
+      case ',': inch = '.'; break;
+      case ';': inch = ':'; break;
+      default: break;
+    }
+    if (!strchr(z85_enc_alphabet, inch)) return VWAD_ERROR;
+    value = value * 85 + z85_dec_alphabet[(vwad_ubyte)inch - 32];
+    if (spos % 5u == 0) {
+      vwad_uint divisor = 256 * 256 * 256;
+      while (divisor) {
+        ddata[dpos++] = value / divisor % 256u;
+        divisor /= 256u;
+      }
+      value = 0;
+    }
+  }
+  if (dpos != 32 + 4) vwad__builtin_trap();
+  if (enkey[spos] != 0) return VWAD_ERROR;
+  const vwad_uint crc32 = crc32_buf(ddata, 32);
+  if (crc32 != get_u32(&ddata[32])) return VWAD_ERROR; // bad checksum
+  memcpy(outkey, ddata, 32);
+  return VWAD_OK;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// compact25519 dev-version
+// Source: https://github.com/DavyLandman/compact25519
+// Licensed under CC0-1.0
+// Based on Daniel Beer's Public Domain c25519 implementation
+// https://www.dlbeer.co.nz/oss/c25519.html version: 2017-10-05
+typedef struct cc_ed25519_iostream_t cc_ed25519_iostream;
+struct cc_ed25519_iostream_t {
+  // return negative on failure
+  int (*total_size) (cc_ed25519_iostream *strm);
+  // read exactly `bufsize` bytes; return non-zero on failure
+  // will never be called with 0 or negative `bufsize`
+  int (*read) (cc_ed25519_iostream *strm, int startpos, void *buf, int bufsize);
+  // user data
+  void *udata;
+};
+
+
+#define ED25519_SEED_SIZE (32)
+#define ED25519_PUBLIC_KEY_SIZE (32)
+#define ED25519_PRIVATE_KEY_SIZE (64)
+#define ED25519_SIGNATURE_SIZE (64)
+
+
+struct sha512_state {
+  vwad_uint64 h[8];
+};
+
+#define SHA512_BLOCK_SIZE  (128)
+#define SHA512_HASH_SIZE  (64)
+
+static const struct sha512_state sha512_initial_state = { {
+  0x6a09e667f3bcc908LL, 0xbb67ae8584caa73bLL,
+  0x3c6ef372fe94f82bLL, 0xa54ff53a5f1d36f1LL,
+  0x510e527fade682d1LL, 0x9b05688c2b3e6c1fLL,
+  0x1f83d9abfb41bd6bLL, 0x5be0cd19137e2179LL,
+} };
+
+static const vwad_uint64 round_k[80] = {
+  0x428a2f98d728ae22LL, 0x7137449123ef65cdLL,
+  0xb5c0fbcfec4d3b2fLL, 0xe9b5dba58189dbbcLL,
+  0x3956c25bf348b538LL, 0x59f111f1b605d019LL,
+  0x923f82a4af194f9bLL, 0xab1c5ed5da6d8118LL,
+  0xd807aa98a3030242LL, 0x12835b0145706fbeLL,
+  0x243185be4ee4b28cLL, 0x550c7dc3d5ffb4e2LL,
+  0x72be5d74f27b896fLL, 0x80deb1fe3b1696b1LL,
+  0x9bdc06a725c71235LL, 0xc19bf174cf692694LL,
+  0xe49b69c19ef14ad2LL, 0xefbe4786384f25e3LL,
+  0x0fc19dc68b8cd5b5LL, 0x240ca1cc77ac9c65LL,
+  0x2de92c6f592b0275LL, 0x4a7484aa6ea6e483LL,
+  0x5cb0a9dcbd41fbd4LL, 0x76f988da831153b5LL,
+  0x983e5152ee66dfabLL, 0xa831c66d2db43210LL,
+  0xb00327c898fb213fLL, 0xbf597fc7beef0ee4LL,
+  0xc6e00bf33da88fc2LL, 0xd5a79147930aa725LL,
+  0x06ca6351e003826fLL, 0x142929670a0e6e70LL,
+  0x27b70a8546d22ffcLL, 0x2e1b21385c26c926LL,
+  0x4d2c6dfc5ac42aedLL, 0x53380d139d95b3dfLL,
+  0x650a73548baf63deLL, 0x766a0abb3c77b2a8LL,
+  0x81c2c92e47edaee6LL, 0x92722c851482353bLL,
+  0xa2bfe8a14cf10364LL, 0xa81a664bbc423001LL,
+  0xc24b8b70d0f89791LL, 0xc76c51a30654be30LL,
+  0xd192e819d6ef5218LL, 0xd69906245565a910LL,
+  0xf40e35855771202aLL, 0x106aa07032bbd1b8LL,
+  0x19a4c116b8d2d0c8LL, 0x1e376c085141ab53LL,
+  0x2748774cdf8eeb99LL, 0x34b0bcb5e19b48a8LL,
+  0x391c0cb3c5c95a63LL, 0x4ed8aa4ae3418acbLL,
+  0x5b9cca4f7763e373LL, 0x682e6ff3d6b2b8a3LL,
+  0x748f82ee5defb2fcLL, 0x78a5636f43172f60LL,
+  0x84c87814a1f0ab72LL, 0x8cc702081a6439ecLL,
+  0x90befffa23631e28LL, 0xa4506cebde82bde9LL,
+  0xbef9a3f7b2c67915LL, 0xc67178f2e372532bLL,
+  0xca273eceea26619cLL, 0xd186b8c721c0c207LL,
+  0xeada7dd6cde0eb1eLL, 0xf57d4f7fee6ed178LL,
+  0x06f067aa72176fbaLL, 0x0a637dc5a2c898a6LL,
+  0x113f9804bef90daeLL, 0x1b710b35131c471bLL,
+  0x28db77f523047d84LL, 0x32caab7b40c72493LL,
+  0x3c9ebe0a15c9bebcLL, 0x431d67c49c100d4cLL,
+  0x4cc5d4becb3e42b6LL, 0x597f299cfc657e2aLL,
+  0x5fcb6fab3ad6faecLL, 0x6c44198c4a475817LL,
+};
+
+static CC25519_INLINE vwad_uint64 load64 (const vwad_ubyte *x) {
+  vwad_uint64 r = *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+
+  return r;
+}
+
+static CC25519_INLINE void store64 (vwad_ubyte *x, vwad_uint64 v) {
+  x += 7; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+}
+
+static CC25519_INLINE vwad_uint64 rot64 (vwad_uint64 x, int bits) {
+  return (x >> bits) | (x << (64 - bits));
+}
+
+static void sha512_block (struct sha512_state *s, const vwad_ubyte *blk) {
+  vwad_uint64 w[16];
+  vwad_uint64 a, b, c, d, e, f, g, h;
+  int i;
+
+  for (i = 0; i < 16; i++) {
+    w[i] = load64(blk);
+    blk += 8;
+  }
+
+  a = s->h[0];
+  b = s->h[1];
+  c = s->h[2];
+  d = s->h[3];
+  e = s->h[4];
+  f = s->h[5];
+  g = s->h[6];
+  h = s->h[7];
+
+  for (i = 0; i < 80; i++) {
+    const vwad_uint64 wi = w[i & 15];
+    const vwad_uint64 wi15 = w[(i + 1) & 15];
+    const vwad_uint64 wi2 = w[(i + 14) & 15];
+    const vwad_uint64 wi7 = w[(i + 9) & 15];
+    const vwad_uint64 s0 = rot64(wi15, 1) ^ rot64(wi15, 8) ^ (wi15 >> 7);
+    const vwad_uint64 s1 = rot64(wi2, 19) ^ rot64(wi2, 61) ^ (wi2 >> 6);
+
+    const vwad_uint64 S0 = rot64(a, 28) ^ rot64(a, 34) ^ rot64(a, 39);
+    const vwad_uint64 S1 = rot64(e, 14) ^ rot64(e, 18) ^ rot64(e, 41);
+    const vwad_uint64 ch = (e & f) ^ ((~e) & g);
+    const vwad_uint64 temp1 = h + S1 + ch + round_k[i] + wi;
+    const vwad_uint64 maj = (a & b) ^ (a & c) ^ (b & c);
+    const vwad_uint64 temp2 = S0 + maj;
+
+    h = g;
+    g = f;
+    f = e;
+    e = d + temp1;
+    d = c;
+    c = b;
+    b = a;
+    a = temp1 + temp2;
+
+    w[i & 15] = wi + s0 + wi7 + s1;
+  }
+
+  s->h[0] += a;
+  s->h[1] += b;
+  s->h[2] += c;
+  s->h[3] += d;
+  s->h[4] += e;
+  s->h[5] += f;
+  s->h[6] += g;
+  s->h[7] += h;
+}
+
+static CC25519_INLINE void sha512_init (struct sha512_state *s) {
+  memcpy(s, &sha512_initial_state, sizeof(*s));
+}
+
+static void sha512_final (struct sha512_state *s, const vwad_ubyte *blk, vwad_uint total_size) {
+  vwad_ubyte temp[SHA512_BLOCK_SIZE] = {0};
+  const vwad_uint last_size = total_size & (SHA512_BLOCK_SIZE - 1);
+
+  if (last_size) memcpy(temp, blk, last_size);
+  temp[last_size] = 0x80;
+
+  if (last_size > 111) {
+    sha512_block(s, temp);
+    memset(temp, 0, sizeof(temp));
+  }
+
+  store64(temp + SHA512_BLOCK_SIZE - 8, total_size << 3);
+  sha512_block(s, temp);
+}
+
+static void sha512_get (const struct sha512_state *s, vwad_ubyte *hash,
+                        vwad_uint offset, vwad_uint len)
+{
+  int i;
+
+  if (offset > SHA512_BLOCK_SIZE) return;
+
+  if (len > SHA512_BLOCK_SIZE - offset) len = SHA512_BLOCK_SIZE - offset;
+
+  i = offset >> 3;
+  offset &= 7;
+
+  if (offset) {
+    vwad_ubyte tmp[8];
+    vwad_uint c = 8 - offset;
+
+    if (c > len) c = len;
+
+    store64(tmp, s->h[i++]);
+    memcpy(hash, tmp + offset, c);
+    len -= c;
+    hash += c;
+  }
+
+  while (len >= 8) {
+    store64(hash, s->h[i++]);
+    hash += 8;
+    len -= 8;
+  }
+
+  if (len) {
+    vwad_ubyte tmp[8];
+
+    store64(tmp, s->h[i]);
+    memcpy(hash, tmp, len);
+  }
+}
+
+#define F25519_SIZE  (32)
+
+static const vwad_ubyte f25519_one[F25519_SIZE] = {1};
+
+static CC25519_INLINE void f25519_copy (vwad_ubyte *x, const vwad_ubyte *a) {
+  memcpy(x, a, F25519_SIZE);
+}
+
+#define FPRIME_SIZE  (32)
+
+struct ed25519_pt {
+  vwad_ubyte x[F25519_SIZE];
+  vwad_ubyte y[F25519_SIZE];
+  vwad_ubyte t[F25519_SIZE];
+  vwad_ubyte z[F25519_SIZE];
+};
+
+static const struct ed25519_pt ed25519_base = {
+  .x = {
+    0x1a, 0xd5, 0x25, 0x8f, 0x60, 0x2d, 0x56, 0xc9,
+    0xb2, 0xa7, 0x25, 0x95, 0x60, 0xc7, 0x2c, 0x69,
+    0x5c, 0xdc, 0xd6, 0xfd, 0x31, 0xe2, 0xa4, 0xc0,
+    0xfe, 0x53, 0x6e, 0xcd, 0xd3, 0x36, 0x69, 0x21
+  },
+  .y = {
+    0x58, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66
+  },
+  .t = {
+    0xa3, 0xdd, 0xb7, 0xa5, 0xb3, 0x8a, 0xde, 0x6d,
+    0xf5, 0x52, 0x51, 0x77, 0x80, 0x9f, 0xf0, 0x20,
+    0x7d, 0xe3, 0xab, 0x64, 0x8e, 0x4e, 0xea, 0x66,
+    0x65, 0x76, 0x8b, 0xd7, 0x0f, 0x5f, 0x87, 0x67
+  },
+  .z = {1, 0}
+};
+
+static const struct ed25519_pt ed25519_neutral = {
+  .x = {0},
+  .y = {1, 0},
+  .t = {0},
+  .z = {1, 0}
+};
+
+#define ED25519_PACK_SIZE  F25519_SIZE
+#define ED25519_EXPONENT_SIZE  32
+
+static CC25519_INLINE void ed25519_copy (struct ed25519_pt *dst, const struct ed25519_pt *src) {
+  memcpy(dst, src, sizeof(*dst));
+}
+
+#define EDSIGN_SECRET_KEY_SIZE  (32)
+#define EDSIGN_PUBLIC_KEY_SIZE  (32)
+#define EDSIGN_SIGNATURE_SIZE   (64)
+
+static CC25519_INLINE void f25519_load (vwad_ubyte *x, vwad_uint c) {
+  vwad_uint i;
+
+  for (i = 0; i < (vwad_uint)sizeof(c); i++) {
+    x[i] = c;
+    c >>= 8;
+  }
+
+  for (; i < F25519_SIZE; i++) x[i] = 0;
+}
+
+static void f25519_select (vwad_ubyte *dst, const vwad_ubyte *zero, const vwad_ubyte *one,
+                           vwad_ubyte condition)
+{
+  const vwad_ubyte mask = -condition;
+  int i;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    dst[i] = zero[i] ^ (mask & (one[i] ^ zero[i]));
+  }
+}
+
+static void f25519_normalize (vwad_ubyte *x) {
+  vwad_ubyte minusp[F25519_SIZE];
+  vwad_ushort c;
+  int i;
+
+  c = (x[31] >> 7) * 19;
+  x[31] &= 127;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += x[i];
+    x[i] = c;
+    c >>= 8;
+  }
+
+  c = 19;
+
+  for (i = 0; i + 1 < F25519_SIZE; i++) {
+    c += x[i];
+    minusp[i] = c;
+    c >>= 8;
+  }
+
+  c += ((vwad_ushort)x[i]) - 128;
+  minusp[31] = c;
+
+  f25519_select(x, minusp, x, (c >> 15) & 1);
+}
+
+static CC25519_INLINE vwad_ubyte f25519_eq (const vwad_ubyte *x, const vwad_ubyte *y) {
+  vwad_ubyte sum = 0;
+  int i;
+
+  for (i = 0; i < F25519_SIZE; i++) sum |= x[i] ^ y[i];
+
+  sum |= (sum >> 4);
+  sum |= (sum >> 2);
+  sum |= (sum >> 1);
+
+  return (sum ^ 1) & 1;
+}
+
+static void f25519_add (vwad_ubyte *r, const vwad_ubyte *a, const vwad_ubyte *b) {
+  vwad_ushort c = 0;
+  int i;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c >>= 8;
+    c += ((vwad_ushort)a[i]) + ((vwad_ushort)b[i]);
+    r[i] = c;
+  }
+
+  r[31] &= 127;
+  c = (c >> 7) * 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_sub (vwad_ubyte *r, const vwad_ubyte *a, const vwad_ubyte *b) {
+  vwad_uint c = 0;
+  int i;
+
+  c = 218;
+  for (i = 0; i + 1 < F25519_SIZE; i++) {
+    c += 65280 + ((vwad_uint)a[i]) - ((vwad_uint)b[i]);
+    r[i] = c;
+    c >>= 8;
+  }
+
+  c += ((vwad_uint)a[31]) - ((vwad_uint)b[31]);
+  r[31] = c & 127;
+  c = (c >> 7) * 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_neg (vwad_ubyte *r, const vwad_ubyte *a) {
+  vwad_uint c = 0;
+  int i;
+
+  c = 218;
+  for (i = 0; i + 1 < F25519_SIZE; i++) {
+    c += 65280 - ((vwad_uint)a[i]);
+    r[i] = c;
+    c >>= 8;
+  }
+
+  c -= ((vwad_uint)a[31]);
+  r[31] = c & 127;
+  c = (c >> 7) * 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_mul__distinct (vwad_ubyte *r, const vwad_ubyte *a, const vwad_ubyte *b) {
+  vwad_uint c = 0;
+  int i;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    int j;
+
+    c >>= 8;
+    for (j = 0; j <= i; j++) {
+      c += ((vwad_uint)a[j]) * ((vwad_uint)b[i - j]);
+    }
+
+    for (; j < F25519_SIZE; j++) {
+      c += ((vwad_uint)a[j]) *
+           ((vwad_uint)b[i + F25519_SIZE - j]) * 38;
+    }
+
+    r[i] = c;
+  }
+
+  r[31] &= 127;
+  c = (c >> 7) * 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_mul_c (vwad_ubyte *r, const vwad_ubyte *a, vwad_uint b) {
+  vwad_uint c = 0;
+  int i;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c >>= 8;
+    c += b * ((vwad_uint)a[i]);
+    r[i] = c;
+  }
+
+  r[31] &= 127;
+  c >>= 7;
+  c *= 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_inv__distinct (vwad_ubyte *r, const vwad_ubyte *x) {
+  vwad_ubyte s[F25519_SIZE];
+  int i;
+
+  f25519_mul__distinct(s, x, x);
+  f25519_mul__distinct(r, s, x);
+
+  for (i = 0; i < 248; i++) {
+    f25519_mul__distinct(s, r, r);
+    f25519_mul__distinct(r, s, x);
+  }
+
+  f25519_mul__distinct(s, r, r);
+
+  f25519_mul__distinct(r, s, s);
+  f25519_mul__distinct(s, r, x);
+
+  f25519_mul__distinct(r, s, s);
+
+  f25519_mul__distinct(s, r, r);
+  f25519_mul__distinct(r, s, x);
+
+  f25519_mul__distinct(s, r, r);
+  f25519_mul__distinct(r, s, x);
+}
+
+static void exp2523 (vwad_ubyte *r, const vwad_ubyte *x, vwad_ubyte *s) {
+  int i;
+
+  f25519_mul__distinct(r, x, x);
+  f25519_mul__distinct(s, r, x);
+
+  for (i = 0; i < 248; i++) {
+    f25519_mul__distinct(r, s, s);
+    f25519_mul__distinct(s, r, x);
+  }
+
+  f25519_mul__distinct(r, s, s);
+
+  f25519_mul__distinct(s, r, r);
+  f25519_mul__distinct(r, s, x);
+}
+
+static void f25519_sqrt (vwad_ubyte *r, const vwad_ubyte *a) {
+  vwad_ubyte v[F25519_SIZE];
+  vwad_ubyte i[F25519_SIZE];
+  vwad_ubyte x[F25519_SIZE];
+  vwad_ubyte y[F25519_SIZE];
+
+  f25519_mul_c(x, a, 2);
+  exp2523(v, x, y);
+
+  f25519_mul__distinct(y, v, v);
+  f25519_mul__distinct(i, x, y);
+  f25519_load(y, 1);
+  f25519_sub(i, i, y);
+
+  f25519_mul__distinct(x, v, a);
+  f25519_mul__distinct(r, x, i);
+}
+
+static void fprime_select (vwad_ubyte *dst,
+                           const vwad_ubyte *zero, const vwad_ubyte *one,
+                           vwad_ubyte condition)
+{
+  const vwad_ubyte mask = -condition;
+  int i;
+
+  for (i = 0; i < FPRIME_SIZE; i++) {
+    dst[i] = zero[i] ^ (mask & (one[i] ^ zero[i]));
+  }
+}
+
+static void raw_try_sub (vwad_ubyte *x, const vwad_ubyte *p) {
+  vwad_ubyte minusp[FPRIME_SIZE];
+  vwad_ushort c = 0;
+  int i;
+
+  for (i = 0; i < FPRIME_SIZE; i++) {
+    c = ((vwad_ushort)x[i]) - ((vwad_ushort)p[i]) - c;
+    minusp[i] = c;
+    c = (c >> 8) & 1;
+  }
+
+  fprime_select(x, minusp, x, c);
+}
+
+static int prime_msb (const vwad_ubyte *p) {
+  int i;
+  vwad_ubyte x;
+
+  for (i = FPRIME_SIZE - 1; i >= 0; i--) {
+    if (p[i]) break;
+  }
+
+  x = p[i];
+  i <<= 3;
+
+  while (x) {
+    x >>= 1;
+    i++;
+  }
+
+  return i - 1;
+}
+
+static void shift_n_bits (vwad_ubyte *x, int n) {
+  vwad_ushort c = 0;
+  int i;
+
+  for (i = 0; i < FPRIME_SIZE; i++) {
+    c |= ((vwad_ushort)x[i]) << n;
+    x[i] = c;
+    c >>= 8;
+  }
+}
+
+static CC25519_INLINE int min_int (int a, int b) {
+  return a < b ? a : b;
+}
+
+static void fprime_from_bytes (vwad_ubyte *n,
+                               const vwad_ubyte *x, vwad_uint len,
+                               const vwad_ubyte *modulus)
+{
+  const int preload_total = min_int(prime_msb(modulus) - 1, len << 3);
+  const int preload_bytes = preload_total >> 3;
+  const int preload_bits = preload_total & 7;
+  const int rbits = (len << 3) - preload_total;
+  int i;
+
+  memset(n, 0, FPRIME_SIZE);
+
+  for (i = 0; i < preload_bytes; i++) {
+    n[i] = x[len - preload_bytes + i];
+  }
+
+  if (preload_bits) {
+    shift_n_bits(n, preload_bits);
+    n[0] |= x[len - preload_bytes - 1] >> (8 - preload_bits);
+  }
+
+  for (i = rbits - 1; i >= 0; i--) {
+    const vwad_ubyte bit = (x[i >> 3] >> (i & 7)) & 1;
+
+    shift_n_bits(n, 1);
+    n[0] |= bit;
+    raw_try_sub(n, modulus);
+  }
+}
+
+static CC25519_INLINE void ed25519_project (struct ed25519_pt *p, const vwad_ubyte *x, const vwad_ubyte *y) {
+  f25519_copy(p->x, x);
+  f25519_copy(p->y, y);
+  f25519_load(p->z, 1);
+  f25519_mul__distinct(p->t, x, y);
+}
+
+static CC25519_INLINE void ed25519_unproject (vwad_ubyte *x, vwad_ubyte *y, const struct ed25519_pt *p) {
+  vwad_ubyte z1[F25519_SIZE];
+
+  f25519_inv__distinct(z1, p->z);
+  f25519_mul__distinct(x, p->x, z1);
+  f25519_mul__distinct(y, p->y, z1);
+
+  f25519_normalize(x);
+  f25519_normalize(y);
+}
+
+static const vwad_ubyte ed25519_d[F25519_SIZE] = {
+  0xa3, 0x78, 0x59, 0x13, 0xca, 0x4d, 0xeb, 0x75,
+  0xab, 0xd8, 0x41, 0x41, 0x4d, 0x0a, 0x70, 0x00,
+  0x98, 0xe8, 0x79, 0x77, 0x79, 0x40, 0xc7, 0x8c,
+  0x73, 0xfe, 0x6f, 0x2b, 0xee, 0x6c, 0x03, 0x52
+};
+
+static CC25519_INLINE void ed25519_pack (vwad_ubyte *c, const vwad_ubyte *x, const vwad_ubyte *y) {
+  vwad_ubyte tmp[F25519_SIZE];
+  vwad_ubyte parity;
+
+  f25519_copy(tmp, x);
+  f25519_normalize(tmp);
+  parity = (tmp[0] & 1) << 7;
+
+  f25519_copy(c, y);
+  f25519_normalize(c);
+  c[31] |= parity;
+}
+
+static vwad_ubyte ed25519_try_unpack (vwad_ubyte *x, vwad_ubyte *y, const vwad_ubyte *comp) {
+  const int parity = comp[31] >> 7;
+  vwad_ubyte a[F25519_SIZE];
+  vwad_ubyte b[F25519_SIZE];
+  vwad_ubyte c[F25519_SIZE];
+
+  f25519_copy(y, comp);
+  y[31] &= 127;
+
+  f25519_mul__distinct(c, y, y);
+
+  f25519_mul__distinct(b, c, ed25519_d);
+  f25519_add(a, b, f25519_one);
+  f25519_inv__distinct(b, a);
+
+  f25519_sub(a, c, f25519_one);
+
+  f25519_mul__distinct(c, a, b);
+
+  f25519_sqrt(a, c);
+  f25519_neg(b, a);
+
+  f25519_select(x, a, b, (a[0] ^ parity) & 1);
+
+  f25519_mul__distinct(a, x, x);
+  f25519_normalize(a);
+  f25519_normalize(c);
+
+  return f25519_eq(a, c);
+}
+
+static const vwad_ubyte ed25519_k[F25519_SIZE] = {
+  0x59, 0xf1, 0xb2, 0x26, 0x94, 0x9b, 0xd6, 0xeb,
+  0x56, 0xb1, 0x83, 0x82, 0x9a, 0x14, 0xe0, 0x00,
+  0x30, 0xd1, 0xf3, 0xee, 0xf2, 0x80, 0x8e, 0x19,
+  0xe7, 0xfc, 0xdf, 0x56, 0xdc, 0xd9, 0x06, 0x24
+};
+
+static void ed25519_add (struct ed25519_pt *r,
+                         const struct ed25519_pt *p1, const struct ed25519_pt *p2)
+{
+  vwad_ubyte a[F25519_SIZE];
+  vwad_ubyte b[F25519_SIZE];
+  vwad_ubyte c[F25519_SIZE];
+  vwad_ubyte d[F25519_SIZE];
+  vwad_ubyte e[F25519_SIZE];
+  vwad_ubyte f[F25519_SIZE];
+  vwad_ubyte g[F25519_SIZE];
+  vwad_ubyte h[F25519_SIZE];
+
+  f25519_sub(c, p1->y, p1->x);
+  f25519_sub(d, p2->y, p2->x);
+  f25519_mul__distinct(a, c, d);
+  f25519_add(c, p1->y, p1->x);
+  f25519_add(d, p2->y, p2->x);
+  f25519_mul__distinct(b, c, d);
+  f25519_mul__distinct(d, p1->t, p2->t);
+  f25519_mul__distinct(c, d, ed25519_k);
+  f25519_mul__distinct(d, p1->z, p2->z);
+  f25519_add(d, d, d);
+  f25519_sub(e, b, a);
+  f25519_sub(f, d, c);
+  f25519_add(g, d, c);
+  f25519_add(h, b, a);
+  f25519_mul__distinct(r->x, e, f);
+  f25519_mul__distinct(r->y, g, h);
+  f25519_mul__distinct(r->t, e, h);
+  f25519_mul__distinct(r->z, f, g);
+}
+
+static void ed25519_double (struct ed25519_pt *r, const struct ed25519_pt *p) {
+  vwad_ubyte a[F25519_SIZE];
+  vwad_ubyte b[F25519_SIZE];
+  vwad_ubyte c[F25519_SIZE];
+  vwad_ubyte e[F25519_SIZE];
+  vwad_ubyte f[F25519_SIZE];
+  vwad_ubyte g[F25519_SIZE];
+  vwad_ubyte h[F25519_SIZE];
+
+  f25519_mul__distinct(a, p->x, p->x);
+  f25519_mul__distinct(b, p->y, p->y);
+  f25519_mul__distinct(c, p->z, p->z);
+  f25519_add(c, c, c);
+  f25519_add(f, p->x, p->y);
+  f25519_mul__distinct(e, f, f);
+  f25519_sub(e, e, a);
+  f25519_sub(e, e, b);
+  f25519_sub(g, b, a);
+  f25519_sub(f, g, c);
+  f25519_neg(h, b);
+  f25519_sub(h, h, a);
+  f25519_mul__distinct(r->x, e, f);
+  f25519_mul__distinct(r->y, g, h);
+  f25519_mul__distinct(r->t, e, h);
+  f25519_mul__distinct(r->z, f, g);
+}
+
+static void ed25519_smult (struct ed25519_pt *r_out, const struct ed25519_pt *p,
+                           const vwad_ubyte *e)
+{
+  struct ed25519_pt r;
+  int i;
+
+  ed25519_copy(&r, &ed25519_neutral);
+
+  for (i = 255; i >= 0; i--) {
+    const vwad_ubyte bit = (e[i >> 3] >> (i & 7)) & 1;
+    struct ed25519_pt s;
+
+    ed25519_double(&r, &r);
+    ed25519_add(&s, &r, p);
+
+    f25519_select(r.x, r.x, s.x, bit);
+    f25519_select(r.y, r.y, s.y, bit);
+    f25519_select(r.z, r.z, s.z, bit);
+    f25519_select(r.t, r.t, s.t, bit);
+  }
+
+  ed25519_copy(r_out, &r);
+}
+
+#define EXPANDED_SIZE  (64)
+
+static const vwad_ubyte ed25519_order[FPRIME_SIZE] = {
+  0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
+  0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10
+};
+
+static CC25519_INLINE vwad_ubyte upp (struct ed25519_pt *p, const vwad_ubyte *packed) {
+  vwad_ubyte x[F25519_SIZE];
+  vwad_ubyte y[F25519_SIZE];
+  vwad_ubyte ok = ed25519_try_unpack(x, y, packed);
+
+  ed25519_project(p, x, y);
+  return ok;
+}
+
+static CC25519_INLINE void pp (vwad_ubyte *packed, const struct ed25519_pt *p) {
+  vwad_ubyte x[F25519_SIZE];
+  vwad_ubyte y[F25519_SIZE];
+
+  ed25519_unproject(x, y, p);
+  ed25519_pack(packed, x, y);
+}
+
+static CC25519_INLINE void sm_pack (vwad_ubyte *r, const vwad_ubyte *k) {
+  struct ed25519_pt p;
+
+  ed25519_smult(&p, &ed25519_base, k);
+  pp(r, &p);
+}
+
+static int hash_with_prefix (vwad_ubyte *out_fp,
+                             vwad_ubyte *init_block, vwad_uint prefix_size,
+                             cc_ed25519_iostream *strm)
+{
+  struct sha512_state s;
+
+  const int xxlen = strm->total_size(strm);
+  if (xxlen < 0) return -1;
+  const vwad_uint len = (vwad_uint)xxlen;
+
+  vwad_ubyte msgblock[SHA512_BLOCK_SIZE];
+
+  sha512_init(&s);
+
+  if (len < SHA512_BLOCK_SIZE && len + prefix_size < SHA512_BLOCK_SIZE) {
+    if (len > 0) {
+      if (strm->read(strm, 0, msgblock, (int)len) != VWAD_OK) return -1;
+      memcpy(init_block + prefix_size, msgblock, len);
+    }
+    sha512_final(&s, init_block, len + prefix_size);
+  } else {
+    vwad_uint i;
+
+    if (strm->read(strm, 0, msgblock, SHA512_BLOCK_SIZE - prefix_size) != VWAD_OK) return -1;
+    memcpy(init_block + prefix_size, msgblock, SHA512_BLOCK_SIZE - prefix_size);
+    sha512_block(&s, init_block);
+
+    for (i = SHA512_BLOCK_SIZE - prefix_size;
+         i + SHA512_BLOCK_SIZE <= len;
+         i += SHA512_BLOCK_SIZE)
+    {
+      if (strm->read(strm, (int)i, msgblock, SHA512_BLOCK_SIZE) != VWAD_OK) return -1;
+      sha512_block(&s, msgblock);
+    }
+
+    const int left = (int)len - (int)i;
+    if (left < 0) vwad__builtin_trap();
+    if (left > 0 && strm->read(strm, (int)i, msgblock, left) != VWAD_OK) return -1;
+
+    sha512_final(&s, msgblock, len + prefix_size);
+  }
+
+  sha512_get(&s, init_block, 0, SHA512_HASH_SIZE);
+  fprime_from_bytes(out_fp, init_block, SHA512_HASH_SIZE, ed25519_order);
+
+  return 0;
+}
+
+static int hash_message (vwad_ubyte *z, const vwad_ubyte *r, const vwad_ubyte *a,
+                         cc_ed25519_iostream *strm)
+{
+  vwad_ubyte block[SHA512_BLOCK_SIZE];
+
+  memcpy(block, r, 32);
+  memcpy(block + 32, a, 32);
+  return hash_with_prefix(z, block, 64, strm);
+}
+
+static int edsign_verify_stream (const vwad_ubyte *signature, const vwad_ubyte *pub,
+                                 cc_ed25519_iostream *strm)
+{
+  struct ed25519_pt p;
+  struct ed25519_pt q;
+  vwad_ubyte lhs[F25519_SIZE];
+  vwad_ubyte rhs[F25519_SIZE];
+  vwad_ubyte z[FPRIME_SIZE];
+  vwad_ubyte ok = 1;
+
+  if (hash_message(z, signature, pub, strm) != 0) return -1;
+
+  sm_pack(lhs, signature + 32);
+
+  ok &= upp(&p, pub);
+  ed25519_smult(&p, &p, z);
+  ok &= upp(&q, signature);
+  ed25519_add(&p, &p, &q);
+  pp(rhs, &p);
+
+  return (ok & f25519_eq(lhs, rhs) ? 0 : -1);
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+VWAD_PUBLIC void (*vwad_logf) (int type, const char *fmt, ...) = NULL;
+
+#define logf(type_,...)  do { \
+  if (vwad_logf) { \
+    vwad_logf(VWAD_LOG_ ## type_, __VA_ARGS__); \
+  } \
+} while (0)
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+VWAD_PUBLIC void (*vwad_assertion_failed) (const char *fmt, ...) = NULL;
+
+static inline const char *SkipPathPartCStr (const char *s) {
+  const char *lastSlash = NULL;
+  for (const char *t = s; *t; ++t) {
+    if (*t == '/') lastSlash = t+1;
+    #ifdef _WIN32
+    if (*t == '\\') lastSlash = t+1;
+    #endif
+  }
+  return (lastSlash ? lastSlash : s);
+}
+
+#ifdef _MSC_VER
+#define vassert(cond_)  do { if (vwad__builtin_expect((!(cond_)), 0)) { const int line__assf = __LINE__; \
+    if (vwad_assertion_failed) { \
+      vwad_assertion_failed("%s:%d: Assertion in `%s` failed: %s\n", \
+        SkipPathPartCStr(__FILE__), line__assf, __FUNCSIG__, #cond_); \
+      vwad__builtin_trap(); /* just in case */ \
+    } else { \
+      vwad__builtin_trap(); \
+    } \
+  } \
+} while (0)
+#else
+#define vassert(cond_)  do { if (vwad__builtin_expect((!(cond_)), 0)) { const int line__assf = __LINE__; \
+    if (vwad_assertion_failed) { \
+      vwad_assertion_failed("%s:%d: Assertion in `%s` failed: %s\n", \
+        SkipPathPartCStr(__FILE__), line__assf, __PRETTY_FUNCTION__, #cond_); \
+      vwad__builtin_trap(); /* just in case */ \
+    } else { \
+      vwad__builtin_trap(); \
+    } \
+  } \
+} while (0)
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+VWAD_PUBLIC void (*vwad_debug_open_file) (vwad_handle *wad, vwad_fidx fidx, vwad_fd fd) = NULL;
+VWAD_PUBLIC void (*vwad_debug_close_file) (vwad_handle *wad, vwad_fidx fidx, vwad_fd fd) = NULL;
+VWAD_PUBLIC void (*vwad_debug_read_chunk) (vwad_handle *wad, int bidx, vwad_fidx fidx, vwad_fd fd, int chunkidx) = NULL;
+VWAD_PUBLIC void (*vwad_debug_flush_chunk) (vwad_handle *wad, int bidx, vwad_fidx fidx, vwad_fd fd, int chunkidx) = NULL;
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// memory allocation
+static CC25519_INLINE void *xalloc (vwad_memman *mman, vwad_uint size) {
+  vassert(size > 0 && size <= 0x7ffffff0u);
+  if (mman != NULL) return mman->alloc(mman, (vwad_uint)size); else return malloc(size);
+}
+
+static CC25519_INLINE void *zalloc (vwad_memman *mman, vwad_uint size) {
+  vassert(size > 0 && size <= 0x7ffffff0u);
+  void *p = (mman != NULL ? mman->alloc(mman, (vwad_uint)size) : malloc(size));
+  if (p) memset(p, 0, size);
+  return p;
+}
+
+static CC25519_INLINE void xfree (vwad_memman *mman, void *p) {
+  if (p != NULL) {
+    if (mman != NULL) mman->free(mman, p); else free(p);
+  }
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+VWAD_PUBLIC vwad_uint vwad_crc32_init (void) { return crc32_init; }
+VWAD_PUBLIC vwad_uint vwad_crc32_part (vwad_uint crc32, const void *src, vwad_uint len) { return crc32_part(crc32, src, len); }
+VWAD_PUBLIC vwad_uint vwad_crc32_final (vwad_uint crc32) { return crc32_final(crc32); }
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+typedef int intbool_t;
+
+enum {
+  int_false = 0,
+  int_true = 1
+};
+
+typedef struct {
+  vwad_uint x1, x2, x;
+  const vwad_ubyte *src;
+  int spos, send;
+} EntDecoder;
+
+typedef struct {
+  vwad_ushort p1, p2;
+} Predictor;
+
+
+typedef struct {
+  Predictor pred[2];
+  int ctx;
+} BitPPM;
+
+typedef struct {
+  Predictor predBits[2 * 256];
+  int ctxBits;
+} BytePPM;
+
+typedef struct {
+  // 8 bits, twice
+  BytePPM bytes[2];
+  // "second byte" flag
+  BitPPM moreFlag;
+} WordPPM;
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static CC25519_INLINE vwad_ubyte DecGetByte (EntDecoder *ee) {
+  if (ee->spos < ee->send) {
+    return ee->src[ee->spos++];
+  } else {
+    ee->spos = 0x7fffffff;
+    return 0;
+  }
+}
+
+static void DecInit (EntDecoder *ee, const void *inbuf, vwad_uint insize) {
+  ee->x1 = 0; ee->x2 = 0xFFFFFFFFU;
+  ee->src = (const vwad_ubyte *)inbuf; ee->spos = 0; ee->send = insize;
+  ee->x = DecGetByte(ee);
+  ee->x = (ee->x << 8) + DecGetByte(ee);
+  ee->x = (ee->x << 8) + DecGetByte(ee);
+  ee->x = (ee->x << 8) + DecGetByte(ee);
+}
+
+static CC25519_INLINE intbool_t DecDecode (EntDecoder *ee, int p) {
+  vwad_uint xmid = ee->x1 + (vwad_uint)(((vwad_uint64)((ee->x2 - ee->x1) & 0xffffffffU) * (vwad_uint)p) >> 17);
+  intbool_t bit = (ee->x <= xmid);
+  if (bit) ee->x2 = xmid; else ee->x1 = xmid + 1;
+  while ((ee->x1 ^ ee->x2) < (1u << 24)) {
+    ee->x1 <<= 8;
+    ee->x2 = (ee->x2 << 8) + 255;
+    ee->x = (ee->x << 8) + DecGetByte(ee);
+  }
+  return bit;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void PredInit (Predictor *pp) {
+  pp->p1 = 1 << 15; pp->p2 = 1 << 15;
+}
+
+static CC25519_INLINE int PredGetP (Predictor *pp) {
+  return (int)((vwad_uint)pp->p1 + (vwad_uint)pp->p2);
+}
+
+static CC25519_INLINE void PredUpdate (Predictor *pp, intbool_t bit) {
+  if (bit) {
+    pp->p1 += ((~((vwad_uint)pp->p1)) >> 3) & 0b0001111111111111;
+    pp->p2 += ((~((vwad_uint)pp->p2)) >> 6) & 0b0000001111111111;
+  } else {
+    pp->p1 -= ((vwad_uint)pp->p1) >> 3;
+    pp->p2 -= ((vwad_uint)pp->p2) >> 6;
+  }
+}
+
+static CC25519_INLINE intbool_t PredGetBitDecodeUpdate (Predictor *pp, EntDecoder *dec) {
+  int p = PredGetP(pp);
+  intbool_t bit = DecDecode(dec, p);
+  PredUpdate(pp, bit);
+  return bit;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void BitPPMInit (BitPPM *ppm, int initstate) {
+  for (vwad_uint f = 0; f < (vwad_uint)sizeof(ppm->pred) / (vwad_uint)sizeof(ppm->pred[0]); ++f) {
+    PredInit(&ppm->pred[f]);
+  }
+  ppm->ctx = !!initstate;
+}
+
+static CC25519_INLINE intbool_t BitPPMDecode (BitPPM *ppm, EntDecoder *dec) {
+  intbool_t bit = PredGetBitDecodeUpdate(&ppm->pred[ppm->ctx], dec);
+  if (bit) ppm->ctx = 1; else ppm->ctx = 0;
+  return bit;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void BytePPMInit (BytePPM *ppm) {
+  for (vwad_uint f = 0; f < (vwad_uint)sizeof(ppm->predBits) / (vwad_uint)sizeof(ppm->predBits[0]); ++f) {
+    PredInit(&ppm->predBits[f]);
+  }
+  ppm->ctxBits = 0;
+}
+
+static CC25519_INLINE vwad_ubyte BytePPMDecodeByte (BytePPM *ppm, EntDecoder *dec) {
+  vwad_uint n = 1;
+  int cofs = ppm->ctxBits * 256;
+  do {
+    intbool_t bit = PredGetBitDecodeUpdate(&ppm->predBits[cofs + n], dec);
+    n += n; if (bit) ++n;
+  } while (n < 0x100);
+  n -= 0x100;
+  ppm->ctxBits = (n >= 0x80);
+  return (vwad_ubyte)n;
+}
+
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void WordPPMInit (WordPPM *ppm) {
+  BytePPMInit(&ppm->bytes[0]); BytePPMInit(&ppm->bytes[1]);
+  BitPPMInit(&ppm->moreFlag, 0);
+}
+
+static CC25519_INLINE int WordPPMDecodeInt (WordPPM *ppm, EntDecoder *dec) {
+  int n = BytePPMDecodeByte(&ppm->bytes[0], dec);
+  if (BitPPMDecode(&ppm->moreFlag, dec)) {
+    n += BytePPMDecodeByte(&ppm->bytes[1], dec) * 0x100;
+  }
+  return n;
+}
+
+
+//==========================================================================
+//
+//  DecompressLZFF3
+//
+//==========================================================================
+static intbool_t DecompressLZFF3 (const void *src, int srclen, void *dest, int unpsize) {
+  intbool_t error;
+  EntDecoder dec;
+  BytePPM ppmData;
+  WordPPM ppmMtOfs, ppmMtLen, ppmLitLen;
+  BitPPM ppmLitFlag;
+  int litcount, n;
+  vwad_uint dictpos, spos;
+
+  #define PutByte(bt_)  do { \
+    if (unpsize != 0) { \
+      ((vwad_ubyte *)dest)[dictpos++] = (vwad_ubyte)(bt_); unpsize -= 1; \
+    } else { \
+      error = int_true; \
+    } \
+  } while (0)
+
+  if (srclen < 1 || srclen > 0x1fffffff) return 0;
+  if (unpsize < 1 || unpsize > 0x1fffffff) return 0;
+
+  error = int_false;
+  dictpos = 0;
+
+  BytePPMInit(&ppmData);
+  WordPPMInit(&ppmMtOfs);
+  WordPPMInit(&ppmMtLen);
+  WordPPMInit(&ppmLitLen);
+  BitPPMInit(&ppmLitFlag, 1);
+
+  DecInit(&dec, src, srclen);
+
+  if (!BitPPMDecode(&ppmLitFlag, &dec)) error = int_true;
+  else {
+    vwad_ubyte sch;
+    int len, ofs;
+
+    litcount = WordPPMDecodeInt(&ppmLitLen, &dec) + 1;
+    while (!error && litcount != 0) {
+      litcount -= 1;
+      n = BytePPMDecodeByte(&ppmData, &dec);
+      PutByte((vwad_ubyte)n);
+      error = error || (dec.spos > dec.send);
+    }
+
+    while (!error && unpsize != 0) {
+      if (BitPPMDecode(&ppmLitFlag, &dec)) {
+        litcount = WordPPMDecodeInt(&ppmLitLen, &dec) + 1;
+        while (!error && litcount != 0) {
+          litcount -= 1;
+          n = BytePPMDecodeByte(&ppmData, &dec);
+          PutByte((vwad_ubyte)n);
+          error = error || (dec.spos > dec.send);
+        }
+      } else {
+        len = WordPPMDecodeInt(&ppmMtLen, &dec) + 3;
+        ofs = WordPPMDecodeInt(&ppmMtOfs, &dec) + 1;
+        error = error || (dec.spos > dec.send) || (len > unpsize) || (ofs > dictpos);
+        if (!error) {
+          spos = dictpos - ofs;
+          while (!error && len != 0) {
+            len -= 1;
+            sch = ((const vwad_ubyte *)dest)[spos];
+            spos++;
+            PutByte(sch);
+          }
+        }
+      }
+    }
+  }
+
+  return (!error && unpsize == 0);
+}
+
+
+//==========================================================================
+//
+//  is_uni_printable
+//
+//  is the given codepoint considered printable?
+//  i restrict it to some useful subset.
+//  unifuck is unifucked, but i hope that i sorted out all
+//  idiotic diactritics and control chars.
+//
+//==========================================================================
+static CC25519_INLINE vwad_bool is_uni_printable (vwad_ushort ch) {
+  return
+    ch == 0x09 || ch == 0x0A || // allow tabs and newlines control chars only
+    (ch >= 0x0020 && ch <= 0x7E) || // ASCII, without 0x7F
+    (ch >= 0x0080 && ch <= 0x024F) || // basic latin
+    (ch >= 0x0390 && ch <= 0x0482) || // some greek, and cyrillic w/o combiners
+    (ch >= 0x048A && ch <= 0x052F) || // more slavic
+    (ch >= 0x1E00 && ch <= 0x1EFF) || // latin extended additional
+    (ch >= 0x2000 && ch <= 0x2C7F) || // some general punctuation, extensions, etc.
+    (ch >= 0x2E00 && ch <= 0x2E42) || // supplemental punctuation
+    (ch >= 0xAB30 && ch <= 0xAB65);   // more latin extended
+}
+
+
+//==========================================================================
+//
+//  utf_char_len
+//
+//  determine utf-8 sequence length (in bytes) by its first char.
+//  returns length (up to 4) or 0 on invalid first char
+//  doesn't allow overlongs
+//
+//==========================================================================
+static CC25519_INLINE vwad_uint utf_char_len (const void *str) {
+  const vwad_ubyte ch = *((const vwad_ubyte *)str);
+  if (ch < 0x80) return 1;
+  else if ((ch&0x0E0) == 0x0C0) return (ch != 0x0C0 && ch != 0x0C1 ? 2 : 0);
+  else if ((ch&0x0F0) == 0x0E0) return 3;
+  else if ((ch&0x0F8) == 0x0F0) return 4;
+  else return 0;
+}
+
+
+//==========================================================================
+//
+//  utf_decode
+//
+//==========================================================================
+static CC25519_INLINE vwad_ushort utf_decode (const char **strp) {
+  const vwad_ubyte *bp = (const vwad_ubyte *)*strp;
+  vwad_ushort res = (vwad_ushort)utf_char_len(bp);
+  vwad_ubyte ch = *bp;
+  if (res < 1 || res > 3) {
+    res = VWAD_REPLACEMENT_CHAR;
+    *strp += 1;
+  } else if (ch < 0x80) {
+    res = ch;
+    *strp += 1;
+  } else if ((ch&0x0E0) == 0x0C0) {
+    if (ch == 0x0C0 || ch == 0x0C1) {
+      res = VWAD_REPLACEMENT_CHAR;
+      *strp += 1;
+    } else {
+      res = ch - 0x0C0;
+      ch = bp[1];
+      if ((ch&0x0C0) != 0x80) {
+        res = VWAD_REPLACEMENT_CHAR;
+        *strp += 1;
+      } else {
+        res = res * 64 + ch - 128;
+        *strp += 2;
+      }
+    }
+  } else if ((ch&0x0F0) == 0x0E0) {
+    res = ch - 0x0E0;
+    ch = bp[1];
+    if ((ch&0x0C0) != 0x80) {
+      res = VWAD_REPLACEMENT_CHAR;
+      *strp += 1;
+    } else {
+      res = res * 64 + ch - 128;
+      ch = bp[2];
+      if ((ch&0x0C0) != 0x80) {
+        res = VWAD_REPLACEMENT_CHAR;
+        *strp += 1;
+      } else {
+        res = res * 64 + ch - 128;
+        *strp += 3;
+      }
+    }
+  } else {
+    res = VWAD_REPLACEMENT_CHAR;
+  }
+  if (res && !is_uni_printable(res)) res = VWAD_REPLACEMENT_CHAR;
+  return res;
+}
+
+
+//==========================================================================
+//
+//  unilower
+//
+//==========================================================================
+static CC25519_INLINE vwad_ushort unilower (vwad_ushort ch) {
+  if ((ch >= 'A' && ch <= 'Z') ||
+      (ch >= 0x00C0 && ch <= 0x00D6) ||
+      (ch >= 0x00D8 && ch <= 0x00DE) ||
+      (ch >= 0x0410 && ch <= 0x042F))
+  {
+    return ch + 0x20;
+  }
+  if (ch == 0x0178) return 0x00FF;
+  if (ch >= 0x0400 && ch <= 0x040F) return ch + 0x50;
+  if ((ch >= 0x1E00 && ch <= 0x1E95) ||
+      (ch >= 0x1EA0 && ch <= 0x1EFF))
+  {
+    return ch|0x01;
+  }
+  if (ch == 0x1E9E) return 0x00DF;
+  return ch;
+}
+
+
+//==========================================================================
+//
+//  vwad_utf_char_len
+//
+//==========================================================================
+VWAD_PUBLIC vwad_uint vwad_utf_char_len (const void *str) {
+  return (str ? utf_char_len(str) : 0);
+}
+
+
+//==========================================================================
+//
+//  vwad_is_uni_printable
+//
+//==========================================================================
+VWAD_PUBLIC vwad_bool vwad_is_uni_printable (vwad_ushort ch) {
+  return is_uni_printable(ch);
+}
+
+
+//==========================================================================
+//
+//  vwad_utf_decode
+//
+//  advances `strp` at least by one byte
+//
+//==========================================================================
+VWAD_PUBLIC vwad_ushort vwad_utf_decode (const char **strp) {
+  return (strp ? utf_decode(strp) : VWAD_REPLACEMENT_CHAR);
+}
+
+
+//==========================================================================
+//
+//  vwad_uni_tolower
+//
+//==========================================================================
+VWAD_PUBLIC vwad_ushort vwad_uni_tolower (vwad_ushort ch) {
+  return unilower(ch);
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static vwad_uint joaatHashStrCI (const char *key) {
+  #define JOAAT_MIX(b_)  do { \
+    hash += (vwad_ubyte)(b_); \
+    hash += hash<<10; \
+    hash ^= hash>>6; \
+  } while (0)
+
+  vwad_uint hash = 0x29a;
+  vwad_uint len = 0;
+  while (*key) {
+    vwad_ushort ch = unilower(utf_decode(&key));
+    JOAAT_MIX(ch);
+    if (ch >= 0x100) JOAAT_MIX(ch>>8);
+    ++len;
+  }
+  // mix length (it should not be greater than 255)
+  JOAAT_MIX(len);
+  // finalize
+  hash += hash<<3;
+  hash ^= hash>>11;
+  hash += hash<<15;
+  return hash;
+}
+
+#define hashStrCI joaatHashStrCI
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static vwad_bool strEquCI (const char *s0, const char *s1) {
+  if (!s0 || !s1) return 0;
+  vwad_ushort c0 = unilower(utf_decode(&s0));
+  vwad_ushort c1 = unilower(utf_decode(&s1));
+  while (c0 != 0 && c1 != 0 && c0 == c1) {
+    if (c0 == VWAD_REPLACEMENT_CHAR || c1 == VWAD_REPLACEMENT_CHAR) return 0;
+    c0 = unilower(utf_decode(&s0));
+    c1 = unilower(utf_decode(&s1));
+  }
+  return (c0 == 0 && c1 == 0);
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+VWAD_PUBLIC vwad_bool vwad_str_equ_ci (const char *s0, const char *s1) { return strEquCI(s0, s1); }
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#define HASH_BUCKETS  (1024)
+
+#define MAX_OPENED_FILES  (128)
+// it must be at least not less than max opened files
+#define MAX_GLOB_BUFFERS  MAX_OPENED_FILES
+
+
+vwad_push_pack
+typedef struct vwad_packed_struct {
+  vwad_uint ofs;       // offset in stream
+  vwad_ushort upksize; // unpacked chunk size-1
+  vwad_ushort pksize;  // packed chunk size (0 means "unpacked")
+} ChunkInfo;
+
+typedef struct vwad_packed_struct {
+  vwad_uint firstChunk; // first chunk
+  vwad_uint nameHash;   // name hash
+  vwad_uint hcNext;     // next name in bucket chain
+  vwad_uint gnameofs;   // group name offset
+  vwad_uint64 ftime;    // since Epoch, 0 is "unknown"
+  vwad_uint crc32;      // full crc32
+  vwad_uint upksize;    // unpacked file size
+  vwad_uint chunkCount; // number of chunks
+  vwad_uint nameofs;    // name offset in names array
+} FileInfo;
+
+typedef struct vwad_packed_struct {
+  vwad_uint crc32;
+  vwad_ushort version;
+  vwad_ushort flags;
+  vwad_uint dirofs;
+  vwad_ushort u_cmt_size;
+  vwad_ushort p_cmt_size;
+  vwad_uint cmt_crc32;
+} MainFileHeader;
+
+typedef struct vwad_packed_struct {
+  vwad_uint pkdir_crc32;
+  vwad_uint dir_crc32;
+  vwad_uint pkdirsize;
+  vwad_uint upkdirsize;
+} MainDirHeader;
+vwad_pop_pack
+
+typedef struct {
+  vwad_uint cidx_abs; // chunk number in file (absolute)
+  vwad_uint size;     // 0: the buffer is not used
+  vwad_uint era;
+  vwad_ubyte data[65536];
+} FileBuffer;
+
+typedef struct {
+  vwad_uint fidx;  // file index for this fd; 0 means "unused"
+  vwad_uint fofs;  // virtual file offset, in bytes
+  vwad_uint bidx;  // current cache buffer index (in `globCache`)
+  // last seen chunk cache (both values could contain `VWAD_BAD_CHUNK`)
+  vwad_uint cidx_rel; // relative chunk index for `cidx_abs`
+  vwad_uint cidx_abs; // absolute chunk index for `cidx_rel`
+} OpenedFile;
+
+
+// should not conflict with open flags!
+struct vwad_handle_t {
+  vwad_iostream *strm;
+  vwad_memman *mman;
+  vwad_uint flags;
+  ed25519_public_key pubkey;
+  char *comment;        // can be NULL
+  char author[128];     // author string
+  char title[128];      // title string
+  vwad_ubyte *updir;    // unpacked directory
+  ChunkInfo *chunks;    // points to the unpacked directory
+  vwad_uint *fat;       // pointer to FAT or `NULL`
+  vwad_uint xorRndSeed; // seed for block decryptor
+  vwad_uint chunkCount; // number of elements in `chunks` array
+  // files (0 is unused)
+  FileInfo *files;      // points to the unpacked directory
+  vwad_uint fileCount;  // number of elements in `files` array
+  // file names (0-terminated)
+  const char *names;    // points to the unpacked directory
+  // directory hash table
+  vwad_uint buckets[HASH_BUCKETS];
+  // public key
+  vwad_uint haspubkey;  // bit 0: has key; bit 1: authenticated
+  // opened files
+  OpenedFile fds[MAX_OPENED_FILES];
+  int fdsUsed; // to avoid excessive scans
+  // temporary buffer to unpack chunks (data + crc32)
+  vwad_ubyte pkdata[65536 + 4];
+  // global cache
+  vwad_uint globCacheSize; // 0 means "each opened file owns exactly one buffer"
+  FileBuffer *globCache[MAX_GLOB_BUFFERS];
+  vwad_uint lastera;
+};
+
+
+typedef struct {
+  vwad_iostream *strm;
+  int currpos, size;
+} EdInfo;
+
+
+//==========================================================================
+//
+//  ed_total_size
+//
+//==========================================================================
+static int ed_total_size (cc_ed25519_iostream *strm) {
+  EdInfo *nfo = (EdInfo *)strm->udata;
+  return nfo->size - (4+64+32); // without header
+}
+
+
+//==========================================================================
+//
+//  ed_read
+//
+//==========================================================================
+static int ed_read (cc_ed25519_iostream *strm, int startpos, void *buf, int bufsize) {
+  EdInfo *nfo = (EdInfo *)strm->udata;
+  if (startpos < 0) return VWAD_ERROR; // oops
+  startpos += 4+64+32; // skip header
+  if (startpos >= nfo->size) return VWAD_ERROR;
+  const int max = nfo->size - startpos;
+  if (bufsize > max) bufsize = max;
+  if (nfo->currpos != startpos) {
+    if (nfo->strm->seek(nfo->strm, startpos) != VWAD_OK) return VWAD_ERROR;
+    nfo->currpos = startpos + bufsize;
+  } else {
+    nfo->currpos += bufsize;
+  }
+  return nfo->strm->read(nfo->strm, buf, bufsize);
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static CC25519_INLINE vwad_bool is_path_delim (char ch) {
+  return (ch == '/' || ch == '\\');
+}
+
+
+//==========================================================================
+//
+//  vwad_normalize_file_name
+//
+//==========================================================================
+VWAD_PUBLIC vwad_result vwad_normalize_file_name (const char *fname, char res[256]) {
+  if (fname == NULL || res == NULL) return VWAD_ERROR;
+  vwad_uint spos = 0, dpos = 0;
+  if (fname[0] == '.' && is_path_delim(fname[1])) ++fname;
+  else if (is_path_delim(fname[0])) { res[0] = '/'; dpos = 1; }
+  while (dpos <= 255 && fname[spos]) {
+    char ch = fname[spos++];
+    if (ch < 32 || ch >= 127) {
+      dpos = 256;
+    } else if (ch == '/' || ch == '\\') {
+      if (dpos != 0 && res[dpos - 1] != '/') res[dpos++] = '/';
+      // skip "." and ".."
+      while (is_path_delim(fname[spos])) ++spos;
+      if (fname[spos] == '.' && fname[spos + 1] == '.' && is_path_delim(fname[spos + 2])) {
+        spos += 2;
+        if (dpos <= 1) dpos = 256;
+        else {
+          // remove last directory
+          vassert(res[dpos - 1] == '/');
+          --dpos;
+          while (dpos > 0 && res[dpos - 1] != '/') --dpos;
+        }
+      } else if (fname[spos] == '.' && is_path_delim(fname[spos + 1])) {
+        spos += 1;
+      }
+    } else {
+      res[dpos++] = ch;
+    }
+  }
+  if (dpos == 0 || dpos > 255) {
+    res[0] = 0; // why not
+    return VWAD_ERROR;
+  } else {
+    res[dpos] = 0;
+    return VWAD_OK;
+  }
+}
+
+
+//==========================================================================
+//
+//  is_valid_string
+//
+//==========================================================================
+static vwad_bool is_valid_string (const char *str) {
+  if (!str) return 1;
+  // check chars
+  vwad_ushort ch;
+  do { ch = utf_decode(&str); } while (ch >= 32 && ch != VWAD_REPLACEMENT_CHAR);
+  return (ch == 0);
+}
+
+
+//==========================================================================
+//
+//  is_valid_comment
+//
+//==========================================================================
+static vwad_bool is_valid_comment (const char *cmt, vwad_uint cmtlen) {
+  vwad_bool res = 1;
+  if (cmt != NULL) {
+    vwad_ushort ch;
+    do {
+      ch = utf_decode(&cmt);
+      if (ch < 32 && (ch != 0 && ch != 9 && ch != 10)) ch = VWAD_REPLACEMENT_CHAR;
+    } while (ch != 0 && ch != VWAD_REPLACEMENT_CHAR);
+    return (ch == 0);
+  } else {
+    res = (cmtlen == 0);
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  is_pointer_aligned
+//
+//  don't fuckin' ask me!
+//
+//==========================================================================
+static vwad_bool is_pointer_aligned (const void *p) {
+  if (p) {
+    vwad_ubyte b;
+    vwad_uint ui = 69;
+    memcpy((void *)&b, (const void *)&ui, 1);
+    if (b != 0) {
+      // little-endian
+      memcpy((void *)&b, ((const char *)(const void *)&p), 1);
+    } else {
+      // big-endian
+      memcpy((void *)&b, ((const char *)(const void *)&p) + sizeof(p) - 1, 1);
+    }
+    return ((b & 0x03) == 0);
+  } else {
+    return 1;
+  }
+}
+
+
+//==========================================================================
+//
+//  is_valid_file_name
+//
+//==========================================================================
+static vwad_bool is_valid_file_name (const char *str) {
+  if (!str || !str[0] || str[0] == '/') return 0;
+  // idiotic trick
+  if (!is_pointer_aligned(str)) return 0; // it should be aligned
+  vwad_uint slen = 0;
+  while (slen <= 255 && str[slen] != 0) slen += 1;
+  if (slen > 255) return 0; // too long
+  if (str[slen - 1] == '/') return 0; // should not end with a slash
+  vwad_uint eofs = slen;
+  do {
+    if (str[eofs]) return 0;
+    ++eofs;
+  } while ((eofs&0x03) != 0);
+  // check chars
+  vwad_ushort ch;
+  do { ch = utf_decode(&str); } while (ch >= 32 && ch != VWAD_REPLACEMENT_CHAR);
+  return (ch == 0);
+}
+
+
+//==========================================================================
+//
+//  is_valid_group_name
+//
+//==========================================================================
+static vwad_bool is_valid_group_name (const char *str) {
+  if (!str) return 0;
+  // idiotic trick
+  if (!is_pointer_aligned(str)) return 0; // it should be aligned
+  vwad_uint slen = 0;
+  while (slen <= 255 && str[slen] != 0) slen += 1;
+  if (slen > 255) return 0; // too long
+  vwad_uint eofs = slen;
+  do {
+    if (str[eofs]) return 0;
+    ++eofs;
+  } while ((eofs&0x03) != 0);
+  // check chars
+  vwad_ushort ch;
+  do { ch = utf_decode(&str); } while (ch >= 32 && ch != VWAD_REPLACEMENT_CHAR);
+  return (ch == 0);
+}
+
+
+//==========================================================================
+//
+//  vwad_open_archive
+//
+//==========================================================================
+VWAD_PUBLIC vwad_handle *vwad_open_archive (vwad_iostream *strm, vwad_uint flags,
+                                            vwad_memman *mman)
+{
+  if (!strm || !strm->seek || !strm->read) {
+    logf(ERROR, "vwad_open_archive: invalid stream");
+    return NULL;
+  }
+  if (strm->seek(strm, 0) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot seek to 0");
+    return NULL;
+  }
+
+  ed25519_public_key pubkey;
+  ed25519_signature edsign;
+  MainFileHeader mhdr;
+  MainDirHeader dhdr;
+  vwad_ubyte *wadcomment = NULL;
+  char sign[4];
+  char author[128];
+  char title[128];
+  vwad_ubyte aslen, tslen;
+
+  // file signature
+  if (strm->read(strm, sign, 4) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read signature");
+    return NULL;
+  }
+  if (memcmp(sign, "VWAD", 4) != 0) {
+    logf(ERROR, "vwad_open_archive: invalid signature");
+    return NULL;
+  }
+  // digital signature
+  if (strm->read(strm, &edsign, (vwad_uint)sizeof(edsign)) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read edsign");
+    return NULL;
+  }
+
+  aslen = 0;
+  for (vwad_uint f = 0; f < (vwad_uint)sizeof(edsign); ++f) aslen |= edsign[f];
+  if (aslen == 0) {
+    logf(ERROR, "vwad_open_archive: invalid edsign");
+    return NULL;
+  }
+
+  // public key
+  if (strm->read(strm, &pubkey, (vwad_uint)sizeof(pubkey)) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read pubkey");
+    return NULL;
+  }
+
+  aslen = 0;
+  for (vwad_uint f = 0; f < (vwad_uint)sizeof(pubkey); ++f) aslen |= pubkey[f];
+  if (aslen == 0) {
+    logf(ERROR, "vwad_open_archive: invalid public key");
+    return NULL;
+  }
+
+  // lengthes
+  if (strm->read(strm, &aslen, 1) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read author length");
+    return NULL;
+  }
+  if (strm->read(strm, &tslen, 1) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read title length");
+    return NULL;
+  }
+
+  // read author
+  if (strm->read(strm, sign, 2) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read author padding");
+    return NULL;
+  }
+  if (memcmp(sign, "\x0d\x0a", 2) != 0) {
+    logf(ERROR, "vwad_open_archive: invalid author padding");
+    return NULL;
+  }
+  if (aslen != 0 && strm->read(strm, author, (int)aslen) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read author");
+    return NULL;
+  }
+  if (aslen > 127) {
+    logf(ERROR, "vwad_open_archive: invalid author string length");
+    return NULL;
+  }
+  author[aslen] = 0;
+  if (!is_valid_string(author)) {
+    logf(WARNING, "vwad_open_archive: invalid author string contents, discarded");
+    memset(author, 0, sizeof(author));
+  }
+
+  // read title
+  if (strm->read(strm, sign, 2) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read title padding");
+    return NULL;
+  }
+  if (memcmp(sign, "\x0d\x0a", 2) != 0) {
+    logf(ERROR, "vwad_open_archive: invalid title padding");
+    return NULL;
+  }
+  if (tslen != 0 && strm->read(strm, title, (int)tslen) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read title");
+    return NULL;
+  }
+  if (tslen > 127) {
+    logf(ERROR, "vwad_open_archive: invalid title string length");
+    return NULL;
+  }
+  title[tslen] = 0;
+  if (!is_valid_string(title)) {
+    logf(WARNING, "vwad_open_archive: invalid title string contents, discarded");
+    memset(title, 0, sizeof(title));
+  }
+
+  // read final padding
+  if (strm->read(strm, sign, 4) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read title padding");
+    return NULL;
+  }
+  if (memcmp(sign, "\x0d\x0a\x1b\x00", 4) != 0) {
+    logf(ERROR, "vwad_open_archive: invalid final padding");
+    return NULL;
+  }
+
+  // read main header
+  if (strm->read(strm, &mhdr, (vwad_uint)sizeof(mhdr)) != VWAD_OK) {
+    logf(ERROR, "vwad_open_archive: cannot read main header");
+    return NULL;
+  }
+
+  vwad_uint fcofs = 4 + (vwad_uint)sizeof(edsign) + (vwad_uint)sizeof(pubkey) +
+                   1+1+2 + aslen + 2 + tslen + 4 +
+                   (vwad_uint)sizeof(mhdr);
+
+  vwad_uint pkseed, seed;
+
+  // decrypt public key
+  #if 0
+  logf(DEBUG, "author: %s", author);
+  logf(DEBUG, "title: %s", title);
+  #endif
+  pkseed = deriveSeed(0xa29, edsign, (vwad_uint)sizeof(ed25519_signature));
+  pkseed = deriveSeed(pkseed, (const vwad_ubyte *)author, (vwad_uint)strlen(author));
+  pkseed = deriveSeed(pkseed, (const vwad_ubyte *)title, (vwad_uint)strlen(title));
+  #if 0
+  logf(DEBUG, "kkseed: 0x%08x", pkseed);
+  #endif
+  crypt_buffer(pkseed, 0x29a, pubkey, (vwad_uint)sizeof(ed25519_public_key));
+
+  // create initial seed from pubkey, author, and title
+  pkseed = deriveSeed(0x29c, pubkey, (vwad_uint)sizeof(ed25519_public_key));
+  pkseed = deriveSeed(pkseed, (const vwad_ubyte *)author, (vwad_uint)strlen(author));
+  pkseed = deriveSeed(pkseed, (const vwad_ubyte *)title, (vwad_uint)strlen(title));
+  #if 0
+  logf(DEBUG, "pkseed: 0x%08x", pkseed);
+  #endif
+  crypt_buffer(pkseed, 1, &mhdr, (vwad_uint)sizeof(mhdr));
+
+  mhdr.crc32 = get_u32(&mhdr.crc32);
+  mhdr.version = get_u16(&mhdr.version);
+  mhdr.flags = get_u16(&mhdr.flags);
+  mhdr.dirofs = get_u32(&mhdr.dirofs);
+  mhdr.u_cmt_size = get_u16(&mhdr.u_cmt_size);
+  mhdr.p_cmt_size = get_u16(&mhdr.p_cmt_size);
+  mhdr.cmt_crc32 = get_u32(&mhdr.cmt_crc32);
+
+  if (mhdr.version != 0) {
+    logf(ERROR, "vwad_open_archive: invalid version");
+    return NULL;
+  }
+  if (mhdr.flags > 0x07u) {
+    logf(ERROR, "vwad_open_archive: invalid flags");
+    return NULL;
+  }
+
+  if (mhdr.u_cmt_size == 0 && mhdr.cmt_crc32 != 0) {
+    logf(ERROR, "vwad_open_archive: corrupted header data");
+    return NULL;
+  }
+
+  if (mhdr.crc32 != crc32_buf(&mhdr.version, (vwad_uint)sizeof(mhdr) - 4)) {
+    logf(ERROR, "vwad_open_archive: corrupted header data");
+    return NULL;
+  }
+
+  if (mhdr.dirofs <= 4+32+64+(int)sizeof(mhdr)+(int)mhdr.p_cmt_size) {
+    logf(ERROR, "vwad_open_archive: invalid directory offset");
+    return NULL;
+  }
+
+  if (mhdr.u_cmt_size == 0 && mhdr.p_cmt_size != 0) {
+    logf(ERROR, "vwad_open_archive: invalid comment size");
+    return NULL;
+  }
+
+  // read comment, because we need it for seed generation
+  if (mhdr.u_cmt_size != 0) {
+    if (mhdr.p_cmt_size == 0) {
+      // not packed
+      fcofs += mhdr.u_cmt_size;
+      wadcomment = zalloc(mman, mhdr.u_cmt_size + 1); // +1 for reusing
+      if (wadcomment == NULL) {
+        logf(ERROR, "vwad_open_archive: cannot allocate buffer for comment");
+        return NULL;
+      }
+      if (strm->read(strm, wadcomment, mhdr.u_cmt_size) != VWAD_OK) {
+        xfree(mman, wadcomment);
+        logf(ERROR, "vwad_open_archive: cannot read comment data");
+        return NULL;
+      }
+      // update seed
+      seed = deriveSeed(pkseed, wadcomment, mhdr.u_cmt_size);
+    } else {
+      // packed
+      fcofs += mhdr.p_cmt_size;
+      wadcomment = zalloc(mman, mhdr.p_cmt_size);
+      if (wadcomment == NULL) {
+        logf(ERROR, "vwad_open_archive: cannot allocate buffer for comment");
+        return NULL;
+      }
+      if (strm->read(strm, wadcomment, mhdr.p_cmt_size) != VWAD_OK) {
+        xfree(mman, wadcomment);
+        logf(ERROR, "vwad_open_archive: cannot read comment data");
+        return NULL;
+      }
+      // update seed
+      seed = deriveSeed(pkseed, wadcomment, mhdr.p_cmt_size);
+    }
+  } else {
+    // still seed
+    seed = deriveSeed(pkseed, wadcomment, 0);
+  }
+  #if 0
+  logf(DEBUG, "xnseed: 0x%08x", seed);
+  #endif
+
+  // determine file size
+  if (strm->seek(strm, (int)mhdr.dirofs) != VWAD_OK) {
+    xfree(mman, wadcomment);
+    logf(ERROR, "vwad_open_archive: cannot seek to directory");
+    return NULL;
+  }
+
+  logf(DEBUG, "vwad_open_archive: dirofs=0x%08x", mhdr.dirofs);
+
+  if (strm->read(strm, &dhdr, (vwad_uint)sizeof(dhdr)) != VWAD_OK) {
+    xfree(mman, wadcomment);
+    logf(ERROR, "vwad_open_archive: cannot read directory header");
+    return NULL;
+  }
+
+  crypt_buffer(seed, 0xfffffffeU, &dhdr, (vwad_uint)sizeof(dhdr));
+
+  dhdr.pkdir_crc32 = get_u32(&dhdr.pkdir_crc32);
+  dhdr.dir_crc32 = get_u32(&dhdr.dir_crc32);
+  dhdr.pkdirsize = get_u32(&dhdr.pkdirsize);
+  dhdr.upkdirsize = get_u32(&dhdr.upkdirsize);
+
+  logf(DEBUG, "vwad_open_archive: pkdirsize=0x%08x", dhdr.pkdirsize);
+  logf(DEBUG, "vwad_open_archive: upkdirsize=0x%08x", dhdr.upkdirsize);
+  if (dhdr.pkdirsize == 0 || dhdr.pkdirsize > 0x04000000U) {
+    xfree(mman, wadcomment);
+    logf(ERROR, "vwad_open_archive: invalid directory size");
+    return NULL;
+  }
+  if (dhdr.upkdirsize <= 4*11 || dhdr.upkdirsize > 0x04000000U) {
+    xfree(mman, wadcomment);
+    logf(ERROR, "vwad_open_archive: invalid directory size");
+    return NULL;
+  }
+  if (0x7fffffffU - mhdr.dirofs < dhdr.pkdirsize) {
+    xfree(mman, wadcomment);
+    logf(ERROR, "vwad_open_archive: invalid directory size");
+    return NULL;
+  }
+
+  // check digital signature
+  vwad_uint haspubkey = 0;
+  if ((mhdr.flags & 0x01) == 0) haspubkey = 1;
+  if (haspubkey) {
+    if ((flags & VWAD_OPEN_NO_SIGN_CHECK) == 0) {
+      cc_ed25519_iostream edstrm;
+      EdInfo nfo;
+      nfo.strm = strm;
+      nfo.currpos = -1;
+      nfo.size = (int)(mhdr.dirofs + dhdr.pkdirsize + (int)sizeof(dhdr));
+      logf(DEBUG, "vwad_open_archive: file size: %d", nfo.size);
+      edstrm.udata = &nfo;
+      edstrm.total_size = ed_total_size;
+      edstrm.read = ed_read;
+
+      logf(NOTE, "checking digital signature...");
+      int sres = edsign_verify_stream(edsign, pubkey, &edstrm);
+      if (sres != 0) {
+        xfree(mman, wadcomment);
+        logf(ERROR, "vwad_open_archive: invalid digital signature");
+        return NULL;
+      }
+      haspubkey = 3; // has a key, and authenticated
+    }
+  }
+
+  // read and unpack directory
+  if (strm->seek(strm, (int)mhdr.dirofs + (int)sizeof(dhdr)) != VWAD_OK) {
+    xfree(mman, wadcomment);
+    logf(ERROR, "vwad_open_archive: cannot seek to directory data");
+    return NULL;
+  }
+
+  void *unpkdir = xalloc(mman, dhdr.upkdirsize + 4); // always end it with 0
+  if (!unpkdir) {
+    xfree(mman, wadcomment);
+    logf(ERROR, "vwad_open_archive: cannot allocate memory for unpacked directory");
+    return NULL;
+  }
+  put_u32((char *)unpkdir + dhdr.upkdirsize, 0);
+
+  void *pkdir = xalloc(mman, dhdr.pkdirsize);
+  if (!pkdir) {
+    xfree(mman, wadcomment);
+    xfree(mman, unpkdir);
+    logf(ERROR, "vwad_open_archive: cannot allocate memory for packed directory");
+    return NULL;
+  }
+
+  if (strm->read(strm, pkdir, dhdr.pkdirsize) != VWAD_OK) {
+    xfree(mman, wadcomment);
+    xfree(mman, pkdir);
+    xfree(mman, unpkdir);
+    logf(ERROR, "vwad_open_archive: cannot read directory data");
+    return NULL;
+  }
+
+  crypt_buffer(seed, 0xffffffffU, pkdir, dhdr.pkdirsize);
+
+  vwad_uint crc32 = crc32_buf(pkdir, dhdr.pkdirsize);
+  if (crc32 != dhdr.pkdir_crc32) {
+    xfree(mman, wadcomment);
+    xfree(mman, pkdir);
+    xfree(mman, unpkdir);
+    logf(DEBUG, "vwad_open_archive: pkcrc: file=0x%08x; real=0x%08x", dhdr.pkdir_crc32, crc32);
+    logf(ERROR, "vwad_open_archive: corrupted packed directory data");
+    return NULL;
+  }
+
+  if (!DecompressLZFF3(pkdir, dhdr.pkdirsize, unpkdir, dhdr.upkdirsize)) {
+    xfree(mman, wadcomment);
+    xfree(mman, pkdir);
+    xfree(mman, unpkdir);
+    logf(ERROR, "vwad_open_archive: cannot decompress directory");
+    return NULL;
+  }
+  xfree(mman, pkdir);
+
+  crc32 = crc32_buf(unpkdir, dhdr.upkdirsize);
+  if (crc32 != dhdr.dir_crc32) {
+    xfree(mman, wadcomment);
+    xfree(mman, unpkdir);
+    logf(DEBUG, "vwad_open_archive: upkcrc: file=0x%08x; real=0x%08x", dhdr.dir_crc32, crc32);
+    logf(ERROR, "vwad_open_archive: corrupted unpacked directory data");
+    return NULL;
+  }
+
+  // allocate wad handle
+  vwad_handle *wad = zalloc(mman, (vwad_uint)sizeof(vwad_handle));
+  if (wad == NULL) {
+    xfree(mman, wadcomment);
+    xfree(mman, unpkdir);
+    logf(ERROR, "vwad_open_archive: cannot allocate memory for vwad handle");
+    return NULL;
+  }
+  wad->strm = strm;
+  wad->mman = mman;
+  wad->flags = (vwad_uint)flags;
+  wad->updir = unpkdir;
+  wad->xorRndSeed = seed;
+  if (haspubkey) {
+    vassert(sizeof(wad->pubkey) == sizeof(pubkey));
+    memcpy(wad->pubkey, pubkey, sizeof(wad->pubkey));
+    wad->haspubkey = haspubkey;
+  } else {
+    memset(wad->pubkey, 0, sizeof(wad->pubkey));
+    wad->haspubkey = 0;
+  }
+
+  strcpy(wad->author, author);
+  strcpy(wad->title, title);
+
+  // init hash buckets
+  for (vwad_uint f = 0; f < HASH_BUCKETS; ++f) wad->buckets[f] = VWAD_UNONE;
+
+  // get counters
+  wad->chunkCount = get_u32(wad->updir + 0);
+  wad->fileCount = get_u32(wad->updir + 4);
+
+  // setup and check chunks
+  vwad_uint upofs = 4+4;
+  if (/*wad->chunkCount == 0 ||*/ wad->chunkCount > 0x1fffffffU ||
+      wad->chunkCount*(vwad_uint)sizeof(ChunkInfo) >= dhdr.upkdirsize ||
+      wad->chunkCount*(vwad_uint)sizeof(ChunkInfo) >= dhdr.upkdirsize - upofs)
+  {
+    logf(ERROR, "invalid chunk count (%u)", wad->chunkCount);
+    goto error;
+  }
+  logf(DEBUG, "chunk count: %u", wad->chunkCount);
+  wad->chunks = (ChunkInfo *)(wad->updir + upofs);
+  upofs += wad->chunkCount * (vwad_uint)sizeof(ChunkInfo);
+
+  for (vwad_uint cidx = 0; cidx < wad->chunkCount; ++cidx) {
+    ChunkInfo *ci = &wad->chunks[cidx];
+    ci->pksize = get_u16(&ci->pksize);
+    if (ci->ofs != 0 || ci->upksize != 0) {
+      logf(ERROR, "invalid chunk data (0; idx=%u): ofs=%u; upksize=%u",
+           cidx, ci->ofs, ci->upksize);
+      goto error;
+    }
+    ci->ofs = 0xffffffffU;
+  }
+
+  // files
+  if (upofs >= dhdr.upkdirsize || dhdr.upkdirsize - upofs < (vwad_uint)sizeof(FileInfo) + 8) {
+    logf(ERROR, "invalid directory data (files, 0)");
+    goto error;
+  }
+
+  if (/*wad->fileCount < 1 ||*/ wad->fileCount > /*0xffffU*/0x00ffffffU ||
+      wad->fileCount * (vwad_uint)sizeof(FileInfo) >= dhdr.upkdirsize ||
+      wad->fileCount * (vwad_uint)sizeof(FileInfo) >= dhdr.upkdirsize - upofs)
+  {
+    logf(ERROR, "invalid file count (%u)", wad->fileCount);
+    goto error;
+  }
+  logf(DEBUG, "file count: %u", wad->fileCount);
+  wad->files = (FileInfo *)(wad->updir + upofs);
+  upofs += wad->fileCount * (vwad_uint)sizeof(FileInfo);
+
+  // FAT
+  if (mhdr.flags & 0x04) {
+    if (dhdr.upkdirsize - upofs < wad->chunkCount * 4u + 4u) {
+      logf(ERROR, "truncated FAT table");
+      goto error;
+    }
+    wad->fat = (vwad_uint *)(wad->updir + upofs);
+    upofs += wad->chunkCount * 4u;
+    logf(DEBUG, "fat size: %u entries", wad->chunkCount);
+    // convert table from deltas to indices
+    vwad_uint prev = 0;
+    for (vwad_uint f = 0; f < wad->chunkCount; f += 1) {
+      if (wad->fat[f] != 0) {
+        prev += get_u32(&wad->fat[f]);
+        wad->fat[f] = prev;
+        if (prev >= wad->chunkCount) {
+          logf(ERROR, "corrupted FAT table");
+          goto error;
+        }
+      } else {
+        wad->fat[f] = 0xffffffffU;
+        prev = 0;
+      }
+    }
+  } else {
+    wad->fat = NULL;
+  }
+
+  // names
+  if (upofs >= dhdr.upkdirsize || dhdr.upkdirsize - upofs < 4) {
+    logf(ERROR, "invalid directory data (names, 0)");
+    goto error;
+  }
+  const vwad_uint namesSize = dhdr.upkdirsize - upofs;
+  if (namesSize < 4 || namesSize > 0x3fffffffU || (namesSize&0x03) != 0) {
+    logf(ERROR, "invalid names size (%u)", namesSize);
+    goto error;
+  }
+  logf(DEBUG, "name table size: %u", namesSize);
+  wad->names = (char *)(wad->updir + upofs);
+
+  // unpack comment
+  if ((flags & VWAD_OPEN_NO_MAIN_COMMENT) == 0) {
+    if (mhdr.u_cmt_size != 0) {
+      if (mhdr.p_cmt_size == 0) {
+        // unpacked, just use it as is
+        wad->comment = (char *)wadcomment;
+        wadcomment = NULL;
+        // decrypt comment with pk-seed
+        crypt_buffer(pkseed, 2, wad->comment, mhdr.u_cmt_size);
+      } else {
+        // packed
+        wad->comment = zalloc(mman, mhdr.u_cmt_size + 1);
+        if (wad->comment == NULL) {
+          xfree(mman, wadcomment);
+          logf(ERROR, "vwad_open_archive: out of memory for comment data");
+          goto error;
+        }
+        // decrypt comment with pk-seed
+        crypt_buffer(pkseed, 2, wadcomment, mhdr.p_cmt_size);
+        const intbool_t cupres = DecompressLZFF3(wadcomment, (int)mhdr.p_cmt_size,
+                                                 wad->comment, (int)mhdr.u_cmt_size);
+        xfree(mman, wadcomment);
+        if (!cupres) {
+          logf(ERROR, "vwad_open_archive: cannot decompress packed comment data");
+          goto error;
+        }
+      }
+      if (mhdr.cmt_crc32 != crc32_buf(wad->comment, mhdr.u_cmt_size)) {
+        logf(WARNING, "vwad_open_archive: corrupted comment data, comment discarded");
+        xfree(mman, wad->comment);
+        wad->comment = NULL;
+      } else if (!is_valid_comment(wad->comment, mhdr.u_cmt_size)) {
+        logf(WARNING, "vwad_open_archive: invalid comment data, comment discarded");
+        xfree(mman, wad->comment);
+        wad->comment = NULL;
+      }
+    } else {
+      vassert(wadcomment == NULL);
+    }
+  } else {
+    xfree(mman, wadcomment);
+  }
+
+  vwad_uint chunkOfs = fcofs;
+  vwad_uint currChunk = 0;
+
+  for (vwad_uint fidx = 0; fidx < wad->fileCount; ++fidx) {
+    FileInfo *fi = &wad->files[fidx];
+
+    fi->firstChunk = get_u32(&fi->firstChunk);
+    fi->ftime = get_u64(&fi->ftime);
+    fi->crc32 = get_u32(&fi->crc32);
+    fi->upksize = get_u32(&fi->upksize);
+    fi->chunkCount = get_u32(&fi->chunkCount);
+    fi->nameofs = get_u32(&fi->nameofs);
+    fi->gnameofs = get_u32(&fi->gnameofs);
+
+    if (fi->nameHash != 0 || fi->hcNext != 0) {
+      logf(ERROR, "invalid file data (zero fields are non-zero)");
+      goto error;
+    }
+
+    if (mhdr.flags & 0x04) {
+      if ((fi->chunkCount == 0 && fi->firstChunk != 0) ||
+          (fi->chunkCount != 0 && fi->firstChunk >= wad->chunkCount))
+      {
+        logf(ERROR, "invalid file data (zero fields are non-zero)");
+        goto error;
+      }
+    } else {
+      if (fi->firstChunk != 0) {
+        logf(ERROR, "invalid file data (zero fields are non-zero)");
+        goto error;
+      }
+    }
+
+    // lengthes?
+    if (fidx != 0 && (mhdr.flags & 0x02) != 0) {
+      // convert to offsets
+      fi->nameofs += wad->files[fidx - 1].nameofs;
+    }
+
+    if (fi->chunkCount == 0) {
+      if (fi->upksize != 0) {
+        logf(ERROR, "invalid file data (file size, !0)");
+        goto error;
+      }
+    } else {
+      if (fi->upksize == 0) {
+        logf(ERROR, "invalid file data (file size, 0)");
+        goto error;
+      }
+    }
+
+    if (fi->upksize > 0x7fffffffU || fi->nameofs >= namesSize) {
+      logf(ERROR, "invalid file data (name offset)");
+      goto error;
+    }
+
+    // should be aligned
+    if (fi->nameofs < 4 || (fi->nameofs&0x03) != 0) {
+      logf(ERROR, "invalid file data (name align)");
+      goto error;
+    }
+
+    const char *name = wad->names + fi->nameofs;
+    if (!is_valid_file_name(name)) {
+      logf(ERROR, "invalid file data (file name) (%s)", name);
+      goto error;
+    }
+
+    if (fi->upksize > 0x7fffffffU || fi->gnameofs >= namesSize) {
+      logf(ERROR, "invalid file data (group name offset)");
+      goto error;
+    }
+
+    // should be aligned
+    if (fi->gnameofs&0x03) {
+      logf(ERROR, "invalid file data (group name align)");
+      goto error;
+    }
+
+    if (!is_valid_group_name(wad->names + fi->gnameofs)) {
+      logf(ERROR, "invalid file data (group name)");
+      goto error;
+    }
+
+    // insert name into hash table (also, check for duplicates)
+    fi->nameHash = hashStrCI(name);
+    const vwad_uint bkt = fi->nameHash % HASH_BUCKETS;
+
+    if (wad->buckets[bkt] != VWAD_UNONE) {
+      FileInfo *bkfi = &wad->files[wad->buckets[bkt]];
+      while (bkfi != NULL && !strEquCI(name, wad->names + bkfi->nameofs)) {
+        if (bkfi->hcNext != VWAD_UNONE) bkfi = &wad->files[bkfi->hcNext]; else bkfi = NULL;
+      }
+      if (bkfi != NULL) {
+        logf(ERROR, "duplicate file name (%s)", name);
+        goto error;
+      }
+    }
+
+    fi->hcNext = wad->buckets[bkt];
+    wad->buckets[bkt] = fidx;
+
+    // fix chunks
+    vwad_uint left = fi->upksize;
+    if ((mhdr.flags & 0x04) == 0) {
+      vassert(fi->firstChunk == 0);
+      if (left != 0) fi->firstChunk = currChunk;
+      vassert((left == 0 && fi->chunkCount == 0) || (left != 0 && fi->chunkCount != 0));
+    } else {
+      vassert(left != 0 || fi->firstChunk == 0);
+      currChunk = fi->firstChunk;
+    }
+    // loop over all chunks
+    for (vwad_uint cnn = 0; cnn < fi->chunkCount; ++cnn) {
+      if (left == 0) {
+        logf(ERROR, "invalid file data (out of chunks)");
+        goto error;
+      }
+      if (currChunk >= wad->chunkCount) {
+        logf(ERROR, "invalid file data (chunks)");
+        goto error;
+      }
+      if (wad->chunks[currChunk].ofs != 0xffffffffU) {
+        logf(ERROR, "invalid file data (chunks, oops)");
+        goto error;
+      }
+      if (chunkOfs >= mhdr.dirofs) {
+        logf(ERROR, "invalid file data (chunk offset); fidx=%u; cofs=0x%08x; dofs=0x%08x",
+                    fidx, chunkOfs, mhdr.dirofs);
+        goto error;
+      }
+      wad->chunks[currChunk].ofs = chunkOfs;
+      vassert(left != 0);
+      if (left > 65536) {
+        wad->chunks[currChunk].upksize = 65535;
+        left -= 65536;
+      } else {
+        wad->chunks[currChunk].upksize = left - 1;
+        left = 0;
+      }
+      chunkOfs += 4; // crc32
+      if (wad->chunks[currChunk].pksize == 0) {
+        // unpacked chunk
+        chunkOfs += wad->chunks[currChunk].upksize + 1;
+      } else {
+        // packed chunk
+        chunkOfs += wad->chunks[currChunk].pksize;
+      }
+      if (chunkOfs > mhdr.dirofs) {
+        logf(ERROR, "invalid file data (chunk offset 1); fidx=%u/%u; cofs=0x%08x; dofs=0x%08x",
+                    fidx, wad->fileCount, chunkOfs, mhdr.dirofs);
+        goto error;
+      }
+
+      if ((mhdr.flags & 0x04) == 0) {
+        currChunk += 1;
+      } else {
+        currChunk = wad->fat[currChunk];
+      }
+    }
+
+    // final check
+    if (fi->chunkCount != 0 && (mhdr.flags & 0x04) != 0 && currChunk != 0xffffffffU) {
+      logf(ERROR, "invalid file data (extra chunk); cofs=0x%08x; dofs=0x%08x", chunkOfs, mhdr.dirofs);
+      goto error;
+    }
+  }
+
+  // final check
+  if ((mhdr.flags & 0x04) == 0) {
+    if (chunkOfs != mhdr.dirofs) {
+      logf(ERROR, "invalid file data (extra chunk); cofs=0x%08x; dofs=0x%08x", chunkOfs, mhdr.dirofs);
+      goto error;
+    }
+  } else {
+    // check for unused chunks
+    for (vwad_uint cnn = 0; cnn < wad->chunkCount; ++cnn) {
+      if (wad->chunks[cnn].ofs == 0xffffffffU) {
+        logf(ERROR, "orphaned chunk found");
+        goto error;
+      }
+    }
+  }
+
+  wad->lastera = 1;
+
+  // mark everything as unused
+  for (vwad_uint f = 0; f < MAX_OPENED_FILES; ++f) wad->fds[f].fidx = VWAD_NOFIDX;
+
+  // default cache settings
+  vwad_set_archive_cache(wad, 4);
+
+  return wad;
+
+error:
+  if (wad != NULL) {
+    xfree(mman, wad->updir);
+    memset(wad, 0, sizeof(vwad_handle)); // just in case
+    xfree(mman, wad);
+  }
+  logf(ERROR, "vwad_open_archive: cannot parse directory");
+  return NULL;
+}
+
+
+//==========================================================================
+//
+//  vwad_close_archive
+//
+//==========================================================================
+VWAD_PUBLIC void vwad_close_archive (vwad_handle **wadp) {
+  if (wadp) {
+    vwad_handle *wad = *wadp;
+    if (wad) {
+      *wadp = NULL;
+      vwad_memman *mman = wad->mman;
+      // there is no need to close opened files, nothing is allocated for them
+      for (vwad_uint c = 0; c < MAX_GLOB_BUFFERS; ++c) {
+        xfree(mman, wad->globCache[c]);
+      }
+      xfree(mman, wad->updir);
+      xfree(mman, wad->comment);
+      memset(wad, 0, sizeof(vwad_handle)); // just in case
+      xfree(mman, wad);
+    }
+  }
+}
+
+
+//==========================================================================
+//
+//  vwad_set_archive_cache
+//
+//==========================================================================
+VWAD_PUBLIC void vwad_set_archive_cache (vwad_handle *wad, int chunkCount) {
+  if (wad != NULL) {
+    if (chunkCount < 0) chunkCount = 0;
+    else if (chunkCount > MAX_GLOB_BUFFERS) chunkCount = MAX_GLOB_BUFFERS;
+    if (wad->globCacheSize != (vwad_uint)chunkCount) {
+      // file reader will check and invalidate buffers
+      // there is no need to flush the cache, file reader will do the trick
+      // but we need to free extra unused buffers
+      // free extra buffers
+      // for local caching, we may have duplicate buffers in global cache; just free 'em all!
+      for (int c = chunkCount; c < MAX_GLOB_BUFFERS; ++c) {
+        xfree(wad->mman, wad->globCache[c]);
+        wad->globCache[c] = NULL;
+      }
+      wad->globCacheSize = (vwad_uint)chunkCount;
+    }
+  }
+}
+
+
+//==========================================================================
+//
+//  vwad_get_archive_comment_size
+//
+//==========================================================================
+VWAD_PUBLIC vwad_uint vwad_get_archive_comment_size (vwad_handle *wad) {
+  return (wad && wad->comment ? (vwad_uint)strlen(wad->comment) : 0);
+}
+
+
+//==========================================================================
+//
+//  vwad_get_archive_comment
+//
+//==========================================================================
+VWAD_PUBLIC void vwad_get_archive_comment (vwad_handle *wad, char *dest, vwad_uint destsize) {
+  if (!wad || !wad->comment || destsize < 2 || !dest) {
+    if (dest && destsize) dest[0] = 0;
+  } else {
+    vwad_uint csize = (vwad_uint)strlen(wad->comment);
+    if (csize > destsize) csize = destsize;
+    if (csize) memcpy(dest, wad->comment, csize);
+    dest[csize] = 0;
+  }
+}
+
+
+//==========================================================================
+//
+//  vwad_get_archive_author
+//
+//==========================================================================
+VWAD_PUBLIC const char *vwad_get_archive_author (vwad_handle *wad) {
+  return (wad ? wad->author : "");
+}
+
+
+//==========================================================================
+//
+//  vwad_get_archive_title
+//
+//==========================================================================
+VWAD_PUBLIC const char *vwad_get_archive_title (vwad_handle *wad) {
+  return (wad ? wad->title : "");
+}
+
+
+//==========================================================================
+//
+//  vwad_free_archive_comment
+//
+//  forget main archive comment and free its memory.
+//
+//==========================================================================
+VWAD_PUBLIC void vwad_free_archive_comment (vwad_handle *wad) {
+  if (wad && wad->comment) {
+    xfree(wad->mman, wad->comment);
+    wad->comment = NULL;
+  }
+}
+
+
+//==========================================================================
+//
+//  vwad_is_authenticated
+//
+//==========================================================================
+VWAD_PUBLIC vwad_bool vwad_is_authenticated (vwad_handle *wad) {
+  return (wad && (wad->haspubkey & 0x02) != 0);
+}
+
+
+//==========================================================================
+//
+//  vwad_has_pubkey
+//
+//==========================================================================
+VWAD_PUBLIC vwad_bool vwad_has_pubkey (vwad_handle *wad) {
+  return (wad && (wad->haspubkey & 0x01) != 0);
+}
+
+
+//==========================================================================
+//
+//  vwad_get_pubkey
+//
+//==========================================================================
+VWAD_PUBLIC vwad_result vwad_get_pubkey (vwad_handle *wad, vwad_public_key pubkey) {
+  if (wad && wad->haspubkey) {
+    if (pubkey) memcpy(pubkey, wad->pubkey, sizeof(vwad_public_key));
+    return VWAD_OK;
+  } else {
+    if (pubkey) memset(pubkey, 0, sizeof(vwad_public_key));
+    return VWAD_ERROR;
+  }
+}
+
+
+//==========================================================================
+//
+//  vwad_get_archive_file_count
+//
+//==========================================================================
+VWAD_PUBLIC vwad_fidx vwad_get_archive_file_count (vwad_handle *wad) {
+  return (wad ? (vwad_fidx)wad->fileCount : 0);
+}
+
+
+//==========================================================================
+//
+//  vwad_get_file_name
+//
+//==========================================================================
+VWAD_PUBLIC const char *vwad_get_file_name (vwad_handle *wad, vwad_fidx fidx) {
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount) {
+    return wad->names + wad->files[fidx].nameofs;
+  } else {
+    return NULL;
+  }
+}
+
+
+//==========================================================================
+//
+//  vwad_get_file_group_name
+//
+//==========================================================================
+VWAD_PUBLIC const char *vwad_get_file_group_name (vwad_handle *wad, vwad_fidx fidx) {
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount) {
+    return wad->names + wad->files[fidx].gnameofs;
+  } else {
+    return NULL;
+  }
+}
+
+
+//==========================================================================
+//
+//  vwad_get_file_size
+//
+//==========================================================================
+VWAD_PUBLIC int vwad_get_file_size (vwad_handle *wad, vwad_fidx fidx) {
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount) {
+    return wad->files[fidx].upksize;
+  } else {
+    return VWAD_ERROR;
+  }
+}
+
+
+//==========================================================================
+//
+//  find_file
+//
+//==========================================================================
+static vwad_fidx find_file (vwad_handle *wad, const char *name) {
+  if (name != NULL) {
+    for (;;) {
+      if (name[0] == '/') ++name;
+      else if (name[0] == '.' && name[1] == '/') name += 2;
+      else break;
+    }
+  }
+  if (wad && wad->fileCount > 0 && name != NULL && name[0]) {
+    const vwad_uint hash = hashStrCI(name);
+    const vwad_uint bkt = hash % HASH_BUCKETS;
+    vwad_uint fidx = wad->buckets[bkt];
+    while (fidx != VWAD_UNONE) {
+      if (wad->files[fidx].nameHash == hash &&
+          strEquCI(wad->names + wad->files[fidx].nameofs, name))
+      {
+        return (vwad_fidx)fidx;
+      }
+      fidx = wad->files[fidx].hcNext;
+    }
+  }
+  return VWAD_ERROR;
+}
+
+
+//==========================================================================
+//
+//  vwad_has_file
+//
+//==========================================================================
+VWAD_PUBLIC vwad_fidx vwad_find_file (vwad_handle *wad, const char *name) {
+  return find_file(wad, name);
+}
+
+
+//==========================================================================
+//
+//  vwad_get_ftime
+//
+//  returns 0 if there is an error, or the time is not set
+//
+//==========================================================================
+VWAD_PUBLIC vwad_ftime vwad_get_ftime (vwad_handle *wad, vwad_fidx fidx) {
+  vwad_uint64 res = 0;
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount) {
+    res = wad->files[fidx].ftime;
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwad_get_fcrc32
+//
+//  get crc32 for the whole file
+//
+//==========================================================================
+VWAD_PUBLIC vwad_uint vwad_get_fcrc32 (vwad_handle *wad, vwad_fidx fidx) {
+  vwad_uint res = 0;
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount) {
+    res = wad->files[fidx].crc32;
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwad_open_fidx
+//
+//  return file handle or -1
+//  note that maximum number of simultaneously opened files is 128
+//
+//==========================================================================
+VWAD_PUBLIC vwad_fd vwad_open_fidx (vwad_handle *wad, vwad_fidx fidx) {
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount) {
+    // find free fd
+    vwad_fd fd = 0;
+    while (fd < MAX_OPENED_FILES && wad->fds[fd].fidx != VWAD_NOFIDX) fd += 1;
+    if (fd != MAX_OPENED_FILES) {
+      // i found her!
+      OpenedFile *fl = &wad->fds[fd];
+      fl->fidx = fidx;
+      fl->fofs = 0;
+      fl->bidx = 0;
+      fl->cidx_abs = VWAD_BAD_CHUNK;
+      fl->cidx_rel = VWAD_BAD_CHUNK;
+      if (wad->fdsUsed < fd) wad->fdsUsed = fd;
+      if (vwad_debug_open_file) vwad_debug_open_file(wad, fidx, fd);
+      return fd;
+    } else {
+      return -2;
+    }
+  }
+  return VWAD_ERROR;
+}
+
+
+//==========================================================================
+//
+//  vwad_open_file
+//
+//  open file by name
+//
+//==========================================================================
+VWAD_PUBLIC vwad_fd vwad_open_file (vwad_handle *wad, const char *name) {
+  if (wad && name && name[0]) {
+    const vwad_fidx fidx = vwad_find_file(wad, name);
+    if (fidx >= 0) {
+      return vwad_open_fidx(wad, fidx);
+    }
+  }
+  return VWAD_ERROR;
+}
+
+
+//==========================================================================
+//
+//  vwad_fclose
+//
+//==========================================================================
+VWAD_PUBLIC void vwad_fclose (vwad_handle *wad, vwad_fd fd) {
+  if (wad && fd >= 0 && fd < MAX_OPENED_FILES) {
+    OpenedFile *fl = &wad->fds[fd];
+    if (fl->fidx != VWAD_NOFIDX) {
+      if (vwad_debug_close_file) vwad_debug_close_file(wad, fl->fidx, fd);
+      fl->fidx = VWAD_NOFIDX;
+      // in local cache mode, free the corresponding buffer
+      if (wad->globCacheSize == 0) {
+        xfree(wad->mman, wad->globCache[fd]);
+        wad->globCache[fd] = NULL;
+      }
+      // fix max fd
+      if (fd == wad->fdsUsed) {
+        while (fd >= 0 && wad->fds[fd].fidx == VWAD_NOFIDX) --fd;
+        wad->fdsUsed = fd + 1;
+      }
+    }
+  }
+}
+
+
+//==========================================================================
+//
+//  vwad_has_opened_files
+//
+//==========================================================================
+VWAD_PUBLIC vwad_bool vwad_has_opened_files (vwad_handle *wad) {
+  return (wad && wad->fdsUsed > 0);
+}
+
+
+//==========================================================================
+//
+//  vwad_find_chunk
+//
+//  `cc_rel` is the current relative chunk index (or `VWAD_BAD_CHUNK`)
+//  `cc_abs` is the corresponding absolute chunk index (or `VWAD_BAD_CHUNK`)
+//  `cidx` is the relative chunk we want to convert to absolute
+//
+//==========================================================================
+static CC25519_INLINE vwad_uint vwad_find_chunk (vwad_handle *wad, FileInfo *fi,
+                                                 OpenedFile *fo, vwad_uint cidx)
+{
+  if (!wad || !fi || cidx >= fi->chunkCount) return VWAD_BAD_CHUNK;
+  if (wad->fat) {
+    //logf(DEBUG, "FAT: first chunk is %u", fi->firstChunk);
+    // can we follow the chain?
+    vwad_uint cc_rel, cc_abs;
+    if (fo) {
+      cc_rel = fo->cidx_rel;
+      cc_abs = fo->cidx_abs;
+    } else {
+      cc_rel = VWAD_BAD_CHUNK;
+      cc_abs = VWAD_BAD_CHUNK;
+    }
+    if (cidx < cc_rel || cc_rel == VWAD_BAD_CHUNK || cc_abs == VWAD_BAD_CHUNK) {
+      // cannot follow
+      cc_abs = fi->firstChunk;
+      cc_rel = 0;
+      #if 0
+      if (fo) logf(DEBUG, "FAT: rewind to %u", cidx);
+      #endif
+    } else {
+      // can follow
+      #if 0
+      logf(DEBUG, "FAT: follow from %u to %u (%u steps)", cc_rel, cidx, cidx-cc_rel);
+      #endif
+      cidx -= cc_rel;
+    }
+    while (cidx != 0 && cc_abs != VWAD_BAD_CHUNK) {
+      cc_abs = wad->fat[cc_abs];
+      cidx -= 1;
+      cc_rel += 1;
+    }
+    if (fo) {
+      fo->cidx_rel = cc_rel;
+      fo->cidx_abs = cc_abs;
+    }
+    return cc_abs;
+  } else {
+    return fi->firstChunk + cidx;
+  }
+}
+
+
+//==========================================================================
+//
+//  read_chunk
+//
+//  `cidx` is absolute chunk number
+//
+//==========================================================================
+static vwad_result read_chunk (vwad_handle *wad, OpenedFile *fl, FileBuffer *buf,
+                               vwad_uint cidx)
+{
+  vassert(wad);
+  vassert(cidx < wad->chunkCount);
+
+  const vwad_uint nonce = 4 + cidx;
+  const ChunkInfo *ci = &wad->chunks[cidx];
+  const vwad_uint cupsize = ci->upksize + 1;
+
+  // seek to chunk
+  if (wad->strm->seek(wad->strm, (int)ci->ofs) != VWAD_OK) {
+    logf(ERROR, "read_chunk: cannot seek to chunk %u", cidx);
+    return VWAD_ERROR;
+  }
+
+  // read data
+  if (ci->pksize == 0) {
+    // unpacked
+    if (wad->strm->read(wad->strm, &wad->pkdata[0], cupsize + 4) != VWAD_OK) {
+      buf->size = 0;
+      logf(ERROR, "read_chunk: cannot read unpacked chunk %u", cidx);
+      return VWAD_ERROR;
+    }
+    crypt_buffer(wad->xorRndSeed, nonce, &wad->pkdata[0], cupsize + 4);
+    memcpy(buf->data, &wad->pkdata[4], cupsize);
+  } else {
+    // packed
+    if (wad->strm->read(wad->strm, &wad->pkdata[0], ci->pksize + 4) != VWAD_OK) {
+      buf->size = 0;
+      logf(ERROR, "read_chunk: cannot read packed chunk %u", cidx);
+      return VWAD_ERROR;
+    }
+    crypt_buffer(wad->xorRndSeed, nonce, &wad->pkdata[0], ci->pksize + 4);
+    if (!DecompressLZFF3(&wad->pkdata[4], ci->pksize, buf->data, cupsize)) {
+      buf->size = 0;
+      logf(ERROR, "read_chunk: cannot unpack chunk %u (%u -> %u)", cidx,
+                  ci->pksize, cupsize);
+      return VWAD_ERROR;
+    }
+  }
+
+  // check crc
+  if ((wad->flags & VWAD_OPEN_NO_CRC_CHECKS) == 0) {
+    if (crc32_buf(buf->data, cupsize) != get_u32(&wad->pkdata[0])) {
+      buf->size = 0;
+      logf(ERROR, "read_chunk: corrupted chunk %u data (crc32)", cidx);
+      return VWAD_ERROR;
+    }
+  }
+
+  buf->cidx_abs = cidx;
+  buf->size = cupsize;
+
+  return VWAD_OK;
+}
+
+
+//==========================================================================
+//
+//  ensure_buffer
+//
+//==========================================================================
+static FileBuffer *ensure_buffer (vwad_handle *wad, vwad_fd fd, OpenedFile *fl, vwad_uint ofs) {
+  vassert(wad != NULL);
+  vassert(fd >= 0 && fd < MAX_OPENED_FILES);
+
+  vassert(fl->fidx != VWAD_NOFIDX);
+
+  FileInfo *fi = &wad->files[fl->fidx];
+  if (ofs >= fi->upksize) return NULL;
+
+  const vwad_uint cidx = vwad_find_chunk(wad, fi, fl, ofs / 65536u);
+  vassert(fl->bidx < MAX_GLOB_BUFFERS);
+  // fix current
+
+  FileBuffer *res = wad->globCache[fl->bidx];
+
+  // is buffer valid?
+  if (!res || res->cidx_abs != cidx || res->size == 0) {
+    // no, check if we already have the chunk buffered
+    const vwad_uint gbcSize = wad->globCacheSize;
+    vwad_uint bidx;
+    FileBuffer *gb;
+    vwad_uint ggevict = VWAD_UNONE;
+    vwad_uint goodera = 0xffffffffU;
+    vwad_bool gfound = 0;
+    vwad_bool ggevict_empty = 0;
+
+    // for local cache, `gbcSize` is 0, so it is ok
+    for (bidx = 0; !gfound && bidx < gbcSize; ++bidx) {
+      gb = wad->globCache[bidx];
+      if (gb != NULL && gb->size != 0 && gb->cidx_abs == cidx) {
+        // i found her!
+        fl->bidx = bidx;
+        gfound = 1;
+      } else if (gb == NULL || gb->size == 0) {
+        // empty global buffer
+        if (!ggevict_empty) { ggevict = bidx; ggevict_empty = 1; }
+      } else if (!ggevict_empty && gb != NULL && gb->era < goodera) {
+        // non-empty global buffer, good for eviction
+        ggevict = bidx; goodera = gb->era;
+      }
+    }
+
+    if (gfound == 0) {
+      if (gbcSize == 0) {
+        // local cache
+        vassert(ggevict == VWAD_UNONE);
+        ggevict = (vwad_uint)fd;
+      } else {
+        // global cache
+        vassert(ggevict != VWAD_UNONE);
+      }
+      gb = wad->globCache[ggevict];
+      if (vwad_debug_flush_chunk && gb && gb->size != 0) {
+        vwad_debug_flush_chunk(wad, (int)ggevict, fl->fidx, fd, (int)gb->cidx_abs);
+      }
+      if (gb == NULL) {
+        // new buffer
+        gb = xalloc(wad->mman, (vwad_uint)sizeof(FileBuffer));
+        if (gb == NULL) {
+          logf(ERROR, "ensure_buffer: cannot allocate memory for chunk cache");
+          return NULL;
+        }
+        gb->cidx_abs = 0;
+        gb->size = 0;
+        gb->era = 0;
+        wad->globCache[ggevict] = gb;
+      }
+      if (vwad_debug_read_chunk) {
+        vwad_debug_read_chunk(wad, (int)ggevict, fl->fidx, fd, (int)cidx);
+      }
+      // we need to read the chunk
+      if (read_chunk(wad, fl, gb, cidx) != VWAD_OK) {
+        return NULL;
+      }
+      fl->bidx = ggevict;
+    }
+  }
+
+  // i found her!
+  res = wad->globCache[fl->bidx];
+  vassert(res != NULL);
+  vassert(res->cidx_abs == cidx);
+  vassert(res->size == wad->chunks[cidx].upksize + 1);
+
+  // fix buffer era
+  if (res->era != wad->lastera) {
+    if (wad->lastera == 0xffffffffU) {
+      wad->lastera = 1;
+      for (vwad_uint f = 0; f < wad->globCacheSize; ++f) {
+        if (wad->globCache[f] != NULL) wad->globCache[f]->era = 0;
+      }
+    }
+    res->era = wad->lastera;
+    ++wad->lastera;
+  }
+
+  // done
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwad_read
+//
+//  return number of read bytes, or -1 on error
+//
+//==========================================================================
+VWAD_PUBLIC int vwad_read (vwad_handle *wad, vwad_fd fd, void *dest, int len) {
+  int read = -1;
+  if (wad && len >= 0 && fd >= 0 && fd < MAX_OPENED_FILES) {
+    OpenedFile *fl = &wad->fds[fd];
+    if (fl->fidx != VWAD_NOFIDX) {
+      vassert(len == 0 || dest != NULL);
+      FileInfo *fi = &wad->files[fl->fidx];
+      read = 0;
+      while (len != 0 && fl->fofs < fi->upksize) {
+        const FileBuffer *fbuf = ensure_buffer(wad, fd, fl, fl->fofs);
+        if (!fbuf) {
+          // oops
+          read = -1;
+          len = 0;
+        } else {
+          const vwad_uint left = fi->upksize - fl->fofs;
+          vwad_uint rd = (vwad_uint)len;
+          if (rd > left) rd = left;
+          vassert(fbuf->size > 0 && fbuf->size <= 65536);
+          const vwad_uint bufskip = fl->fofs % 65536u;
+          if (bufskip > fbuf->size) {
+            read = -1;
+            len = 0;
+          } else {
+            const vwad_uint bufleft = fbuf->size - bufskip;
+            vassert(bufleft > 0);
+            if (rd > bufleft) rd = bufleft;
+            #if 0
+            fprintf(stderr, "READ: ofs=0x%08x; len=%d; rd=%u; bufleft=%u; bufskip=%u\n",
+                    fl->fofs, len, rd, bufleft, bufskip);
+            #endif
+            vassert(rd > 0 && rd <= (vwad_uint)len);
+            memcpy(dest, fbuf->data + bufskip, rd);
+            len -= (int)rd;
+            fl->fofs += rd;
+            read += (int)rd;
+            dest = (void *)((vwad_ubyte *)dest + rd);
+          }
+        }
+      }
+    }
+  }
+  return read;
+}
+
+
+//==========================================================================
+//
+//  vwad_fdfidx
+//
+//==========================================================================
+VWAD_PUBLIC vwad_fidx vwad_fdfidx (vwad_handle *wad, vwad_fd fd) {
+  if (wad && fd >= 0 && fd < MAX_OPENED_FILES) {
+    OpenedFile *fl = &wad->fds[fd];
+    if (fl->fidx != VWAD_NOFIDX) return (vwad_fidx)fl->fidx;
+  }
+  return VWAD_ERROR;
+}
+
+
+//==========================================================================
+//
+//  vwad_seek
+//
+//  return 0 on success
+//
+//==========================================================================
+VWAD_PUBLIC vwad_result vwad_seek (vwad_handle *wad, vwad_fd fd, int pos) {
+  int res = -1;
+  if (wad && pos >= 0 && fd >= 0 && fd < MAX_OPENED_FILES) {
+    OpenedFile *fl = &wad->fds[fd];
+    if (fl->fidx != VWAD_NOFIDX) {
+      if ((vwad_uint)pos <= wad->files[fl->fidx].upksize) {
+        fl->fofs = (vwad_uint)pos;
+        res = 0;
+      } else {
+        res = -3;
+      }
+    } else {
+      res = -4;
+    }
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwad_tell
+//
+//==========================================================================
+VWAD_PUBLIC int vwad_tell (vwad_handle *wad, vwad_fd fd) {
+  if (wad && fd >= 0 && fd < MAX_OPENED_FILES) {
+    OpenedFile *fl = &wad->fds[fd];
+    if (fl->fidx != VWAD_NOFIDX) return (int)fl->fofs;
+  }
+  return VWAD_ERROR;
+}
+
+
+//==========================================================================
+//
+//  vwad_get_file_chunk_count
+//
+//  this is used in creator, to copy raw chunks
+//
+//==========================================================================
+VWAD_PUBLIC int vwad_get_file_chunk_count (vwad_handle *wad, vwad_fidx fidx) {
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount) {
+    return (int)wad->files[fidx].chunkCount;
+  }
+  return VWAD_ERROR;
+}
+
+
+//==========================================================================
+//
+//  vwad_get_raw_file_chunk_info
+//
+//  this is used in creator, to copy raw chunks
+//
+//==========================================================================
+VWAD_PUBLIC vwad_result vwad_get_raw_file_chunk_info (vwad_handle *wad, vwad_fidx fidx,
+                                                      int chunkidx,
+                                                      int *pksz, int *upksz, vwad_bool *packed)
+{
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount &&
+      chunkidx >= 0 && chunkidx < (int)wad->files[fidx].chunkCount)
+  {
+    const vwad_uint cc = vwad_find_chunk(wad, &wad->files[fidx], NULL, (vwad_uint)chunkidx);
+    if (cc != VWAD_BAD_CHUNK) {
+      const ChunkInfo *ci = &wad->chunks[cc];
+      if (upksz != NULL) *upksz = (int)ci->upksize + 1;
+      // packed size is with CRC32
+      if (pksz != NULL) *pksz = (int)(ci->pksize == 0 ? (int)ci->upksize + 1 : (int)ci->pksize) + 4;
+      if (packed != NULL) *packed = (ci->pksize != 0);
+      return VWAD_OK;
+    }
+  }
+  return VWAD_ERROR;
+}
+
+
+//==========================================================================
+//
+//  vwad_read_raw_file_chunk
+//
+//  this is used in creator, to copy raw chunks
+//
+//==========================================================================
+VWAD_PUBLIC vwad_result vwad_read_raw_file_chunk (vwad_handle *wad, vwad_fidx fidx, int chunkidx,
+                                                  void *buf)
+{
+  if (wad && fidx >= 0 && fidx < (vwad_fidx)wad->fileCount &&
+      chunkidx >= 0 && chunkidx < (int)wad->files[fidx].chunkCount && buf != NULL)
+  {
+    FileInfo *fi = &wad->files[fidx];
+    const vwad_uint cc = vwad_find_chunk(wad, fi, NULL, (vwad_uint)chunkidx);
+    if (cc != VWAD_BAD_CHUNK) {
+      const ChunkInfo *ci = &wad->chunks[cc];
+      const vwad_uint csize = (ci->pksize == 0 ? ci->upksize + 1u : ci->pksize) + 4u; /* with CRC32 */
+      if (wad->strm->seek(wad->strm, (int)ci->ofs) != VWAD_OK) return VWAD_ERROR;
+      if (wad->strm->read(wad->strm, buf, (int)csize) != VWAD_OK) return VWAD_ERROR;
+      // decrypt chunk
+      const vwad_uint nonce = 4 + cc;
+      crypt_buffer(wad->xorRndSeed, nonce, buf, csize);
+      return VWAD_OK;
+    }
+  }
+  return VWAD_ERROR;
+}
+
+
+//==========================================================================
+//
+//  vwad_wildmatch
+//
+//  returns:
+//    -1: malformed pattern
+//     0: equal
+//     1: not equal
+//
+//==========================================================================
+VWAD_PUBLIC vwad_result vwad_wildmatch (const char *pat, vwad_uint plen,
+                                        const char *str, vwad_uint slen)
+{
+  #define GETSCH(dst_)  do { \
+    const char *stmp = &str[spos]; \
+    const vwad_uint uclen = utf_char_len(stmp); \
+    if (error || uclen == 0 || uclen > 3 || slen - spos < uclen) { error = 1; (dst_) = VWAD_REPLACEMENT_CHAR; } \
+    else { \
+      (dst_) = unilower(utf_decode(&stmp)); \
+      if ((dst_) < 32 || (dst_) == VWAD_REPLACEMENT_CHAR) error = 1; \
+      spos += uclen; \
+    } \
+  } while (0)
+
+  #define GETPCH(dst_)  do { \
+    const char *stmp = &pat[patpos]; \
+    const vwad_uint uclen = utf_char_len(stmp); \
+    if (error || uclen == 0 || uclen > 3 || plen - patpos < uclen) { error = 1; (dst_) = VWAD_REPLACEMENT_CHAR; } \
+    else { \
+      (dst_) = unilower(utf_decode(&stmp)); \
+      if ((dst_) < 32 || (dst_) == VWAD_REPLACEMENT_CHAR) error = 1; \
+      else patpos += uclen; \
+    } \
+  } while (0)
+
+  vwad_ushort sch, c0, c1;
+  vwad_bool hasMatch, inverted;
+  vwad_bool star = 0, dostar = 0;
+  vwad_uint patpos = 0, spos = 0;
+  int error = 0;
+
+  while (!error && !dostar && spos < slen) {
+    if (patpos == plen) {
+      dostar = 1;
+    } else {
+      GETSCH(sch); GETPCH(c0);
+      if (!error) {
+        switch (c0) {
+          case '\\':
+            GETPCH(c0);
+            dostar = (sch != c0);
+            break;
+          case '?': // match anything except '.'
+            dostar = (sch == '.');
+            break;
+          case '*':
+            star = 1;
+            --spos; // otherwise "*abc" will not match "abc"
+            slen -= spos; str += spos;
+            plen -= patpos; pat += patpos;
+            while (plen != 0 && *pat == '*') { --plen; ++pat; }
+            // restart the loop
+            spos = 0; patpos = 0;
+            break;
+          case '[':
+            hasMatch = 0;
+            inverted = 0;
+            if (patpos == plen) error = 1; // malformed pattern
+            else if (pat[patpos] == '^') {
+              inverted = 1;
+              ++patpos;
+              error = (patpos == plen); // malformed pattern?
+            }
+            if (!error) {
+              do {
+                GETPCH(c0);
+                if (!error && patpos != plen && pat[patpos] == '-') {
+                  // char range
+                  ++patpos; // skip '-'
+                  GETPCH(c1);
+                } else {
+                  c1 = c0;
+                }
+                // casts are UB, hence the stupid macro
+                hasMatch = hasMatch || (sch >= c0 && sch <= c1);
+              } while (!error && patpos != plen && pat[patpos] != ']');
+            }
+            error = error || (patpos == plen) || (pat[patpos] != ']'); // malformed pattern?
+            dostar = !error && (hasMatch != inverted);
+            break;
+          default:
+            dostar = (sch != c0);
+            break;
+        }
+      }
+    }
+    // star check
+    if (dostar && !error) {
+      // `error` is always zero here
+      if (!star) {
+        // not equal, do not reset "dostar"
+        spos = slen;
+      } else {
+        dostar = 0;
+        if (plen == 0) {
+          // equal
+          spos = slen;
+        } else {
+          --slen; ++str; // slen is never zero here
+          spos = 0; patpos = 0;
+        }
+      }
+    }
+  }
+
+  int res;
+  if (error) res = -1; // malformed pattern
+  else if (dostar) res = 1; // not equal
+  else {
+    plen -= patpos; pat += patpos;
+    while (plen != 0 && *pat == '*') { --plen; ++pat; }
+    if (plen == 0) res = 0; else res = 1;
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwad_wildmatch_path
+//
+//  this matches individual path parts
+//  exception: if `pat` contains no slashes, match only the name
+//
+//==========================================================================
+#ifdef VWAD_DEBUG_WILDPATH
+#include <stdio.h>
+#endif
+VWAD_PUBLIC vwad_result vwad_wildmatch_path (const char *pat, vwad_uint plen,
+                                             const char *str, vwad_uint slen)
+{
+  vwad_uint ppos, spos;
+  vwad_bool pat_has_slash = 0;
+  vwad_result res;
+
+  while (plen && pat[0] == '/') { pat_has_slash = 1; --plen; ++pat; }
+  // look for slashes
+  if (!pat_has_slash) {
+    ppos = 0; while (ppos < plen && pat[ppos] != '/') ++ppos;
+    pat_has_slash = (ppos < plen);
+  }
+
+  // if no slashes in pattern, match only filename
+  if (!pat_has_slash) {
+    spos = slen; while (spos != 0 && str[spos - 1] != '/') --spos;
+    slen -= spos; str += spos;
+    res = vwad_wildmatch(pat, plen, str, slen);
+  } else {
+    // match by path parts
+    #ifdef VWAD_DEBUG_WILDPATH
+    fprintf(stderr, "=== pat:<%.*s>; str:<%.*s> ===\n",
+            (vwad_uint)plen, pat, (vwad_uint)slen, str);
+    #endif
+    while (slen && str[0] == '/') { --slen; ++str; }
+    res = 0;
+    while (res == 0 && plen != 0 && slen != 0) {
+      // find slash in pat and in str
+      ppos = 0; while (ppos != plen && pat[ppos] != '/') ++ppos;
+      spos = 0; while (spos != slen && str[spos] != '/') ++spos;
+      #ifdef VWAD_DEBUG_WILDPATH
+      fprintf(stderr, "  MT: ppos=%u; spos=%u; pat=<%.*s>; str=<%.*s> (ex: %d)\n",
+              (vwad_uint)ppos, (vwad_uint)spos,
+              (vwad_uint)ppos, pat, (vwad_uint)spos, str,
+              ((ppos == plen) != (spos == slen)));
+      #endif
+      if ((ppos == plen) != (spos == slen)) {
+        res = 1;
+      } else {
+        res = vwad_wildmatch(pat, ppos, str, spos);
+        plen -= ppos; pat += ppos;
+        slen -= spos; str += spos;
+        while (plen && pat[0] == '/') { --plen; ++pat; }
+        while (slen && str[0] == '/') { --slen; ++str; }
+      }
+    }
+    #ifdef VWAD_DEBUG_WILDPATH
+    fprintf(stderr, " res: %d\n", res);
+    #endif
+  }
+
+  return res;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#if defined(__cplusplus)
+}
+#endif

--- a/thirdparty/libvwad/vwadvfs.h
+++ b/thirdparty/libvwad/vwadvfs.h
@@ -1,0 +1,397 @@
+/* coded by Ketmar // Invisible Vector (psyc://ketmar.no-ip.org/~Ketmar)
+ * Understanding is not required. Only obedience.
+ *
+ * This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar.
+ * See http://www.wtfpl.net/ for more details.
+ */
+/*
+  VWADs are chunked archives with zlib-comparable compression ratio.
+  usually VWAD size on max copression level is little lesser than
+  the corresponding ZIP file. the most useful feature of VWAD is the
+  ability to read files non-sequentially without unpacking the whole
+  file first. i.e. seeking in archive files is quite cheap, and can
+  be used freely.
+
+  any archive can be signed with Ed25519 digital signature. please,
+  note that you have to provide good cryptographically strong PRNG
+  by yourself (actually, you should use it to generate a private key,
+  the library itself doesn't have any PRNG generator).
+
+  note that while archive chunks are "encrypted", this "encryption"
+  is not cryptographically strong, and used mostly to hide non-compressed
+  data from simple viewing tools.
+
+  archived files can be annotated with arbitrary "group name". this can
+  be used in various content creation tools. group tags are not used
+  by the library itself. group names are case-insensitive.
+
+  also, archived files can have a 64-bit last modification timestamp
+  (seconds since Unix Epoch). you can use zero as timestamp if you
+  don't care.
+
+  file names can containprintable unicode chars from the first plane
+  (see `vwad_is_uni_printable()`), and names are case-insensitive.
+  all names should be utf-8 encoded. also note that whice case folding
+  is unicode-aware, not all codepoints are implemented. latin-1 and
+  basic cyrillic should be safe, though.
+  path delimiter is "/" (and only "/").
+  file names may not contain chars [1..31], and char 127.
+
+  archive can be tagged with author name, short description, and a comment.
+  author name and description can contain unicode chars, but cannot have
+  control chars (with codes < 31).
+  comments can be multiline (only '\x0a' is allowed as a newline char).
+  tabs are allowed too.
+
+  currently, only limited subset of the first unicode plane is supported.
+  deal with it.
+
+  WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
+  the reader is not thread-safe. i.e. you cannot use opened handle to
+  read different files in different threads without locking. but different
+  handles for different threads are allowed.
+  WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
+*/
+#ifndef VWADVFS_HEADER
+#define VWADVFS_HEADER
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// this should be 8 bit (i hope so)
+typedef unsigned char vwad_ubyte;
+// this should be 16 bit (i hope so)
+typedef unsigned short vwad_ushort;
+// this should be 32 bit (i hope so)
+typedef unsigned int vwad_uint;
+// this should be 64 bit (i hope so)
+typedef unsigned long long vwad_uint64;
+
+// size checks
+typedef char vwad_temp_typedef_check_char[(sizeof(char) == 1) ? 1 : -1];
+typedef char vwad_temp_typedef_check_char[(sizeof(int) == 4) ? 1 : -1];
+typedef char vwad_temp_typedef_check_ubyte[(sizeof(vwad_ubyte) == 1) ? 1 : -1];
+typedef char vwad_temp_typedef_check_ushort[(sizeof(vwad_ushort) == 2) ? 1 : -1];
+typedef char vwad_temp_typedef_check_uint[(sizeof(vwad_uint) == 4) ? 1 : -1];
+typedef char vwad_temp_typedef_check_uint64[(sizeof(vwad_uint64) == 8) ? 1 : -1];
+
+// this should be 64 bit (i hope so)
+typedef vwad_uint64 vwad_ftime;
+
+
+// for self-documentation purposes
+typedef int vwad_bool;
+
+// file index; <0 means "no file"
+typedef int vwad_fidx;
+
+// file descriptor; negative means "invalid", zero or positive is ok
+typedef int vwad_fd;
+
+// for self-documentation purposes
+// 0 is success, negative value is error
+typedef int vwad_result;
+
+// for `vwad_result`
+#define VWAD_OK  (0)
+
+// opaque handle
+typedef struct vwad_handle_t vwad_handle;
+
+// i/o stream
+typedef struct vwad_iostream_t vwad_iostream;
+struct vwad_iostream_t {
+  // return non-zero on failure; failure can be delayed
+  // will never be called with negative `pos`
+  vwad_result (*seek) (vwad_iostream *strm, int pos);
+  // read *exactly* bufsize bytes; return 0 on success, negative on failure
+  // will never be called with zero or negative `bufsize`
+  vwad_result (*read) (vwad_iostream *strm, void *buf, int bufsize);
+  // user data
+  void *udata;
+};
+
+// memory allocation
+typedef struct vwad_memman_t vwad_memman;
+struct vwad_memman_t {
+  // will never be called with zero `size`
+  // return NULL on OOM
+  void *(*alloc) (vwad_memman *mman, vwad_uint size);
+  // will never be called with NULL `p`
+  void (*free) (vwad_memman *mman, void *p);
+  // user data
+  void *udata;
+};
+
+// Ed25519 public key, 32 bytes
+typedef vwad_ubyte vwad_public_key[32];
+
+// 40 bytes of key, 5 bytes of crc32, plus zero
+typedef char vwad_z85_key[46];
+
+
+enum {
+  VWAD_LOG_NOTE,
+  VWAD_LOG_WARNING,
+  VWAD_LOG_ERROR,
+  VWAD_LOG_DEBUG,
+};
+
+// logging; can be NULL
+// `type` is the above enum
+extern void (*vwad_logf) (int type, const char *fmt, ...);
+
+// assertion; can be NULL, then the lib will simply traps
+extern void (*vwad_assertion_failed) (const char *fmt, ...);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// can be used to debug the library. you don't need this.
+extern void (*vwad_debug_open_file) (vwad_handle *wad, vwad_fidx fidx, vwad_fd fd);
+extern void (*vwad_debug_close_file) (vwad_handle *wad, vwad_fidx fidx, vwad_fd fd);
+extern void (*vwad_debug_read_chunk) (vwad_handle *wad, int bidx, vwad_fidx fidx, vwad_fd fd, int chunkidx);
+extern void (*vwad_debug_flush_chunk) (vwad_handle *wad, int bidx, vwad_fidx fidx, vwad_fd fd, int chunkidx);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// you can encode keys in printable ASCII chars, and decode them back.
+// encoded key contains a checksum, so mistyped keys could be detected.
+void vwad_z85_encode_key (const vwad_public_key inkey, vwad_z85_key enkey);
+vwad_result vwad_z85_decode_key (const vwad_z85_key enkey, vwad_public_key outkey);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// flags for `vwad_open_archive()`, to be bitwise ORed
+#define VWAD_OPEN_DEFAULT          (0u)
+// if you are not interested in archive comment, use this flag.
+// it will save some memory.
+#define VWAD_OPEN_NO_MAIN_COMMENT  (0x2000u)
+// this flag can be used to omit digital signature checks.
+// signature checks are fast, so you should use this flag
+// only if you have a partially corrupted file which you
+// want to read anyway.
+// note that ed25519 public key will be read and accessible
+// even with disabled checks, but you should not use it to
+// determine the authorship, for example.
+#define VWAD_OPEN_NO_SIGN_CHECK    (0x4000u)
+// WARNING! DO NOT USE THIS!
+// this can be used to recover files with partially corrupted data,
+// but DON'T pass it "for speed", CRC checks are fast, and you
+// should not omit them.
+#define VWAD_OPEN_NO_CRC_CHECKS    (0x8000u)
+
+// on success, will copy stream pointer and memman pointer
+// (i.e. they should be alive until `vwad_close_archive()`).
+// if `mman` is `NULL`, use libc memory manager.
+// default cache settings is 256KB (4 buffers).
+vwad_handle *vwad_open_archive (vwad_iostream *strm, vwad_uint flags, vwad_memman *mman);
+
+// will free handle memory, and clean handle pointer.
+void vwad_close_archive (vwad_handle **wadp);
+
+// setup global chunk cache for the archive, in chunks. each chunk is ~64KB.
+// by default, there is 4-chunk cache.
+// this can speedup Doom WAD reading, for example, when the caller is
+// often open/close the same files.
+// this is an advice, not a demand.
+// <=0 means "disable global cache" (each opened file will use one local buffer).
+// (this mode is not heavily tested, and may be removed in the future.)
+// notice: "global" here means that all files opened in this archive
+//         share the cache. different archives has different caches, though.
+void vwad_set_archive_cache (vwad_handle *wad, int bufferCount);
+
+
+// this includes the trailing 0 byte. i.e. allocating a buffer
+// of this size should be enough to get any comment untruncated.
+#define VWAD_MAX_COMMENT_SIZE  (65536)
+
+// get size of the comment, without the trailing zero byte.
+// returns 0 on error, or on empty comment.
+vwad_uint vwad_get_archive_comment_size (vwad_handle *wad);
+
+// can return empty string if there is no comment,
+// or `VWAD_OPEN_NO_MAIN_COMMENT` passed,
+// or if `vwad_free_archive_comment()` was called.
+// WARNING! `dest` must be at least `vwad_get_archive_comment_size()` + 1 bytes!
+//          this is because the comment is terminated with zero byte.
+// will truncate comment if destination buffer is not big enough (with zero byte).
+// `destsize` if the full buffer size in bytes. returned data is 0-terminated, i.e.
+// it is a valid C string (except when `destsize` is 0).
+void vwad_get_archive_comment (vwad_handle *wad, char *dest, vwad_uint destsize);
+
+// forget main archive comment and free its memory.
+// you will not be able to get archive comment after calling this.
+void vwad_free_archive_comment (vwad_handle *wad);
+
+// never returns NULL
+const char *vwad_get_archive_author (vwad_handle *wad);
+// never returns NULL
+const char *vwad_get_archive_title (vwad_handle *wad);
+
+// check if the given archive has any files opened with `vwad_fopen()`.
+vwad_bool vwad_has_opened_files (vwad_handle *wad);
+
+// check if opened wad is authenticated. if the library was
+// built without ed25519 support, or the wad was opened with
+// "omit signature check" flag, there could be a public key,
+// but the wad will not be authenticated with that key.
+vwad_bool vwad_is_authenticated (vwad_handle *wad);
+// check if the wad has a ed25519 public key. it doesn't matter
+// if the wad was authenticated or not, the key is always avaliable
+// (if the wad contains it, of course).
+// i.e. you can turn off auth check, and use this function to
+// detect if there is a digital signature without actually checking it.
+vwad_bool vwad_has_pubkey (vwad_handle *wad);
+// on failure, `pubkey` content is zeroed.
+// if there is no digital signature, there is no pubkey.
+// it doesn't matter if the archive was authenticated or not.
+vwad_result vwad_get_pubkey (vwad_handle *wad, vwad_public_key pubkey);
+
+// returns maximum fidx in this wad.
+// avaliable files are [0..res).
+// on error, returns 0.
+vwad_fidx vwad_get_archive_file_count (vwad_handle *wad);
+
+// returns NULL on invalid `fidx`; group name can be empty string.
+// WARNING! while currenly VWAD creation tools will use the same
+//          name (pointer) for the same group name, this is not
+//          enforced, and you should not rely on it. always compare
+//          string contents instead.
+const char *vwad_get_file_group_name (vwad_handle *wad, vwad_fidx fidx);
+
+// first index is 0, last is `vwad_get_file_count() - 1`.
+// returns NULL on invalid `fidx`
+const char *vwad_get_file_name (vwad_handle *wad, vwad_fidx fidx);
+// returns negative number on error.
+int vwad_get_file_size (vwad_handle *wad, vwad_fidx fidx);
+// returns 0 if there is an error, or the time is not set
+// returned time is in UTC, seconds since Epoch (or 0 if unknown)
+vwad_ftime vwad_get_ftime (vwad_handle *wad, vwad_fidx fidx);
+// get crc32 for the whole file
+vwad_uint vwad_get_fcrc32 (vwad_handle *wad, vwad_fidx fidx);
+
+// normalize file name: remove "/./", resolve "/../", remove
+// double slashes, etc. it should be safe to pass the result
+// to `vwad_find_file()`. if the result is longer than 255
+// chars, returns error, and `res` contents are undefined.
+// also, converts backslashes to proper forward slashes.
+// please note that last slash will NOT be removed, but
+// such file name is invalid.
+// starting "/" will be retained, though.
+vwad_result vwad_normalize_file_name (const char *fname, char res[256]);
+
+// find file by name. internally, the library is using a hash
+// table, so this is quite fast.
+// searching is case-insensitive for ASCII chars.
+// use slashes ("/") to separate directories. do not start
+// `name` with a slash, use strictly one slash to separate
+// path parts. "." and ".." pseudodirs are not supported.
+// returns negative number if no file found.
+vwad_fidx vwad_find_file (vwad_handle *wad, const char *name);
+
+// open file for reading using its index
+// (obtained from `vwad_find_file()`, for example).
+// return file handle or negative value on error.
+// (note that 0 is a valid file handle!)
+// note that maximum number of simultaneously opened files is 128.
+vwad_fd vwad_open_fidx (vwad_handle *wad, vwad_fidx fidx);
+
+// open file by name.
+vwad_fd vwad_open_file (vwad_handle *wad, const char *name);
+
+// close opened file. calling with invalid fd is ok.
+// calling with closed fd may close the file opened elsewhere
+// (because fds are reused).
+void vwad_fclose (vwad_handle *wad, vwad_fd fd);
+
+// return negative number if fd is invalid.
+vwad_fidx vwad_fdfidx (vwad_handle *wad, vwad_fd fd);
+
+// change current reading position.
+vwad_result vwad_seek (vwad_handle *wad, vwad_fd fd, int pos);
+
+// return current reading position, or negative number on error.
+int vwad_tell (vwad_handle *wad, vwad_fd fd);
+
+// return number of read bytes, or negative on error.
+// trying to read 0 bytes will return 0 (after performing validity checks).
+// still, trying to read 0 bytes may succeed even if some arguments
+// are invalid, so don't use this as cheap check for "is this fd valid".
+// if you want to know if fd is valid, use `vwad_fdfidx()`, it is faster anyway.
+int vwad_read (vwad_handle *wad, vwad_fd fd, void *buf, int len);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// reading raw chunks can be used in archive creator to copy data
+// without recompressing it.
+
+#define VWAD_MAX_RAW_CHUNK_SIZE  (65536 + 4)
+
+// this is used in creator, to copy raw chunks
+// returns -1 on error
+int vwad_get_file_chunk_count (vwad_handle *wad, vwad_fidx fidx);
+// this is used in creator, to copy raw chunks
+// 4 bytes of CRC32 are INCLUDED in `pksz` (but not in `upksz`)!
+// `pksz` is never zero; to check if the chunk is packed, use `packed`
+vwad_result vwad_get_raw_file_chunk_info (vwad_handle *wad, vwad_fidx fidx, int chunkidx,
+                                          int *pksz, int *upksz, vwad_bool *packed);
+// this is used in creator, to copy raw chunks
+// reads chunk WITH CRC32!
+vwad_result vwad_read_raw_file_chunk (vwad_handle *wad, vwad_fidx fidx, int chunkidx, void *buf);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// your bog stadard CRC32 calculator. uses the same poly as zlib.
+
+vwad_uint vwad_crc32_init (void);
+vwad_uint vwad_crc32_part (vwad_uint crc32, const void *src, vwad_uint len);
+vwad_uint vwad_crc32_final (vwad_uint crc32);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// utf-8 case insensitive string equality check.
+vwad_bool vwad_str_equ_ci (const char *s0, const char *s1);
+
+// case-insensitive utf-8 wildcard matching
+// returns:
+//   -1: malformed pattern
+//    0: equal
+//    1: not equal
+vwad_result vwad_wildmatch (const char *pat, vwad_uint plen, const char *str, vwad_uint slen);
+
+// this matches individual path parts.
+// exception: if `pat` contains no slashes, match only the name.
+// if `pat` is like "/mask", match only root dir files.
+// masks like "/*/*/" will match anything 2 subdirs or deeper.
+// masks like "/*/*" will match exactly the one subdir.
+vwad_result vwad_wildmatch_path (const char *pat, vwad_uint plen, const char *str, vwad_uint slen);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// WARNING! the following API works only with unicode plane 1 -- [0..65535]!
+
+// "invalid char" unicode code
+#define VWAD_REPLACEMENT_CHAR  (0x0FFFDu)
+
+vwad_uint vwad_utf_char_len (const void *str);
+// advances `strp` at least by one byte.
+// returns `VWAD_REPLACEMENT_CHAR` on invalid char.
+// invalid chars are thouse with invalid utf-8, 0x7f, and unprintable.
+// printable chars are determined with `vwad_is_uni_printable()`.
+vwad_ushort vwad_utf_decode (const char **strp);
+
+// control chars are not printable, except tab (0x09), and newline (0x0a).
+// del (0x7f) is not printable too.
+vwad_bool vwad_is_uni_printable (vwad_ushort ch);
+// supports only limited set of known chars (mostly latin and slavic).
+vwad_ushort vwad_uni_tolower (vwad_ushort ch);
+
+
+#if defined(__cplusplus)
+}
+#endif
+#endif

--- a/thirdparty/libvwad/vwadwrite.c
+++ b/thirdparty/libvwad/vwadwrite.c
@@ -1,0 +1,4213 @@
+/* coded by Ketmar // Invisible Vector (psyc://ketmar.no-ip.org/~Ketmar)
+ * Understanding is not required. Only obedience.
+ *
+ * This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar.
+ * See http://www.wtfpl.net/ for more details.
+ */
+#include "vwadwrite.h"
+
+#include <stdarg.h>
+#include <string.h>
+
+// to test the code
+//#define VWAD_COMPILE_DECOMPRESSOR
+
+#define VWAD_USE_NAME_LENGTHES
+
+
+#define VWADWR_FILE_ENTRY_SIZE   (4 * 10)
+#define VWADWR_CHUNK_ENTRY_SIZE  (4 + 2 + 2)
+
+#define VWADWR_NO_CHUNKS  (0xffffffffU)
+
+#define VWADWR_PUBLIC
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+/* turning off inlining saves ~10kb of binary code on x86 */
+#ifdef _MSC_VER
+# define CC25519_INLINE  __forceinline
+// not used if decompressor is not compiled in
+# define VWAD_OKUNUSED
+#else
+# define CC25519_INLINE  inline __attribute__((always_inline))
+// not used if decompressor is not compiled in
+# define VWAD_OKUNUSED  __attribute__((unused))
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// M$VC support modelled after Dasho code, thank you!
+#ifdef _MSC_VER
+# define vwad__builtin_expect(cond_val_,exp_val_)  (cond_val_)
+# define vwad__builtin_trap  abort
+# define vwad_packed_struct
+# define vwad_push_pack  __pragma(pack(push, 1))
+# define vwad_pop_pack   __pragma(pack(pop))
+#else
+# define vwad__builtin_expect  __builtin_expect
+# define vwad__builtin_trap    __builtin_trap
+# define vwad_packed_struct    __attribute__((packed))
+# define vwad_push_pack
+# define vwad_pop_pack
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static CC25519_INLINE vwadwr_ushort get_u16 (const void *src) {
+  vwadwr_ushort res = ((const vwadwr_ubyte *)src)[0];
+  res |= ((vwadwr_ushort)((const vwadwr_ubyte *)src)[1])<<8;
+  return res;
+}
+
+static CC25519_INLINE vwadwr_uint get_u32 (const void *src) {
+  vwadwr_uint res = ((const vwadwr_ubyte *)src)[0];
+  res |= ((vwadwr_uint)((const vwadwr_ubyte *)src)[1])<<8;
+  res |= ((vwadwr_uint)((const vwadwr_ubyte *)src)[2])<<16;
+  res |= ((vwadwr_uint)((const vwadwr_ubyte *)src)[3])<<24;
+  return res;
+}
+
+static CC25519_INLINE void put_u64 (void *dest, vwadwr_uint64 u) {
+  ((vwadwr_ubyte *)dest)[0] = (vwadwr_ubyte)u;
+  ((vwadwr_ubyte *)dest)[1] = (vwadwr_ubyte)(u>>8);
+  ((vwadwr_ubyte *)dest)[2] = (vwadwr_ubyte)(u>>16);
+  ((vwadwr_ubyte *)dest)[3] = (vwadwr_ubyte)(u>>24);
+  ((vwadwr_ubyte *)dest)[4] = (vwadwr_ubyte)(u>>32);
+  ((vwadwr_ubyte *)dest)[5] = (vwadwr_ubyte)(u>>40);
+  ((vwadwr_ubyte *)dest)[6] = (vwadwr_ubyte)(u>>48);
+  ((vwadwr_ubyte *)dest)[7] = (vwadwr_ubyte)(u>>56);
+}
+
+static CC25519_INLINE void put_u32 (void *dest, vwadwr_uint u) {
+  ((vwadwr_ubyte *)dest)[0] = (vwadwr_ubyte)u;
+  ((vwadwr_ubyte *)dest)[1] = (vwadwr_ubyte)(u>>8);
+  ((vwadwr_ubyte *)dest)[2] = (vwadwr_ubyte)(u>>16);
+  ((vwadwr_ubyte *)dest)[3] = (vwadwr_ubyte)(u>>24);
+}
+
+static CC25519_INLINE void put_u16 (void *dest, vwadwr_ushort u) {
+  ((vwadwr_ubyte *)dest)[0] = (vwadwr_ubyte)u;
+  ((vwadwr_ubyte *)dest)[1] = (vwadwr_ubyte)(u>>8);
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+typedef vwadwr_ubyte ed25519_signature[64];
+typedef vwadwr_ubyte ed25519_public_key[32];
+typedef vwadwr_ubyte ed25519_secret_key[32];
+typedef vwadwr_ubyte ed25519_random_seed[32];
+
+
+typedef struct cc_ed25519_iostream_t cc_ed25519_iostream;
+struct cc_ed25519_iostream_t {
+  // return negative on failure
+  int (*total_size) (cc_ed25519_iostream *strm);
+  // read exactly `bufsize` bytes; return non-zero on failure
+  // will never be called with 0 or negative `bufsize`
+  int (*read) (cc_ed25519_iostream *strm, int startpos, void *buf, int bufsize);
+  // user data
+  void *udata;
+};
+
+#define ED25519_SEED_SIZE (32)
+#define ED25519_PUBLIC_KEY_SIZE (32)
+#define ED25519_SIGNATURE_SIZE (64)
+
+
+struct sha512_state {
+  vwadwr_uint64 h[8];
+};
+
+#define SHA512_BLOCK_SIZE  (128)
+#define SHA512_HASH_SIZE  (64)
+
+static const struct sha512_state sha512_initial_state = { {
+  0x6a09e667f3bcc908LL, 0xbb67ae8584caa73bLL,
+  0x3c6ef372fe94f82bLL, 0xa54ff53a5f1d36f1LL,
+  0x510e527fade682d1LL, 0x9b05688c2b3e6c1fLL,
+  0x1f83d9abfb41bd6bLL, 0x5be0cd19137e2179LL,
+} };
+
+static const vwadwr_uint64 round_k[80] = {
+  0x428a2f98d728ae22LL, 0x7137449123ef65cdLL,
+  0xb5c0fbcfec4d3b2fLL, 0xe9b5dba58189dbbcLL,
+  0x3956c25bf348b538LL, 0x59f111f1b605d019LL,
+  0x923f82a4af194f9bLL, 0xab1c5ed5da6d8118LL,
+  0xd807aa98a3030242LL, 0x12835b0145706fbeLL,
+  0x243185be4ee4b28cLL, 0x550c7dc3d5ffb4e2LL,
+  0x72be5d74f27b896fLL, 0x80deb1fe3b1696b1LL,
+  0x9bdc06a725c71235LL, 0xc19bf174cf692694LL,
+  0xe49b69c19ef14ad2LL, 0xefbe4786384f25e3LL,
+  0x0fc19dc68b8cd5b5LL, 0x240ca1cc77ac9c65LL,
+  0x2de92c6f592b0275LL, 0x4a7484aa6ea6e483LL,
+  0x5cb0a9dcbd41fbd4LL, 0x76f988da831153b5LL,
+  0x983e5152ee66dfabLL, 0xa831c66d2db43210LL,
+  0xb00327c898fb213fLL, 0xbf597fc7beef0ee4LL,
+  0xc6e00bf33da88fc2LL, 0xd5a79147930aa725LL,
+  0x06ca6351e003826fLL, 0x142929670a0e6e70LL,
+  0x27b70a8546d22ffcLL, 0x2e1b21385c26c926LL,
+  0x4d2c6dfc5ac42aedLL, 0x53380d139d95b3dfLL,
+  0x650a73548baf63deLL, 0x766a0abb3c77b2a8LL,
+  0x81c2c92e47edaee6LL, 0x92722c851482353bLL,
+  0xa2bfe8a14cf10364LL, 0xa81a664bbc423001LL,
+  0xc24b8b70d0f89791LL, 0xc76c51a30654be30LL,
+  0xd192e819d6ef5218LL, 0xd69906245565a910LL,
+  0xf40e35855771202aLL, 0x106aa07032bbd1b8LL,
+  0x19a4c116b8d2d0c8LL, 0x1e376c085141ab53LL,
+  0x2748774cdf8eeb99LL, 0x34b0bcb5e19b48a8LL,
+  0x391c0cb3c5c95a63LL, 0x4ed8aa4ae3418acbLL,
+  0x5b9cca4f7763e373LL, 0x682e6ff3d6b2b8a3LL,
+  0x748f82ee5defb2fcLL, 0x78a5636f43172f60LL,
+  0x84c87814a1f0ab72LL, 0x8cc702081a6439ecLL,
+  0x90befffa23631e28LL, 0xa4506cebde82bde9LL,
+  0xbef9a3f7b2c67915LL, 0xc67178f2e372532bLL,
+  0xca273eceea26619cLL, 0xd186b8c721c0c207LL,
+  0xeada7dd6cde0eb1eLL, 0xf57d4f7fee6ed178LL,
+  0x06f067aa72176fbaLL, 0x0a637dc5a2c898a6LL,
+  0x113f9804bef90daeLL, 0x1b710b35131c471bLL,
+  0x28db77f523047d84LL, 0x32caab7b40c72493LL,
+  0x3c9ebe0a15c9bebcLL, 0x431d67c49c100d4cLL,
+  0x4cc5d4becb3e42b6LL, 0x597f299cfc657e2aLL,
+  0x5fcb6fab3ad6faecLL, 0x6c44198c4a475817LL,
+};
+
+static CC25519_INLINE vwadwr_uint64 load64 (const vwadwr_ubyte *x) {
+  vwadwr_uint64 r = *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+  r = (r << 8) | *(x++);
+
+  return r;
+}
+
+static CC25519_INLINE void store64 (vwadwr_ubyte *x, vwadwr_uint64 v) {
+  x += 7; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+  v >>= 8; *(x--) = v;
+}
+
+static CC25519_INLINE vwadwr_uint64 rot64 (vwadwr_uint64 x, int bits) {
+  return (x >> bits) | (x << (64 - bits));
+}
+
+static void sha512_block (struct sha512_state *s, const vwadwr_ubyte *blk) {
+  vwadwr_uint64 w[16];
+  vwadwr_uint64 a, b, c, d, e, f, g, h;
+  int i;
+
+  for (i = 0; i < 16; i++) {
+    w[i] = load64(blk);
+    blk += 8;
+  }
+
+  a = s->h[0];
+  b = s->h[1];
+  c = s->h[2];
+  d = s->h[3];
+  e = s->h[4];
+  f = s->h[5];
+  g = s->h[6];
+  h = s->h[7];
+
+  for (i = 0; i < 80; i++) {
+    const vwadwr_uint64 wi = w[i & 15];
+    const vwadwr_uint64 wi15 = w[(i + 1) & 15];
+    const vwadwr_uint64 wi2 = w[(i + 14) & 15];
+    const vwadwr_uint64 wi7 = w[(i + 9) & 15];
+    const vwadwr_uint64 s0 = rot64(wi15, 1) ^ rot64(wi15, 8) ^ (wi15 >> 7);
+    const vwadwr_uint64 s1 = rot64(wi2, 19) ^ rot64(wi2, 61) ^ (wi2 >> 6);
+
+    const vwadwr_uint64 S0 = rot64(a, 28) ^ rot64(a, 34) ^ rot64(a, 39);
+    const vwadwr_uint64 S1 = rot64(e, 14) ^ rot64(e, 18) ^ rot64(e, 41);
+    const vwadwr_uint64 ch = (e & f) ^ ((~e) & g);
+    const vwadwr_uint64 temp1 = h + S1 + ch + round_k[i] + wi;
+    const vwadwr_uint64 maj = (a & b) ^ (a & c) ^ (b & c);
+    const vwadwr_uint64 temp2 = S0 + maj;
+
+    h = g;
+    g = f;
+    f = e;
+    e = d + temp1;
+    d = c;
+    c = b;
+    b = a;
+    a = temp1 + temp2;
+
+    w[i & 15] = wi + s0 + wi7 + s1;
+  }
+
+  s->h[0] += a;
+  s->h[1] += b;
+  s->h[2] += c;
+  s->h[3] += d;
+  s->h[4] += e;
+  s->h[5] += f;
+  s->h[6] += g;
+  s->h[7] += h;
+}
+
+static CC25519_INLINE void sha512_init (struct sha512_state *s) {
+  memcpy(s, &sha512_initial_state, sizeof(*s));
+}
+
+static void sha512_final (struct sha512_state *s, const vwadwr_ubyte *blk, vwadwr_uint total_size) {
+  vwadwr_ubyte temp[SHA512_BLOCK_SIZE] = {0};
+  const vwadwr_uint last_size = total_size & (SHA512_BLOCK_SIZE - 1);
+
+  if (last_size) memcpy(temp, blk, last_size);
+  temp[last_size] = 0x80;
+
+  if (last_size > 111) {
+    sha512_block(s, temp);
+    memset(temp, 0, sizeof(temp));
+  }
+
+  store64(temp + SHA512_BLOCK_SIZE - 8, total_size << 3);
+  sha512_block(s, temp);
+}
+
+static void sha512_get (const struct sha512_state *s, vwadwr_ubyte *hash,
+                        vwadwr_uint offset, vwadwr_uint len)
+{
+  int i;
+
+  if (offset > SHA512_BLOCK_SIZE) return;
+
+  if (len > SHA512_BLOCK_SIZE - offset) len = SHA512_BLOCK_SIZE - offset;
+
+  i = offset >> 3;
+  offset &= 7;
+
+  if (offset) {
+    vwadwr_ubyte tmp[8];
+    vwadwr_uint c = 8 - offset;
+
+    if (c > len) c = len;
+
+    store64(tmp, s->h[i++]);
+    memcpy(hash, tmp + offset, c);
+    len -= c;
+    hash += c;
+  }
+
+  while (len >= 8) {
+    store64(hash, s->h[i++]);
+    hash += 8;
+    len -= 8;
+  }
+
+  if (len) {
+    vwadwr_ubyte tmp[8];
+
+    store64(tmp, s->h[i]);
+    memcpy(hash, tmp, len);
+  }
+}
+
+#define F25519_SIZE  (32)
+
+static CC25519_INLINE void f25519_copy (vwadwr_ubyte *x, const vwadwr_ubyte *a) {
+  memcpy(x, a, F25519_SIZE);
+}
+
+#define FPRIME_SIZE  (32)
+
+static CC25519_INLINE void fprime_copy (vwadwr_ubyte *x, const vwadwr_ubyte *a) {
+  memcpy(x, a, FPRIME_SIZE);
+}
+
+struct ed25519_pt {
+  vwadwr_ubyte x[F25519_SIZE];
+  vwadwr_ubyte y[F25519_SIZE];
+  vwadwr_ubyte t[F25519_SIZE];
+  vwadwr_ubyte z[F25519_SIZE];
+};
+
+static const struct ed25519_pt ed25519_base = {
+  .x = {
+    0x1a, 0xd5, 0x25, 0x8f, 0x60, 0x2d, 0x56, 0xc9,
+    0xb2, 0xa7, 0x25, 0x95, 0x60, 0xc7, 0x2c, 0x69,
+    0x5c, 0xdc, 0xd6, 0xfd, 0x31, 0xe2, 0xa4, 0xc0,
+    0xfe, 0x53, 0x6e, 0xcd, 0xd3, 0x36, 0x69, 0x21
+  },
+  .y = {
+    0x58, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+    0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66
+  },
+  .t = {
+    0xa3, 0xdd, 0xb7, 0xa5, 0xb3, 0x8a, 0xde, 0x6d,
+    0xf5, 0x52, 0x51, 0x77, 0x80, 0x9f, 0xf0, 0x20,
+    0x7d, 0xe3, 0xab, 0x64, 0x8e, 0x4e, 0xea, 0x66,
+    0x65, 0x76, 0x8b, 0xd7, 0x0f, 0x5f, 0x87, 0x67
+  },
+  .z = {1, 0}
+};
+
+static const struct ed25519_pt ed25519_neutral = {
+  .x = {0},
+  .y = {1, 0},
+  .t = {0},
+  .z = {1, 0}
+};
+
+#define ED25519_PACK_SIZE  F25519_SIZE
+#define ED25519_EXPONENT_SIZE  32
+
+static CC25519_INLINE void ed25519_prepare (vwadwr_ubyte *e) {
+  e[0] &= 0xf8;
+  e[31] &= 0x7f;
+  e[31] |= 0x40;
+}
+
+static CC25519_INLINE void ed25519_copy (struct ed25519_pt *dst, const struct ed25519_pt *src) {
+  memcpy(dst, src, sizeof(*dst));
+}
+
+#define EDSIGN_SECRET_KEY_SIZE  (32)
+#define EDSIGN_PUBLIC_KEY_SIZE  (32)
+#define EDSIGN_SIGNATURE_SIZE   (64)
+
+static void f25519_select (vwadwr_ubyte *dst, const vwadwr_ubyte *zero, const vwadwr_ubyte *one,
+                           vwadwr_ubyte condition)
+{
+  const vwadwr_ubyte mask = -condition;
+  int i;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    dst[i] = zero[i] ^ (mask & (one[i] ^ zero[i]));
+  }
+}
+
+static void f25519_normalize (vwadwr_ubyte *x) {
+  vwadwr_ubyte minusp[F25519_SIZE];
+  vwadwr_ushort c;
+  int i;
+
+  c = (x[31] >> 7) * 19;
+  x[31] &= 127;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += x[i];
+    x[i] = c;
+    c >>= 8;
+  }
+
+  c = 19;
+
+  for (i = 0; i + 1 < F25519_SIZE; i++) {
+    c += x[i];
+    minusp[i] = c;
+    c >>= 8;
+  }
+
+  c += ((vwadwr_ushort)x[i]) - 128;
+  minusp[31] = c;
+
+  f25519_select(x, minusp, x, (c >> 15) & 1);
+}
+
+static void f25519_add (vwadwr_ubyte *r, const vwadwr_ubyte *a, const vwadwr_ubyte *b) {
+  vwadwr_ushort c = 0;
+  int i;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c >>= 8;
+    c += ((vwadwr_ushort)a[i]) + ((vwadwr_ushort)b[i]);
+    r[i] = c;
+  }
+
+  r[31] &= 127;
+  c = (c >> 7) * 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_sub (vwadwr_ubyte *r, const vwadwr_ubyte *a, const vwadwr_ubyte *b) {
+  vwadwr_uint c = 0;
+  int i;
+
+  c = 218;
+  for (i = 0; i + 1 < F25519_SIZE; i++) {
+    c += 65280 + ((vwadwr_uint)a[i]) - ((vwadwr_uint)b[i]);
+    r[i] = c;
+    c >>= 8;
+  }
+
+  c += ((vwadwr_uint)a[31]) - ((vwadwr_uint)b[31]);
+  r[31] = c & 127;
+  c = (c >> 7) * 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_neg (vwadwr_ubyte *r, const vwadwr_ubyte *a) {
+  vwadwr_uint c = 0;
+  int i;
+
+  c = 218;
+  for (i = 0; i + 1 < F25519_SIZE; i++) {
+    c += 65280 - ((vwadwr_uint)a[i]);
+    r[i] = c;
+    c >>= 8;
+  }
+
+  c -= ((vwadwr_uint)a[31]);
+  r[31] = c & 127;
+  c = (c >> 7) * 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_mul__distinct (vwadwr_ubyte *r, const vwadwr_ubyte *a, const vwadwr_ubyte *b) {
+  vwadwr_uint c = 0;
+  int i;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    int j;
+
+    c >>= 8;
+    for (j = 0; j <= i; j++) {
+      c += ((vwadwr_uint)a[j]) * ((vwadwr_uint)b[i - j]);
+    }
+
+    for (; j < F25519_SIZE; j++) {
+      c += ((vwadwr_uint)a[j]) *
+           ((vwadwr_uint)b[i + F25519_SIZE - j]) * 38;
+    }
+
+    r[i] = c;
+  }
+
+  r[31] &= 127;
+  c = (c >> 7) * 19;
+
+  for (i = 0; i < F25519_SIZE; i++) {
+    c += r[i];
+    r[i] = c;
+    c >>= 8;
+  }
+}
+
+static void f25519_inv__distinct (vwadwr_ubyte *r, const vwadwr_ubyte *x) {
+  vwadwr_ubyte s[F25519_SIZE];
+  int i;
+
+  f25519_mul__distinct(s, x, x);
+  f25519_mul__distinct(r, s, x);
+
+  for (i = 0; i < 248; i++) {
+    f25519_mul__distinct(s, r, r);
+    f25519_mul__distinct(r, s, x);
+  }
+
+  f25519_mul__distinct(s, r, r);
+  f25519_mul__distinct(r, s, s);
+  f25519_mul__distinct(s, r, x);
+  f25519_mul__distinct(r, s, s);
+  f25519_mul__distinct(s, r, r);
+  f25519_mul__distinct(r, s, x);
+  f25519_mul__distinct(s, r, r);
+  f25519_mul__distinct(r, s, x);
+}
+
+static void raw_add (vwadwr_ubyte *x, const vwadwr_ubyte *p) {
+  vwadwr_ushort c = 0;
+  int i;
+
+  for (i = 0; i < FPRIME_SIZE; i++) {
+    c += ((vwadwr_ushort)x[i]) + ((vwadwr_ushort)p[i]);
+    x[i] = c;
+    c >>= 8;
+  }
+}
+
+static void fprime_select (vwadwr_ubyte *dst, const vwadwr_ubyte *zero, const vwadwr_ubyte *one,
+                           vwadwr_ubyte condition)
+{
+  const vwadwr_ubyte mask = -condition;
+  int i;
+
+  for (i = 0; i < FPRIME_SIZE; i++) {
+    dst[i] = zero[i] ^ (mask & (one[i] ^ zero[i]));
+  }
+}
+
+static void raw_try_sub (vwadwr_ubyte *x, const vwadwr_ubyte *p) {
+  vwadwr_ubyte minusp[FPRIME_SIZE];
+  vwadwr_ushort c = 0;
+  int i;
+
+  for (i = 0; i < FPRIME_SIZE; i++) {
+    c = ((vwadwr_ushort)x[i]) - ((vwadwr_ushort)p[i]) - c;
+    minusp[i] = c;
+    c = (c >> 8) & 1;
+  }
+
+  fprime_select(x, minusp, x, c);
+}
+
+static int prime_msb (const vwadwr_ubyte *p) {
+  int i;
+  vwadwr_ubyte x;
+
+  for (i = FPRIME_SIZE - 1; i >= 0; i--) {
+    if (p[i]) break;
+  }
+
+  x = p[i];
+  i <<= 3;
+
+  while (x) {
+    x >>= 1;
+    i++;
+  }
+
+  return i - 1;
+}
+
+static void shift_n_bits (vwadwr_ubyte *x, int n) {
+  vwadwr_ushort c = 0;
+  int i;
+
+  for (i = 0; i < FPRIME_SIZE; i++) {
+    c |= ((vwadwr_ushort)x[i]) << n;
+    x[i] = c;
+    c >>= 8;
+  }
+}
+
+static CC25519_INLINE int min_int (int a, int b) {
+  return a < b ? a : b;
+}
+
+static void fprime_from_bytes (vwadwr_ubyte *n, const vwadwr_ubyte *x, vwadwr_uint len,
+                               const vwadwr_ubyte *modulus)
+{
+  const int preload_total = min_int(prime_msb(modulus) - 1, len << 3);
+  const int preload_bytes = preload_total >> 3;
+  const int preload_bits = preload_total & 7;
+  const int rbits = (len << 3) - preload_total;
+  int i;
+
+  memset(n, 0, FPRIME_SIZE);
+
+  for (i = 0; i < preload_bytes; i++) {
+    n[i] = x[len - preload_bytes + i];
+  }
+
+  if (preload_bits) {
+    shift_n_bits(n, preload_bits);
+    n[0] |= x[len - preload_bytes - 1] >> (8 - preload_bits);
+  }
+
+  for (i = rbits - 1; i >= 0; i--) {
+    const vwadwr_ubyte bit = (x[i >> 3] >> (i & 7)) & 1;
+
+    shift_n_bits(n, 1);
+    n[0] |= bit;
+    raw_try_sub(n, modulus);
+  }
+}
+
+static CC25519_INLINE void fprime_add (vwadwr_ubyte *r, const vwadwr_ubyte *a, const vwadwr_ubyte *modulus) {
+  raw_add(r, a);
+  raw_try_sub(r, modulus);
+}
+
+static void fprime_mul (vwadwr_ubyte *r, const vwadwr_ubyte *a, const vwadwr_ubyte *b, const vwadwr_ubyte *modulus) {
+  int i;
+
+  memset(r, 0, FPRIME_SIZE);
+
+  for (i = prime_msb(modulus); i >= 0; i--) {
+    const vwadwr_ubyte bit = (b[i >> 3] >> (i & 7)) & 1;
+    vwadwr_ubyte plusa[FPRIME_SIZE];
+
+    shift_n_bits(r, 1);
+    raw_try_sub(r, modulus);
+
+    fprime_copy(plusa, r);
+    fprime_add(plusa, a, modulus);
+
+    fprime_select(r, r, plusa, bit);
+  }
+}
+
+static CC25519_INLINE void ed25519_unproject (vwadwr_ubyte *x, vwadwr_ubyte *y, const struct ed25519_pt *p) {
+  vwadwr_ubyte z1[F25519_SIZE];
+
+  f25519_inv__distinct(z1, p->z);
+  f25519_mul__distinct(x, p->x, z1);
+  f25519_mul__distinct(y, p->y, z1);
+
+  f25519_normalize(x);
+  f25519_normalize(y);
+}
+
+static CC25519_INLINE void ed25519_pack (vwadwr_ubyte *c, const vwadwr_ubyte *x, const vwadwr_ubyte *y) {
+  vwadwr_ubyte tmp[F25519_SIZE];
+  vwadwr_ubyte parity;
+
+  f25519_copy(tmp, x);
+  f25519_normalize(tmp);
+  parity = (tmp[0] & 1) << 7;
+
+  f25519_copy(c, y);
+  f25519_normalize(c);
+  c[31] |= parity;
+}
+
+static const vwadwr_ubyte ed25519_k[F25519_SIZE] = {
+  0x59, 0xf1, 0xb2, 0x26, 0x94, 0x9b, 0xd6, 0xeb,
+  0x56, 0xb1, 0x83, 0x82, 0x9a, 0x14, 0xe0, 0x00,
+  0x30, 0xd1, 0xf3, 0xee, 0xf2, 0x80, 0x8e, 0x19,
+  0xe7, 0xfc, 0xdf, 0x56, 0xdc, 0xd9, 0x06, 0x24
+};
+
+static void ed25519_add (struct ed25519_pt *r,
+                         const struct ed25519_pt *p1, const struct ed25519_pt *p2)
+{
+  vwadwr_ubyte a[F25519_SIZE];
+  vwadwr_ubyte b[F25519_SIZE];
+  vwadwr_ubyte c[F25519_SIZE];
+  vwadwr_ubyte d[F25519_SIZE];
+  vwadwr_ubyte e[F25519_SIZE];
+  vwadwr_ubyte f[F25519_SIZE];
+  vwadwr_ubyte g[F25519_SIZE];
+  vwadwr_ubyte h[F25519_SIZE];
+
+  f25519_sub(c, p1->y, p1->x);
+  f25519_sub(d, p2->y, p2->x);
+  f25519_mul__distinct(a, c, d);
+  f25519_add(c, p1->y, p1->x);
+  f25519_add(d, p2->y, p2->x);
+  f25519_mul__distinct(b, c, d);
+  f25519_mul__distinct(d, p1->t, p2->t);
+  f25519_mul__distinct(c, d, ed25519_k);
+  f25519_mul__distinct(d, p1->z, p2->z);
+  f25519_add(d, d, d);
+  f25519_sub(e, b, a);
+  f25519_sub(f, d, c);
+  f25519_add(g, d, c);
+  f25519_add(h, b, a);
+  f25519_mul__distinct(r->x, e, f);
+  f25519_mul__distinct(r->y, g, h);
+  f25519_mul__distinct(r->t, e, h);
+  f25519_mul__distinct(r->z, f, g);
+}
+
+static void ed25519_double (struct ed25519_pt *r, const struct ed25519_pt *p) {
+  vwadwr_ubyte a[F25519_SIZE];
+  vwadwr_ubyte b[F25519_SIZE];
+  vwadwr_ubyte c[F25519_SIZE];
+  vwadwr_ubyte e[F25519_SIZE];
+  vwadwr_ubyte f[F25519_SIZE];
+  vwadwr_ubyte g[F25519_SIZE];
+  vwadwr_ubyte h[F25519_SIZE];
+
+  f25519_mul__distinct(a, p->x, p->x);
+  f25519_mul__distinct(b, p->y, p->y);
+  f25519_mul__distinct(c, p->z, p->z);
+  f25519_add(c, c, c);
+  f25519_add(f, p->x, p->y);
+  f25519_mul__distinct(e, f, f);
+  f25519_sub(e, e, a);
+  f25519_sub(e, e, b);
+  f25519_sub(g, b, a);
+  f25519_sub(f, g, c);
+  f25519_neg(h, b);
+  f25519_sub(h, h, a);
+  f25519_mul__distinct(r->x, e, f);
+  f25519_mul__distinct(r->y, g, h);
+  f25519_mul__distinct(r->t, e, h);
+  f25519_mul__distinct(r->z, f, g);
+}
+
+static void ed25519_smult (struct ed25519_pt *r_out, const struct ed25519_pt *p,
+                           const vwadwr_ubyte *e)
+{
+  struct ed25519_pt r;
+  int i;
+
+  ed25519_copy(&r, &ed25519_neutral);
+
+  for (i = 255; i >= 0; i--) {
+    const vwadwr_ubyte bit = (e[i >> 3] >> (i & 7)) & 1;
+    struct ed25519_pt s;
+
+    ed25519_double(&r, &r);
+    ed25519_add(&s, &r, p);
+
+    f25519_select(r.x, r.x, s.x, bit);
+    f25519_select(r.y, r.y, s.y, bit);
+    f25519_select(r.z, r.z, s.z, bit);
+    f25519_select(r.t, r.t, s.t, bit);
+  }
+
+  ed25519_copy(r_out, &r);
+}
+
+#define EXPANDED_SIZE  (64)
+
+static const vwadwr_ubyte ed25519_order[FPRIME_SIZE] = {
+  0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
+  0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10
+};
+
+static CC25519_INLINE void expand_key (vwadwr_ubyte *expanded, const vwadwr_ubyte *secret) {
+  struct sha512_state s;
+
+  sha512_init(&s);
+  sha512_final(&s, secret, EDSIGN_SECRET_KEY_SIZE);
+  sha512_get(&s, expanded, 0, EXPANDED_SIZE);
+  ed25519_prepare(expanded);
+}
+
+static CC25519_INLINE void pp (vwadwr_ubyte *packed, const struct ed25519_pt *p) {
+  vwadwr_ubyte x[F25519_SIZE];
+  vwadwr_ubyte y[F25519_SIZE];
+
+  ed25519_unproject(x, y, p);
+  ed25519_pack(packed, x, y);
+}
+
+static CC25519_INLINE void sm_pack (vwadwr_ubyte *r, const vwadwr_ubyte *k) {
+  struct ed25519_pt p;
+
+  ed25519_smult(&p, &ed25519_base, k);
+  pp(r, &p);
+}
+
+static CC25519_INLINE void edsign_sec_to_pub (vwadwr_ubyte *pub, const vwadwr_ubyte *secret) {
+  vwadwr_ubyte expanded[EXPANDED_SIZE];
+
+  expand_key(expanded, secret);
+  sm_pack(pub, expanded);
+}
+
+void vwadwr_z85_get_pubkey (vwadwr_ubyte *pubkey, const vwadwr_ubyte *privkey) {
+  edsign_sec_to_pub (pubkey, privkey);
+}
+
+static int hash_with_prefix (vwadwr_ubyte *out_fp,
+                             vwadwr_ubyte *init_block, vwadwr_uint prefix_size,
+                             cc_ed25519_iostream *strm)
+{
+  struct sha512_state s;
+
+  const int xxlen = strm->total_size(strm);
+  if (xxlen < 0) return -1;
+  const vwadwr_uint len = (vwadwr_uint)xxlen;
+
+  vwadwr_ubyte msgblock[SHA512_BLOCK_SIZE];
+
+  sha512_init(&s);
+
+  if (len < SHA512_BLOCK_SIZE && len + prefix_size < SHA512_BLOCK_SIZE) {
+    if (len > 0) {
+      if (strm->read(strm, 0, msgblock, (int)len) != 0) return -1;
+      memcpy(init_block + prefix_size, msgblock, len);
+    }
+    sha512_final(&s, init_block, len + prefix_size);
+  } else {
+    vwadwr_uint i;
+
+    if (strm->read(strm, 0, msgblock, SHA512_BLOCK_SIZE - prefix_size) != 0) return -1;
+    memcpy(init_block + prefix_size, msgblock, SHA512_BLOCK_SIZE - prefix_size);
+    sha512_block(&s, init_block);
+
+    for (i = SHA512_BLOCK_SIZE - prefix_size;
+         i + SHA512_BLOCK_SIZE <= len;
+         i += SHA512_BLOCK_SIZE)
+    {
+      if (strm->read(strm, (int)i, msgblock, SHA512_BLOCK_SIZE) != 0) return -1;
+      sha512_block(&s, msgblock);
+    }
+
+    const int left = (int)len - (int)i;
+    if (left < 0) vwad__builtin_trap();
+    if (left > 0) {
+      if (strm->read(strm, (int)i, msgblock, left) != 0) return -1;
+    }
+
+    sha512_final(&s, msgblock, len + prefix_size);
+  }
+
+  sha512_get(&s, init_block, 0, SHA512_HASH_SIZE);
+  fprime_from_bytes(out_fp, init_block, SHA512_HASH_SIZE, ed25519_order);
+
+  return 0;
+}
+
+static CC25519_INLINE int generate_k (vwadwr_ubyte *k, const vwadwr_ubyte *kgen_key,
+                                      cc_ed25519_iostream *strm)
+{
+  vwadwr_ubyte block[SHA512_BLOCK_SIZE];
+  memcpy(block, kgen_key, 32);
+  return hash_with_prefix(k, block, 32, strm);
+}
+
+static int hash_message (vwadwr_ubyte *z, const vwadwr_ubyte *r, const vwadwr_ubyte *a,
+                         cc_ed25519_iostream *strm)
+{
+  vwadwr_ubyte block[SHA512_BLOCK_SIZE];
+
+  memcpy(block, r, 32);
+  memcpy(block + 32, a, 32);
+  return hash_with_prefix(z, block, 64, strm);
+}
+
+static int edsign_sign_stream (vwadwr_ubyte *signature, const vwadwr_ubyte *pub, const vwadwr_ubyte *secret,
+                               cc_ed25519_iostream *strm)
+{
+  vwadwr_ubyte expanded[EXPANDED_SIZE];
+  vwadwr_ubyte e[FPRIME_SIZE];
+  vwadwr_ubyte s[FPRIME_SIZE];
+  vwadwr_ubyte k[FPRIME_SIZE];
+  vwadwr_ubyte z[FPRIME_SIZE];
+
+  expand_key(expanded, secret);
+
+  if (generate_k(k, expanded + 32, strm) != 0) return -1;
+  sm_pack(signature, k);
+
+  if (hash_message(z, signature, pub, strm) != 0) return -1;
+
+  fprime_from_bytes(e, expanded, 32, ed25519_order);
+
+  fprime_mul(s, z, e, ed25519_order);
+  fprime_add(s, k, ed25519_order);
+  memcpy(signature + 32, s, 32);
+
+  return 0;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static CC25519_INLINE vwadwr_uint hashU32 (vwadwr_uint v) {
+  v ^= v >> 16;
+  v *= 0x21f0aaadu;
+  v ^= v >> 15;
+  v *= 0x735a2d97u;
+  v ^= v >> 15;
+  return v;
+}
+
+static vwadwr_uint deriveSeed (vwadwr_uint seed, const vwadwr_ubyte *buf, vwadwr_uint buflen) {
+  for (vwadwr_uint f = 0; f < buflen; f += 1) {
+    seed = hashU32((seed + 0x9E3779B9u) ^ buf[f]);
+  }
+  // hash it again
+  return hashU32(seed + 0x9E3779B9u);
+}
+
+static void crypt_buffer (vwadwr_uint xseed, vwadwr_uint64 nonce, void *buf, vwadwr_uint bufsize) {
+  // use xoroshiro-derived PRNG, because i don't need cryptostrong xor at all
+  #define MB32X  do { \
+    /* 2 to the 32 divided by golden ratio; adding forms a Weyl sequence */ \
+    rval = (xseed += 0x9E3779B9u); \
+    rval ^= rval << 13; \
+    rval ^= rval >> 17; \
+    rval ^= rval << 5; \
+    /*rval = hashU32(xseed += 0x9E3779B9u); -- mulberry32*/ \
+  } while (0)
+
+  xseed += nonce;
+  vwadwr_uint rval;
+
+  vwadwr_uint *b32 = (vwadwr_uint *)buf;
+  while (bufsize >= 4) {
+    MB32X;
+    put_u32(b32, get_u32(b32) ^ rval);
+    ++b32;
+    bufsize -= 4;
+  }
+  if (bufsize) {
+    // final [1..3] bytes
+    MB32X;
+    vwadwr_uint n;
+    vwadwr_ubyte *b = (vwadwr_ubyte *)b32;
+    switch (bufsize) {
+      case 3:
+        n = b[0]|((vwadwr_uint)b[1]<<8)|((vwadwr_uint)b[2]<<16);
+        n ^= rval;
+        b[0] = (vwadwr_ubyte)n;
+        b[1] = (vwadwr_ubyte)(n>>8);
+        b[2] = (vwadwr_ubyte)(n>>16);
+        break;
+      case 2:
+        n = b[0]|((vwadwr_uint)b[1]<<8);
+        n ^= rval;
+        b[0] = (vwadwr_ubyte)n;
+        b[1] = (vwadwr_ubyte)(n>>8);
+        break;
+      case 1:
+        b[0] ^= rval;
+        break;
+    }
+  }
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#define crc32_init  (0xffffffffU)
+
+static const vwadwr_uint crctab[16] = {
+  0x00000000, 0x1db71064, 0x3b6e20c8, 0x26d930ac,
+  0x76dc4190, 0x6b6b51f4, 0x4db26158, 0x5005713c,
+  0xedb88320, 0xf00f9344, 0xd6d6a3e8, 0xcb61b38c,
+  0x9b64c2b0, 0x86d3d2d4, 0xa00ae278, 0xbdbdf21c,
+};
+
+
+#define CRC32BYTE(bt_)  do { \
+  crc32 ^= (vwadwr_ubyte)(bt_); \
+  crc32 = crctab[crc32&0x0f]^(crc32>>4); \
+  crc32 = crctab[crc32&0x0f]^(crc32>>4); \
+} while (0)
+
+
+static CC25519_INLINE vwadwr_uint crc32_part (vwadwr_uint crc32, const void *src, vwadwr_uint len) {
+  const vwadwr_ubyte *buf = (const vwadwr_ubyte *)src;
+  while (len--) {
+    CRC32BYTE(*buf++);
+  }
+  return crc32;
+}
+
+static CC25519_INLINE vwadwr_uint crc32_final (vwadwr_uint crc32) {
+  return crc32^0xffffffffU;
+}
+
+static CC25519_INLINE vwadwr_uint crc32_buf (const void *src, vwadwr_uint len) {
+  return crc32_final(crc32_part(crc32_init, src, len));
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// Z85 codec
+static const char *z85_enc_alphabet =
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG"
+  "HIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
+
+static const vwadwr_ubyte z85_dec_alphabet [96] = {
+  0x00, 0x44, 0x00, 0x54, 0x53, 0x52, 0x48, 0x00,
+  0x4B, 0x4C, 0x46, 0x41, 0x00, 0x3F, 0x3E, 0x45,
+  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+  0x08, 0x09, 0x40, 0x00, 0x49, 0x42, 0x4A, 0x47,
+  0x51, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A,
+  0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32,
+  0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A,
+  0x3B, 0x3C, 0x3D, 0x4D, 0x00, 0x4E, 0x43, 0x00,
+  0x00, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+  0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+  0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,
+  0x21, 0x22, 0x23, 0x4F, 0x00, 0x50, 0x00, 0x00
+};
+
+
+//==========================================================================
+//
+//  vwadwr_z85_encode_key
+//
+//==========================================================================
+void vwadwr_z85_encode_key (const vwadwr_public_key inkey, vwadwr_z85_key enkey) {
+  vwadwr_ubyte sdata[32 + 4];
+  memcpy(sdata, inkey, 32);
+  const vwadwr_uint crc32 = crc32_buf(sdata, 32);
+  put_u32(&sdata[32], crc32);
+  vwadwr_uint dpos = 0, spos = 0, value = 0;
+  while (spos < 32 + 4) {
+    value = value * 256u + sdata[spos++];
+    if (spos % 4u == 0) {
+      vwadwr_uint divisor = 85 * 85 * 85 * 85;
+      while (divisor) {
+        char ech = z85_enc_alphabet[value / divisor % 85u];
+        if (ech == '/') ech = '~';
+        enkey[dpos++] = ech;
+        divisor /= 85u;
+      }
+      value = 0;
+    }
+  }
+  if (dpos != (vwadwr_uint)sizeof(vwadwr_z85_key) - 1u) vwad__builtin_trap();
+  enkey[dpos] = 0;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_z85_decode_key
+//
+//==========================================================================
+vwadwr_result vwadwr_z85_decode_key (const vwadwr_z85_key enkey, vwadwr_public_key outkey) {
+  if (enkey == NULL || outkey == NULL) return VWADWR_ERR_ARGS;
+  vwadwr_ubyte ddata[32 + 4];
+  vwadwr_uint dpos = 0, spos = 0, value = 0;
+  while (spos < (vwadwr_uint)sizeof(vwadwr_z85_key) - 1) {
+    char inch = enkey[spos++];
+    switch (inch) {
+      case 0: return VWADWR_ERR_BAD_ASCII;
+      case '\\': inch = '/'; break;
+      case '~': inch = '/'; break;
+      case '|': inch = '!'; break;
+      case ',': inch = '.'; break;
+      case ';': inch = ':'; break;
+      default: break;
+    }
+    if (!strchr(z85_enc_alphabet, inch)) return VWADWR_ERR_BAD_ASCII;
+    value = value * 85 + z85_dec_alphabet[(vwadwr_ubyte)inch - 32];
+    if (spos % 5u == 0) {
+      vwadwr_uint divisor = 256 * 256 * 256;
+      while (divisor) {
+        ddata[dpos++] = value / divisor % 256u;
+        divisor /= 256u;
+      }
+      value = 0;
+    }
+  }
+  if (dpos != 32 + 4) vwad__builtin_trap();
+  if (enkey[spos] != 0) return VWADWR_ERR_BAD_ASCII;
+  const vwadwr_uint crc32 = crc32_buf(ddata, 32);
+  if (crc32 != get_u32(&ddata[32])) return VWADWR_ERR_BAD_ASCII; // bad checksum
+  memcpy(outkey, ddata, 32);
+  return VWADWR_OK;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// logging; can be NULL
+// `type` is the above enum
+void (*vwadwr_logf) (int type, const char *fmt, ...);
+
+#define logf(type_,...)  do { \
+  if (vwadwr_logf) { \
+    vwadwr_logf(VWADWR_LOG_ ## type_, __VA_ARGS__); \
+  } \
+} while (0)
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+void (*vwadwr_assertion_failed) (const char *fmt, ...) = NULL;
+
+static inline const char *SkipPathPartCStr (const char *s) {
+  const char *lastSlash = NULL;
+  for (const char *t = s; *t; ++t) {
+    if (*t == '/') lastSlash = t+1;
+    #ifdef _WIN32
+    if (*t == '\\') lastSlash = t+1;
+    #endif
+  }
+  return (lastSlash ? lastSlash : s);
+}
+
+#ifdef _MSC_VER
+#define vassert(cond_)  do { if (vwad__builtin_expect((!(cond_)), 0)) { const int line__assf = __LINE__; \
+    if (vwadwr_assertion_failed) { \
+      vwadwr_assertion_failed("%s:%d: Assertion in `%s` failed: %s\n", \
+        SkipPathPartCStr(__FILE__), line__assf, __FUNCSIG__, #cond_); \
+      vwad__builtin_trap(); /* just in case */ \
+    } else { \
+      vwad__builtin_trap(); \
+    } \
+  } \
+} while (0)
+#else
+#define vassert(cond_)  do { if (vwad__builtin_expect((!(cond_)), 0)) { const int line__assf = __LINE__; \
+    if (vwadwr_assertion_failed) { \
+      vwadwr_assertion_failed("%s:%d: Assertion in `%s` failed: %s\n", \
+        SkipPathPartCStr(__FILE__), line__assf, __PRETTY_FUNCTION__, #cond_); \
+      vwad__builtin_trap(); /* just in case */ \
+    } else { \
+      vwad__builtin_trap(); \
+    } \
+  } \
+} while (0)
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// memory allocation
+#ifdef VWADWR_DEBUG_ALLOCS
+  // optional notifier for debug. called:
+  //   before alloc; `p` is `NULL`, `size` is size
+  //   after alloc; `p` is not `NULL`, `size` is size
+  //   before free; `p` is not `NULL`, `size` is `0`
+  void (*notify) (vwadwr_memman *mman, void *p, vwadwr_uint size,
+                  const char *srcfunc, const char *srcfile, int srcline);
+
+static CC25519_INLINE void *xalloc1 (vwadwr_memman *mman, vwadwr_uint size,
+                                     const char *srcfunc, const char *srcfile, int srcline)
+{
+  vassert(size > 0 && size <= 0x7ffffff0u);
+  if (mman != NULL) {
+    if (mman->notify != NULL) mman->notify(mman, NULL, size, srcfunc, srcfile, srcline);
+    void *res = mman->alloc(mman, (vwadwr_uint)size);
+    if (mman->notify != NULL) mman->notify(mman, res, size, srcfunc, srcfile, srcline);
+    return res;
+  } else {
+    return malloc(size);
+  }
+}
+
+
+static CC25519_INLINE void *zalloc1 (vwadwr_memman *mman, vwadwr_uint size,
+                                     const char *srcfunc, const char *srcfile, int srcline)
+{
+  vassert(size > 0 && size <= 0x7ffffff0u);
+  void *p = xalloc1(mman, size, srcfunc, srcfile, srcline);
+  if (p) memset(p, 0, size);
+  return p;
+}
+
+
+static CC25519_INLINE void xfree1 (vwadwr_memman *mman, void *p,
+                                   const char *srcfunc, const char *srcfile, int srcline)
+{
+  if (p != NULL) {
+    if (mman != NULL) {
+      if (mman->notify != NULL) mman->notify(mman, p, 0, srcfunc, srcfile, srcline);
+      mman->free(mman, p);
+    } else {
+      free(p);
+    }
+  }
+}
+
+#define xalloc(mm_,sz_)  xalloc1((mm_), (sz_), __PRETTY_FUNCTION__, __FILE__, __LINE__)
+#define zalloc(mm_,sz_)  zalloc1((mm_), (sz_), __PRETTY_FUNCTION__, __FILE__, __LINE__)
+#define xfree(mm_,pp_)   xfree1((mm_), (pp_), __PRETTY_FUNCTION__, __FILE__, __LINE__)
+
+#else
+
+static CC25519_INLINE void *xalloc (vwadwr_memman *mman, vwadwr_uint size) {
+  vassert(size > 0 && size <= 0x7ffffff0u);
+  if (mman != NULL) return mman->alloc(mman, (vwadwr_uint)size); else return malloc(size);
+}
+
+
+static CC25519_INLINE void *zalloc (vwadwr_memman *mman, vwadwr_uint size) {
+  vassert(size > 0 && size <= 0x7ffffff0u);
+  void *p = (mman != NULL ? mman->alloc(mman, (vwadwr_uint)size) : malloc(size));
+  if (p) memset(p, 0, size);
+  return p;
+}
+
+
+static CC25519_INLINE void xfree (vwadwr_memman *mman, void *p) {
+  if (p != NULL) {
+    if (mman != NULL) mman->free(mman, p); else free(p);
+  }
+}
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+typedef int intbool_t;
+
+enum {
+  int_false = 0,
+  int_true = 1
+};
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+typedef struct {
+  vwadwr_uint x1, x2;
+  vwadwr_ubyte *dest;
+  int dpos, dend;
+} EntEncoder;
+
+typedef struct {
+  vwadwr_uint x1, x2, x;
+  const vwadwr_ubyte *src;
+  int spos, send;
+} EntDecoder;
+
+typedef struct {
+  vwadwr_ushort p1, p2;
+} Predictor;
+
+
+typedef struct {
+  Predictor pred[2];
+  int ctx;
+} BitPPM;
+
+typedef struct {
+  Predictor predBits[2 * 256];
+  int ctxBits;
+} BytePPM;
+
+typedef struct {
+  // 8 bits, twice
+  BytePPM bytes[2];
+  // "second byte" flag
+  BitPPM moreFlag;
+} WordPPM;
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void EncInit (EntEncoder *ee, void *outbuf, vwadwr_uint obsize) {
+  ee->x1 = 0; ee->x2 = 0xFFFFFFFFU;
+  ee->dest = (vwadwr_ubyte *)outbuf; ee->dpos = 0;
+  ee->dend = obsize;
+}
+
+static CC25519_INLINE void EncEncode (EntEncoder *ee, int p, intbool_t bit) {
+  vwadwr_uint xmid = ee->x1 + (vwadwr_uint)(((vwadwr_uint64)((ee->x2 - ee->x1) & 0xffffffffU) * (vwadwr_uint)p) >> 17);
+  if (bit) ee->x2 = xmid; else ee->x1 = xmid + 1;
+  while ((ee->x1 ^ ee->x2) < (1u << 24)) {
+    if (ee->dpos < ee->dend) {
+      ee->dest[ee->dpos++] = (vwadwr_ubyte)(ee->x2 >> 24);
+    } else {
+      ee->dpos = 0x7fffffff - 8;
+    }
+    ee->x1 <<= 8;
+    ee->x2 = (ee->x2 << 8) + 255;
+  }
+}
+
+static void EncFlush (EntEncoder *ee) {
+  if (ee->dpos + 4 <= ee->dend) {
+    ee->dest[ee->dpos++] = (vwadwr_ubyte)(ee->x2 >> 24); ee->x2 <<= 8;
+    ee->dest[ee->dpos++] = (vwadwr_ubyte)(ee->x2 >> 24); ee->x2 <<= 8;
+    ee->dest[ee->dpos++] = (vwadwr_ubyte)(ee->x2 >> 24); ee->x2 <<= 8;
+    ee->dest[ee->dpos++] = (vwadwr_ubyte)(ee->x2 >> 24); ee->x2 <<= 8;
+  } else {
+    ee->dpos = 0x7fffffff - 8;
+  }
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#ifdef VWAD_COMPILE_DECOMPRESSOR
+static VWAD_OKUNUSED CC25519_INLINE vwadwr_ubyte DecGetByte (EntDecoder *ee) {
+  if (ee->spos < ee->send) {
+    return ee->src[ee->spos++];
+  } else {
+    ee->spos = 0x7fffffff;
+    return 0;
+  }
+}
+
+static VWAD_OKUNUSED void DecInit (EntDecoder *ee, const void *inbuf, vwadwr_uint insize) {
+  ee->x1 = 0; ee->x2 = 0xFFFFFFFFU;
+  ee->src = (const vwadwr_ubyte *)inbuf; ee->spos = 0; ee->send = insize;
+  ee->x = DecGetByte(ee);
+  ee->x = (ee->x << 8) + DecGetByte(ee);
+  ee->x = (ee->x << 8) + DecGetByte(ee);
+  ee->x = (ee->x << 8) + DecGetByte(ee);
+}
+
+static VWAD_OKUNUSED CC25519_INLINE intbool_t DecDecode (EntDecoder *ee, int p) {
+  vwadwr_uint xmid = ee->x1 + (vwadwr_uint)(((vwadwr_uint64)((ee->x2 - ee->x1) & 0xffffffffU) * (vwadwr_uint)p) >> 17);
+  intbool_t bit = (ee->x <= xmid);
+  if (bit) ee->x2 = xmid; else ee->x1 = xmid + 1;
+  while ((ee->x1 ^ ee->x2) < (1u << 24)) {
+    ee->x1 <<= 8;
+    ee->x2 = (ee->x2 << 8) + 255;
+    ee->x = (ee->x << 8) + DecGetByte(ee);
+  }
+  return bit;
+}
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void PredInit (Predictor *pp) {
+  pp->p1 = 1 << 15; pp->p2 = 1 << 15;
+}
+
+static CC25519_INLINE int PredGetP (Predictor *pp) {
+  return (int)((vwadwr_uint)pp->p1 + (vwadwr_uint)pp->p2);
+}
+
+static CC25519_INLINE void PredUpdate (Predictor *pp, intbool_t bit) {
+  if (bit) {
+    pp->p1 += ((~((vwadwr_uint)pp->p1)) >> 3) & 0b0001111111111111;
+    pp->p2 += ((~((vwadwr_uint)pp->p2)) >> 6) & 0b0000001111111111;
+  } else {
+    pp->p1 -= ((vwadwr_uint)pp->p1) >> 3;
+    pp->p2 -= ((vwadwr_uint)pp->p2) >> 6;
+  }
+}
+
+static CC25519_INLINE int PredGetPAndUpdate (Predictor *pp, intbool_t bit) {
+  int p = PredGetP(pp);
+  PredUpdate(pp, bit);
+  return p;
+}
+
+#ifdef VWAD_COMPILE_DECOMPRESSOR
+static VWAD_OKUNUSED CC25519_INLINE intbool_t PredGetBitDecodeUpdate (Predictor *pp, EntDecoder *dec) {
+  int p = PredGetP(pp);
+  intbool_t bit = DecDecode(dec, p);
+  PredUpdate(pp, bit);
+  return bit;
+}
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void BitPPMInit (BitPPM *ppm, int initstate) {
+  for (vwadwr_uint f = 0; f < (vwadwr_uint)sizeof(ppm->pred) / (vwadwr_uint)sizeof(ppm->pred[0]); ++f) {
+    PredInit(&ppm->pred[f]);
+  }
+  ppm->ctx = !!initstate;
+}
+
+static CC25519_INLINE void BitPPMEncode (BitPPM *ppm, EntEncoder *enc, intbool_t bit) {
+  int p = ppm->ctx;
+  if (bit) ppm->ctx = 1; else ppm->ctx = 0;
+  p = PredGetPAndUpdate(&ppm->pred[p], bit);
+  EncEncode(enc, p, bit);
+}
+
+#ifdef VWAD_COMPILE_DECOMPRESSOR
+static VWAD_OKUNUSED CC25519_INLINE intbool_t BitPPMDecode (BitPPM *ppm, EntDecoder *dec) {
+  intbool_t bit = PredGetBitDecodeUpdate(&ppm->pred[ppm->ctx], dec);
+  if (bit) ppm->ctx = 1; else ppm->ctx = 0;
+  return bit;
+}
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void BytePPMInit (BytePPM *ppm) {
+  for (vwadwr_uint f = 0; f < (vwadwr_uint)sizeof(ppm->predBits) / (vwadwr_uint)sizeof(ppm->predBits[0]); ++f) {
+    PredInit(&ppm->predBits[f]);
+  }
+  ppm->ctxBits = 0;
+}
+
+static CC25519_INLINE void BytePPMEncodeByte (BytePPM *ppm, EntEncoder *enc, int bt) {
+  int c2 = 1;
+  int cofs = ppm->ctxBits * 256;
+  ppm->ctxBits = (bt >= 0x80);
+  for (int f = 0; f <= 7; ++f) {
+    intbool_t bit = (bt&0x80) != 0; bt <<= 1;
+    int p = PredGetPAndUpdate(&ppm->predBits[cofs + c2], bit);
+    EncEncode(enc, p, bit);
+    c2 += c2; if (bit) ++c2;
+  }
+}
+
+#ifdef VWAD_COMPILE_DECOMPRESSOR
+static VWAD_OKUNUSED CC25519_INLINE vwadwr_ubyte BytePPMDecodeByte (BytePPM *ppm, EntDecoder *dec) {
+  vwadwr_uint n = 1;
+  int cofs = ppm->ctxBits * 256;
+  do {
+    intbool_t bit = PredGetBitDecodeUpdate(&ppm->predBits[cofs + n], dec);
+    n += n; if (bit) ++n;
+  } while (n < 0x100);
+  n -= 0x100;
+  ppm->ctxBits = (n >= 0x80);
+  return (vwadwr_ubyte)n;
+}
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static void WordPPMInit (WordPPM *ppm) {
+  BytePPMInit(&ppm->bytes[0]); BytePPMInit(&ppm->bytes[1]);
+  BitPPMInit(&ppm->moreFlag, 0);
+}
+
+static CC25519_INLINE void WordPPMEncodeInt (WordPPM *ppm, EntEncoder *enc, int n) {
+  BytePPMEncodeByte(&ppm->bytes[0], enc, n&0xff);
+  if (n >= 0x100) {
+    BitPPMEncode(&ppm->moreFlag, enc, 1);
+    BytePPMEncodeByte(&ppm->bytes[1], enc, (n>>8)&0xff);
+  } else {
+    BitPPMEncode(&ppm->moreFlag, enc, 0);
+  }
+}
+
+
+#ifdef VWAD_COMPILE_DECOMPRESSOR
+static VWAD_OKUNUSED CC25519_INLINE int WordPPMDecodeInt (WordPPM *ppm, EntDecoder *dec) {
+  int n = BytePPMDecodeByte(&ppm->bytes[0], dec);
+  if (BitPPMDecode(&ppm->moreFlag, dec)) {
+    n += BytePPMDecodeByte(&ppm->bytes[1], dec) * 0x100;
+  }
+  return n;
+}
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+//# define LZFF_HASH_SIZE   (1021u)
+#define LZFF_HASH_SIZE    (2039u)
+//# define LZFF_HASH_SIZE   (4093u)
+#define LZFF_NUM_LIMIT    (0x10000)
+#define LZFF_OFS_LIMIT    LZFF_NUM_LIMIT
+#define LZFF_NUM_BUCKETS  (LZFF_OFS_LIMIT * 2)
+
+typedef struct {
+  vwadwr_uint sptr;
+  vwadwr_uint bytes4;
+  vwadwr_uint prev;
+} LZFFHashEntry;
+
+
+//==========================================================================
+//
+//  CompressLZFF3
+//
+//==========================================================================
+static int CompressLZFF3 (vwadwr_memman *mman, const void *source, int srclen,
+                          void *dest, int dstlen,
+                          vwadwr_bool allow_lazy)
+{
+  vwadwr_uint bestofs, bestlen, he, b4, lp, wr;
+  vwadwr_uint mmax, mlen, cpp, pos;
+  vwadwr_uint mtbestofs, mtbestlen;
+  vwadwr_uint ssizemax;
+  vwadwr_uint srcsize;
+  vwadwr_uint litcount, litpos, spos;
+  vwadwr_uint hfree, heidx, ntidx;
+  vwadwr_uint dict[LZFF_HASH_SIZE];
+  const vwadwr_ubyte *src;
+  EntEncoder enc;
+  BytePPM ppmData;
+  WordPPM ppmMtOfs, ppmMtLen, ppmLitLen;
+  BitPPM ppmLitFlag;
+  LZFFHashEntry *htbl;
+
+  #define FlushLit()  do { \
+    lp = litpos; \
+    while (litcount != 0) { \
+      BitPPMEncode(&ppmLitFlag, &enc, int_true); \
+      wr = litcount; if (wr > LZFF_NUM_LIMIT) wr = LZFF_NUM_LIMIT; \
+      litcount -= wr; \
+      WordPPMEncodeInt(&ppmLitLen, &enc, wr - 1); \
+      while (wr != 0) { \
+        BytePPMEncodeByte(&ppmData, &enc, src[lp]); \
+        lp += 1; wr -= 1; \
+      } \
+    } \
+  } while (0)
+
+  // repopulate hash buckets; this helps with huge files
+  #define Rehash()  do { \
+    memset(dict, -1, sizeof(dict)); \
+    hfree = 0; \
+    pos = (spos > LZFF_OFS_LIMIT + 1 ? spos - LZFF_OFS_LIMIT - 1 : 0); \
+    if (pos >= spos) vwad__builtin_trap(); \
+    b4 = \
+      (vwadwr_uint)(src[pos]) + \
+      ((vwadwr_uint)(src[pos + 1]) << 8) + \
+      ((vwadwr_uint)(src[pos + 2]) << 16) + \
+      ((vwadwr_uint)(src[pos + 3]) << 24); \
+    do { \
+      heidx = (b4 * 0x9E3779B1u) % LZFF_HASH_SIZE; \
+      he = dict[heidx]; \
+      ntidx = hfree++; \
+      htbl[ntidx].sptr = pos; \
+      htbl[ntidx].bytes4 = b4; \
+      htbl[ntidx].prev = he; \
+      dict[heidx] = ntidx; \
+      ++pos; \
+      /* update bytes */ \
+      b4 = (b4 >> 8) + ((vwadwr_uint)src[pos + 3] << 24); \
+    } while (pos != spos); \
+  } while (0)
+
+  #define AddHashAt()  do { \
+    if (hfree == LZFF_NUM_BUCKETS) Rehash(); \
+    b4 = \
+      (vwadwr_uint)(src[spos]) + \
+      ((vwadwr_uint)(src[spos + 1]) << 8) + \
+      ((vwadwr_uint)(src[spos + 2]) << 16) + \
+      ((vwadwr_uint)(src[spos + 3]) << 24); \
+    heidx = (b4 * 0x9E3779B1u) % LZFF_HASH_SIZE; \
+    he = dict[heidx]; \
+    ntidx = hfree++; \
+    htbl[ntidx].sptr = spos; \
+    htbl[ntidx].bytes4 = b4; \
+    htbl[ntidx].prev = he; \
+    dict[heidx] = ntidx; \
+    /*return he;*/ \
+  } while (0)
+
+  //void FindMatch (uint32_t *pbestofs, uint32_t *pbestlen)
+  #define FindMatch(pbestofs, pbestlen)  do { \
+    mtbestofs = 0; mtbestlen = 3; /* we want matches of at least 4 bytes */ \
+    ssizemax = srcsize - spos; \
+    AddHashAt(); \
+    while (he != ~0) { \
+      cpp = htbl[he].sptr; \
+      if (spos - cpp > LZFF_OFS_LIMIT) he = ~0; \
+      else { \
+        mmax = srcsize - spos; \
+        if (ssizemax < mmax) mmax = ssizemax; \
+        if (LZFF_OFS_LIMIT < mmax) mmax = LZFF_OFS_LIMIT; \
+        if (mmax > mtbestlen && htbl[he].bytes4 == b4) { \
+          /* fast reject based on the last byte */ \
+          if (mtbestlen == 3 || src[spos + mtbestlen] == src[cpp + mtbestlen]) { \
+            /* yet another fast reject */ \
+            if (mtbestlen <= 4 || \
+                (src[spos + (mtbestlen>>1)] == src[cpp + (mtbestlen>>1)] && \
+                 (mtbestlen < 8 || src[spos + mtbestlen - 1] == src[cpp + mtbestlen - 1]))) \
+            { \
+              mlen = 4; \
+              while (mlen < mmax && src[spos + mlen] == src[cpp + mlen]) ++mlen; \
+              if (mlen > mtbestlen) { \
+                mtbestofs = spos - cpp; \
+                mtbestlen = mlen; \
+              } \
+            } \
+          } \
+        } \
+        he = htbl[he].prev; \
+      } \
+    } \
+    pbestofs = mtbestofs; pbestlen = mtbestlen; \
+  } while (0)
+
+
+  if (srclen < 1 || srclen > 0x3fffffff) return VWADWR_ERR_ARGS;
+  if (dstlen < 1 || dstlen > 0x3fffffff) return VWADWR_ERR_ARGS;
+
+  src = (const vwadwr_ubyte *)source;
+  srcsize = (vwadwr_uint)srclen;
+
+  memset(dict, -1, sizeof(dict));
+  htbl = xalloc(mman, (vwadwr_uint)sizeof(htbl[0]) * LZFF_NUM_BUCKETS);
+  if (htbl == NULL) return VWADWR_ERR_MEM;
+  hfree = 0;
+
+  BytePPMInit(&ppmData);
+  WordPPMInit(&ppmMtOfs);
+  WordPPMInit(&ppmMtLen);
+  WordPPMInit(&ppmLitLen);
+  BitPPMInit(&ppmLitFlag, 1);
+
+  EncInit(&enc, dest, (vwadwr_uint)dstlen);
+
+  litpos = 0;
+  if (srcsize <= 6) {
+    // don't even bother trying
+    litcount = srcsize;
+  } else {
+    // first byte is always a literal
+    litcount = 1;
+    spos = 1;
+    while (spos < srcsize - 3) {
+      FindMatch(bestofs, bestlen);
+      //ProgReport();
+      if (bestofs == 0) {
+        if (litcount == 0) litpos = spos;
+        ++litcount;
+        ++spos;
+      } else {
+        // try match with the next char
+        vwadwr_uint xdiff;
+        if (allow_lazy && spos < srcsize - 4) {
+          xdiff = 2;
+          int doagain;
+          do {
+            vwadwr_uint bestofs1, bestlen1;
+            spos += 1; FindMatch(bestofs1, bestlen1);
+            if (bestlen1 >= bestlen + 2) {
+              if (litcount == 0) litpos = spos - 1;
+              ++litcount;
+              bestofs = bestofs1; bestlen = bestlen1;
+              doagain = (spos != srcsize - 3);
+            } else {
+              doagain = 0;
+            }
+          } while (doagain);
+        } else {
+          xdiff = 1;
+        }
+        if (litcount) FlushLit();
+        BitPPMEncode(&ppmLitFlag, &enc, int_false);
+        WordPPMEncodeInt(&ppmMtLen, &enc, bestlen - 3);
+        WordPPMEncodeInt(&ppmMtOfs, &enc, bestofs - 1);
+        spos += 1; bestlen -= xdiff;
+        if (spos + bestlen < srcsize - 3) {
+          while (bestlen != 0) {
+            bestlen -= 1;
+            AddHashAt();
+            spos += 1;
+          }
+        } else {
+          spos += bestlen;
+        }
+        if (enc.dpos >= 0x7fff0000) spos = srcsize;
+      }
+    }
+    // last bytes as literals
+    if (litcount == 0) litpos = spos;
+    litcount += srcsize - spos;
+  }
+
+  if (enc.dpos < 0x7fff0000) FlushLit();
+  EncFlush(&enc);
+
+  xfree(mman, htbl);
+
+  return (enc.dpos < 0x7fff0000 ? enc.dpos : VWADWR_ERR_FILE_TOO_BIG);
+}
+
+
+//==========================================================================
+//
+//  CompressLZFF3LitOnly
+//
+//==========================================================================
+static int CompressLZFF3LitOnly (const void *source, int srclen, void *dest, int dstlen) {
+  int srcsize;
+  int litcount;
+  const vwadwr_ubyte *src;
+  EntEncoder enc;
+  BytePPM ppmData;
+  WordPPM ppmLitLen;
+  BitPPM ppmLitFlag;
+
+  if (srclen < 1 || srclen > 0x3fffffff) return VWADWR_ERR_ARGS;
+  if (dstlen < 1 || dstlen > 0x3fffffff) return VWADWR_ERR_ARGS;
+
+  src = (const vwadwr_ubyte *)source;
+  srcsize = (vwadwr_uint)srclen;
+
+  BytePPMInit(&ppmData);
+  WordPPMInit(&ppmLitLen);
+  BitPPMInit(&ppmLitFlag, 1);
+
+  EncInit(&enc, dest, (vwadwr_uint)dstlen);
+
+  litcount = srcsize;
+
+  int lp = 0;
+  while (litcount != 0) {
+    BitPPMEncode(&ppmLitFlag, &enc, int_true);
+    int wr = litcount; if (wr > LZFF_NUM_LIMIT) wr = LZFF_NUM_LIMIT;
+    litcount -= wr;
+    WordPPMEncodeInt(&ppmLitLen, &enc, wr - 1);
+    while (wr != 0) {
+      BytePPMEncodeByte(&ppmData, &enc, src[lp]);
+      lp += 1; wr -= 1;
+      if ((wr&0x3ff) == 0 && enc.dpos >= 0x7fff0000) { litcount = 0; wr = 0; }
+    }
+  }
+
+  EncFlush(&enc);
+
+  return (enc.dpos < 0x7fff0000 ? enc.dpos : VWADWR_ERR_FILE_TOO_BIG);
+}
+
+
+//==========================================================================
+//
+//  DecompressLZFF3
+//
+//==========================================================================
+#ifdef VWAD_COMPILE_DECOMPRESSOR
+static VWAD_OKUNUSED intbool_t DecompressLZFF3 (const void *src, int srclen,
+                                                void *dest, int unpsize)
+{
+  intbool_t error;
+  EntDecoder dec;
+  BytePPM ppmData;
+  WordPPM ppmMtOfs, ppmMtLen, ppmLitLen;
+  BitPPM ppmLitFlag;
+  int litcount, n;
+  vwadwr_uint dictpos, spos;
+
+  #define PutByte(bt_)  do { \
+    if (unpsize != 0) { \
+      ((vwadwr_ubyte *)dest)[dictpos++] = (vwadwr_ubyte)(bt_); unpsize -= 1; \
+    } else { \
+      error = int_true; \
+    } \
+  } while (0)
+
+  if (srclen < 1 || srclen > 0x3fffffff) return 0;
+  if (unpsize < 1 || unpsize > 0x3fffffff) return 0;
+
+  error = int_false;
+  dictpos = 0;
+
+  BytePPMInit(&ppmData);
+  WordPPMInit(&ppmMtOfs);
+  WordPPMInit(&ppmMtLen);
+  WordPPMInit(&ppmLitLen);
+  BitPPMInit(&ppmLitFlag, 1);
+
+  DecInit(&dec, src, srclen);
+
+  if (!BitPPMDecode(&ppmLitFlag, &dec)) error = int_true;
+  else {
+    vwadwr_ubyte sch;
+    int len, ofs;
+
+    litcount = WordPPMDecodeInt(&ppmLitLen, &dec) + 1;
+    while (!error && litcount != 0) {
+      litcount -= 1;
+      n = BytePPMDecodeByte(&ppmData, &dec);
+      PutByte((vwadwr_ubyte)n);
+      error = error || (dec.spos > dec.send);
+    }
+
+    while (!error && unpsize != 0) {
+      if (BitPPMDecode(&ppmLitFlag, &dec)) {
+        litcount = WordPPMDecodeInt(&ppmLitLen, &dec) + 1;
+        while (!error && litcount != 0) {
+          litcount -= 1;
+          n = BytePPMDecodeByte(&ppmData, &dec);
+          PutByte((vwadwr_ubyte)n);
+          error = error || (dec.spos > dec.send);
+        }
+      } else {
+        len = WordPPMDecodeInt(&ppmMtLen, &dec) + 3;
+        ofs = WordPPMDecodeInt(&ppmMtOfs, &dec) + 1;
+        error = error || (dec.spos > dec.send) || (len > unpsize) || (ofs > dictpos);
+        if (!error) {
+          spos = dictpos - ofs;
+          while (!error && len != 0) {
+            len -= 1;
+            sch = ((const vwadwr_ubyte *)dest)[spos];
+            spos++;
+            PutByte(sch);
+          }
+        }
+      }
+    }
+  }
+
+  return (!error && unpsize == 0);
+}
+#endif
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static vwadwr_result ioseek (vwadwr_iostream *strm, int pos) {
+  FILE *fl = (FILE *)strm->udata;
+  if (fseek(fl, pos, SEEK_SET) == 0) return 0;
+  return -1;
+}
+
+static int iotell (vwadwr_iostream *strm) {
+  FILE *fl = (FILE *)strm->udata;
+  const long pos = ftell(fl);
+  if (pos < 0 || pos >= 0x7ffffff0) return -1;
+  return (int)pos;
+}
+
+static int ioread (vwadwr_iostream *strm, void *buf, int bufsize) {
+  FILE *fl = (FILE *)strm->udata;
+  return (int)fread(buf, 1, bufsize, fl);
+}
+
+static vwadwr_result iowrite (vwadwr_iostream *strm, const void *buf, int bufsize) {
+  FILE *fl = (FILE *)strm->udata;
+  if (fwrite(buf, bufsize, 1, fl) != 1) return -1;
+  return 0;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_new_file_stream
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_iostream *vwadwr_new_file_stream (FILE *fl) {
+  vassert(fl != NULL);
+  vwadwr_iostream *res = calloc(1, sizeof(vwadwr_iostream));
+  res->seek = ioseek;
+  res->tell = iotell;
+  res->read = ioread;
+  res->write = iowrite;
+  res->udata = fl;
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_close_file_stream
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_close_file_stream (vwadwr_iostream *strm) {
+  vwadwr_result res = 0;
+  if (strm) {
+    if (strm->udata) {
+      if (fclose((FILE *)strm->udata) != 0) res = -1;
+    }
+    free(strm);
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_free_file_stream
+//
+//==========================================================================
+VWADWR_PUBLIC void vwadwr_free_file_stream (vwadwr_iostream *strm) {
+  if (strm) {
+    free(strm);
+  }
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+VWADWR_PUBLIC vwadwr_uint vwadwr_crc32_init (void) { return crc32_init; }
+VWADWR_PUBLIC vwadwr_uint vwadwr_crc32_part (vwadwr_uint crc32, const void *src, vwadwr_uint len) { return crc32_part(crc32, src, len); }
+VWADWR_PUBLIC vwadwr_uint vwadwr_crc32_final (vwadwr_uint crc32) { return crc32_final(crc32); }
+
+
+//==========================================================================
+//
+//  is_uni_printable
+//
+//  is the given codepoint considered printable?
+//  i restrict it to some useful subset.
+//  unifuck is unifucked, but i hope that i sorted out all
+//  idiotic diactritics and control chars.
+//
+//==========================================================================
+static CC25519_INLINE vwadwr_bool is_uni_printable (vwadwr_ushort ch) {
+  return
+    ch == 0x09 || ch == 0x0A || // allow tabs and newlines control chars only
+    (ch >= 0x0020 && ch <= 0x7E) || // ASCII, without 0x7F
+    (ch >= 0x0080 && ch <= 0x024F) || // basic latin
+    (ch >= 0x0390 && ch <= 0x0482) || // some greek, and cyrillic w/o combiners
+    (ch >= 0x048A && ch <= 0x052F) || // more slavic
+    (ch >= 0x1E00 && ch <= 0x1EFF) || // latin extended additional
+    (ch >= 0x2000 && ch <= 0x2C7F) || // some general punctuation, extensions, etc.
+    (ch >= 0x2E00 && ch <= 0x2E42) || // supplemental punctuation
+    (ch >= 0xAB30 && ch <= 0xAB65);   // more latin extended
+}
+
+
+//==========================================================================
+//
+//  utf_char_len
+//
+//  determine utf-8 sequence length (in bytes) by its first char.
+//  returns length (up to 4) or 0 on invalid first char
+//  doesn't allow overlongs
+//
+//==========================================================================
+static CC25519_INLINE vwadwr_uint utf_char_len (const void *str) {
+  const vwadwr_ubyte ch = *((const vwadwr_ubyte *)str);
+  if (ch < 0x80) return 1;
+  else if ((ch&0x0E0) == 0x0C0) return (ch != 0x0C0 && ch != 0x0C1 ? 2 : 0);
+  else if ((ch&0x0F0) == 0x0E0) return 3;
+  else if ((ch&0x0F8) == 0x0F0) return 4;
+  else return 0;
+}
+
+
+//==========================================================================
+//
+//  utf_decode
+//
+//==========================================================================
+static CC25519_INLINE vwadwr_ushort utf_decode (const char **strp) {
+  const vwadwr_ubyte *bp = (const vwadwr_ubyte *)*strp;
+  vwadwr_ushort res = (vwadwr_ushort)utf_char_len(bp);
+  vwadwr_ubyte ch = *bp;
+  if (res < 1 || res > 3) {
+    res = VWADWR_REPLACEMENT_CHAR;
+    *strp += 1;
+  } else if (ch < 0x80) {
+    res = ch;
+    *strp += 1;
+  } else if ((ch&0x0E0) == 0x0C0) {
+    if (ch == 0x0C0 || ch == 0x0C1) {
+      res = VWADWR_REPLACEMENT_CHAR;
+      *strp += 1;
+    } else {
+      res = ch - 0x0C0;
+      ch = bp[1];
+      if ((ch&0x0C0) != 0x80) {
+        res = VWADWR_REPLACEMENT_CHAR;
+        *strp += 1;
+      } else {
+        res = res * 64 + ch - 128;
+        *strp += 2;
+      }
+    }
+  } else if ((ch&0x0F0) == 0x0E0) {
+    res = ch - 0x0E0;
+    ch = bp[1];
+    if ((ch&0x0C0) != 0x80) {
+      res = VWADWR_REPLACEMENT_CHAR;
+      *strp += 1;
+    } else {
+      res = res * 64 + ch - 128;
+      ch = bp[2];
+      if ((ch&0x0C0) != 0x80) {
+        res = VWADWR_REPLACEMENT_CHAR;
+        *strp += 1;
+      } else {
+        res = res * 64 + ch - 128;
+        *strp += 3;
+      }
+    }
+  } else {
+    res = VWADWR_REPLACEMENT_CHAR;
+  }
+  if (res && !is_uni_printable(res)) res = VWADWR_REPLACEMENT_CHAR;
+  return res;
+}
+
+
+//==========================================================================
+//
+//  unilower
+//
+//==========================================================================
+static CC25519_INLINE vwadwr_ushort unilower (vwadwr_ushort ch) {
+  if ((ch >= 'A' && ch <= 'Z') ||
+      (ch >= 0x00C0 && ch <= 0x00D6) ||
+      (ch >= 0x00D8 && ch <= 0x00DE) ||
+      (ch >= 0x0410 && ch <= 0x042F))
+  {
+    return ch + 0x20;
+  }
+  if (ch == 0x0178) return 0x00FF;
+  if (ch >= 0x0400 && ch <= 0x040F) return ch + 0x50;
+  if ((ch >= 0x1E00 && ch <= 0x1E95) ||
+      (ch >= 0x1EA0 && ch <= 0x1EFF))
+  {
+    return ch|0x01;
+  }
+  if (ch == 0x1E9E) return 0x00DF;
+  return ch;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_utf_char_len
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_uint vwadwr_utf_char_len (const void *str) {
+  return (str ? utf_char_len(str) : 0);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_is_uni_printable
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_bool vwadwr_is_uni_printable (vwadwr_ushort ch) {
+  return is_uni_printable(ch);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_utf_decode
+//
+//  advances `strp` at least by one byte
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_ushort vwadwr_utf_decode (const char **strp) {
+  return (strp ? utf_decode(strp) : VWADWR_REPLACEMENT_CHAR);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_uni_tolower
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_ushort vwadwr_uni_tolower (vwadwr_ushort ch) {
+  return unilower(ch);
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static vwadwr_uint joaatHashStrCI (const char *key) {
+  #define JOAAT_MIX(b_)  do { \
+    hash += (vwadwr_ubyte)(b_); \
+    hash += hash<<10; \
+    hash ^= hash>>6; \
+  } while (0)
+
+  vwadwr_uint hash = 0x29a;
+  vwadwr_uint len = 0;
+  while (*key) {
+    vwadwr_ushort ch = unilower(utf_decode(&key));
+    JOAAT_MIX(ch);
+    if (ch >= 0x100) JOAAT_MIX(ch>>8);
+    ++len;
+  }
+  // mix length (it should not be greater than 255)
+  JOAAT_MIX(len);
+  // finalize
+  hash += hash<<3;
+  hash ^= hash>>11;
+  hash += hash<<15;
+  return hash;
+}
+
+#define hashStrCI joaatHashStrCI
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+static vwadwr_bool strEquCI (const char *s0, const char *s1) {
+  if (!s0 || !s1) return 0;
+  vwadwr_ushort c0 = unilower(utf_decode(&s0));
+  vwadwr_ushort c1 = unilower(utf_decode(&s1));
+  while (c0 != 0 && c1 != 0&& c0 == c1) {
+    if (c0 == VWADWR_REPLACEMENT_CHAR || c1 == VWADWR_REPLACEMENT_CHAR) return 0;
+    c0 = unilower(utf_decode(&s0));
+    c1 = unilower(utf_decode(&s1));
+  }
+  return (c0 == 0 && c1 == 0);
+}
+
+
+//==========================================================================
+//
+//  is_path_delim
+//
+//==========================================================================
+static CC25519_INLINE int is_path_delim (char ch) {
+  #ifdef WIN32
+  return (ch == '\\' || ch == '/');
+  #else
+  return (ch == '/');
+  #endif
+}
+
+
+//==========================================================================
+//
+//  normalize_name
+//
+//==========================================================================
+static char *normalize_name (vwadwr_memman *mman, const char *s) {
+  if (s == NULL) return NULL;
+  for (;;) {
+    if (is_path_delim(s[0])) s += 1;
+    else if (s[0] == '.' && is_path_delim(s[1])) s += 2;
+    else break;
+  }
+  if (!s[0]) return NULL;
+  if (s[0] == '.' && s[1] == 0) return NULL;
+  if (s[0] == '.' && s[1] == '.' && (s[2] == 0 || is_path_delim(s[2]))) return NULL;
+  for (const char *t = s; *t; ++t) {
+    if (is_path_delim(*t)) {
+      if (t[1] == '.' && t[2] == '.' && (t[3] == 0 || is_path_delim(t[3]))) return NULL;
+    } else if (*t == 0x7f || (*t > 0 && *t < 32)) {
+      return NULL;
+    }
+  }
+  vwadwr_uint rlen = 0;
+  while (rlen <= 4096 && s[rlen] != 0) ++rlen;
+  if (rlen == 0 || rlen > 4096 || is_path_delim(s[rlen - 1])) return NULL;
+  char *res = zalloc(mman, rlen + 1);
+  if (res == NULL) return NULL;
+  vwadwr_uint dpos = 0;
+  for (vwadwr_uint f = 0; f < rlen; f += 1) {
+    char ch = s[f];
+    #ifdef WIN32
+    if (ch == '\\') ch = '/';
+    #endif
+    if (ch == '/') {
+      if (dpos == 0 || res[dpos - 1] == '/') continue;
+    }
+    res[dpos++] = ch;
+  }
+  if (dpos == 0 || res[dpos - 1] == '/') { xfree(mman, res); return NULL; }
+  vassert(dpos <= rlen);
+  res[dpos] = 0;
+  return res;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#define HASH_BUCKETS     (1024u)
+#define CHUNK_PAGE_SIZE  (32768u)
+
+#define CHUNK_PG_MAX     ((CHUNK_PAGE_SIZE/2u)-(unsigned)sizeof(void *))
+
+typedef struct ChunkPage_t ChunkPage;
+struct ChunkPage_t {
+  vwadwr_ushort pksize[CHUNK_PG_MAX];  // packed chunk size (0 means "unpacked")
+  ChunkPage *next;
+};
+
+
+typedef struct GroupName_t GroupName;
+struct GroupName_t {
+  vwadwr_uint gnameofs; // !0: this group already registered
+  char *name;
+  GroupName *next;
+};
+
+typedef struct FileName_t FileName;
+struct FileName_t {
+  vwadwr_uint nameofs;
+  char *name; // dynamically allocated
+};
+
+typedef struct ChunkFAT_t ChunkFAT;
+struct ChunkFAT_t {
+  vwadwr_uint findex; // index of the first chunk
+  vwadwr_uint ccount; // number of consecutive chunks
+  ChunkFAT *next;     // next chunk in FAT list
+};
+
+// `FileInfo` flags
+// compression level, decoded
+#define FI_ALLOW_LZ       (1u<<0)
+#define FI_ALLOW_LITONLY  (1u<<1)
+#define FI_ALLOW_LAZY     (1u<<2)
+#define FI_SEGMENTED      (1u<<3)
+#define FI_RAW            (1u<<4)
+#define FI_FLUSHED        (1u<<5)
+
+typedef struct FileInfo_t FileInfo;
+struct FileInfo_t {
+  vwadwr_fhandle fd;      // used in opened files list; -1 for finished files
+  vwadwr_uint upksize;    // unpacked file size (current or final)
+  vwadwr_uint pksize;     // unpacked file size (current or final)
+  vwadwr_uint chunkCount; // chunk count
+  vwadwr_uint nhash;      // name hash
+  vwadwr_uint crc32;      // full crc32
+  vwadwr_uint64 ftime;    // file time since Epoch
+  FileInfo *bknext;       // next name in bucket
+  FileName *fname;        // owned by this record
+  GroupName *group;       // points to some struct in dir, i.e. not owned by this record
+  ChunkFAT *fatHead;      // FAT table
+  ChunkFAT *fatTail;      // FAT table
+  vwadwr_uint flags;      // see `FI_xxx` constants
+  vwadwr_uint wrpos;      // position in `wrchunk`
+  //char wrchunk[65536];    // buffered data for the current chunk
+  FileInfo *next;
+  char *wrchunkPtr;    // buffered data for the current chunk; 65536 bytes
+};
+
+
+vwad_push_pack
+typedef struct vwad_packed_struct {
+  vwadwr_uint crc32;
+  vwadwr_ushort version;
+  vwadwr_ushort flags;
+  vwadwr_uint dirofs;
+  vwadwr_ushort u_cmt_size;
+  vwadwr_ushort p_cmt_size;
+  vwadwr_uint cmt_crc32;
+} MainFileHeader;
+vwad_pop_pack
+
+
+struct vwadwr_archive_t {
+  vwadwr_memman *mman;
+  vwadwr_iostream *outstrm;
+  ed25519_secret_key privkey;
+  vwadwr_bool has_privkey;
+  ed25519_public_key pubkey; // this is also chacha20 key
+  MainFileHeader mhdr;
+  ChunkPage *chunkPagesHead;
+  ChunkPage *chunkPagesTail;
+  GroupName *groupNames;
+  vwadwr_uint xorRndSeed;
+  vwadwr_uint xorRndSeedPK;
+  vwadwr_uint chunkCount; // number of used elements in `chunks` array
+  // finished files
+  FileInfo *filesHead;
+  FileInfo *filesTail;
+  vwadwr_uint fileCount;
+  vwadwr_uint namesSize;
+  // file writing API
+  FileInfo *openedFiles; // list of currently opened files
+  vwadwr_fhandle lastUsedFD;
+  // directory hash table, for duplicate name checks
+  FileInfo *buckets[HASH_BUCKETS];
+  char author[256];
+  char title[256];
+  // two chunk comression buffers (data and CRC32)
+  // we can keep them here, because chunk writing is serialised
+  char pkbuf0[65536 + 4];
+  char pkbuf1[65536 + 4];
+};
+
+
+//==========================================================================
+//
+//  is_valid_file_name
+//
+//==========================================================================
+static vwadwr_bool is_valid_file_name (const char *str) {
+  if (!str || !str[0] || str[0] == '/') return 0;
+  vwadwr_uint slen = 0;
+  while (slen <= 255 && str[slen] != 0) slen += 1;
+  if (slen > 255) return 0; // too long
+  if (str[slen - 1] == '/') return 0; // should not end with a slash
+  // check chars
+  vwadwr_ushort ch;
+  do { ch = utf_decode(&str); } while (ch >= 32 && ch != VWADWR_REPLACEMENT_CHAR);
+  return (ch == 0);
+}
+
+
+//==========================================================================
+//
+//  is_valid_string
+//
+//==========================================================================
+static vwadwr_bool is_valid_string (const char *cmt, int maxlen, vwadwr_bool oneline) {
+  vwadwr_bool res = 1;
+  if (cmt != NULL) {
+    const char *cmtstart = cmt;
+    while (res) {
+      const vwadwr_ushort ch = utf_decode(&cmt);
+      if ((size_t)(cmt - cmtstart) > (size_t)maxlen + 1) res = 0;
+      else if (ch == 0) break;
+      else if (ch == VWADWR_REPLACEMENT_CHAR) res = 0;
+      else if (oneline) {
+        if (ch < 32) res = 0;
+      } else {
+        if (ch < 32 && ch != 9 && ch != 10) res = 0;
+      }
+    }
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_free_finfo
+//
+//==========================================================================
+static void vwadwr_free_finfo (vwadwr_memman *mman, FileInfo *fi) {
+  while (fi->fatHead != NULL) {
+    ChunkFAT *fat = fi->fatHead;
+    fi->fatHead = fat->next;
+    xfree(mman, fat);
+  }
+  xfree(mman, fi->fname->name);
+  xfree(mman, fi->fname);
+  xfree(mman, fi);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_free_archive_memory
+//
+//==========================================================================
+static void vwadwr_free_archive_memory (vwadwr_archive *wad) {
+  vassert(wad);
+  vwadwr_memman *mman = wad->mman;
+  ChunkPage *ci = wad->chunkPagesHead;
+  while (ci != NULL) {
+    ChunkPage *cx = ci; ci = ci->next;
+    xfree(mman, cx);
+  }
+  FileInfo *fi = wad->filesHead;
+  while (fi != NULL) {
+    FileInfo *fx = fi; fi = fi->next;
+    vwadwr_free_finfo(mman, fx);
+  }
+  fi = wad->openedFiles;
+  while (fi != NULL) {
+    FileInfo *fx = fi; fi = fi->next;
+    vwadwr_free_finfo(mman, fx);
+  }
+  GroupName *gi = wad->groupNames;
+  while (gi != NULL) {
+    GroupName *fx = gi; gi = gi->next;
+    xfree(mman, fx->name);
+    xfree(mman, fx);
+  }
+  memset(wad, 0, sizeof(vwadwr_archive));
+  wad->mman = mman; // we will need it later
+}
+
+
+//==========================================================================
+//
+//  set_error
+//
+//==========================================================================
+static CC25519_INLINE void set_error (vwadwr_archive *wad) {
+  if (wad && wad->outstrm) vwadwr_free_archive_memory(wad);
+}
+
+
+//==========================================================================
+//
+//  is_error
+//
+//==========================================================================
+static CC25519_INLINE vwadwr_bool is_error (const vwadwr_archive *wad) {
+  return (!wad || !wad->outstrm);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_is_error
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_bool vwadwr_is_error (const vwadwr_archive *wad) {
+  return is_error(wad);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_free_archive
+//
+//==========================================================================
+VWADWR_PUBLIC void vwadwr_free_archive (vwadwr_archive **wadp) {
+  if (wadp) {
+    vwadwr_archive *wad = *wadp;
+    if (wad) {
+      *wadp = NULL;
+      vwadwr_memman *mman = wad->mman;
+      vwadwr_free_archive_memory(wad);
+      xfree(mman, wad);
+    }
+  }
+}
+
+
+//==========================================================================
+//
+//  check_privkey
+//
+//==========================================================================
+static vwadwr_bool check_privkey (const vwadwr_secret_key privkey) {
+  int zcount = 0, ocount = 0;
+  for (vwadwr_uint f = 0; f < (vwadwr_uint)sizeof(vwadwr_secret_key); f += 1) {
+    switch (privkey[f]) {
+      case 0: ++zcount; break;
+      case 1: ++ocount; break;
+    }
+  }
+  if (zcount > 2 || ocount > 2) return 0;
+  for (vwadwr_uint f = 0; f < (vwadwr_uint)sizeof(vwadwr_secret_key) - 1u; f += 1) {
+    const vwadwr_ubyte v = privkey[f];
+    int count = 0;
+    for (vwadwr_uint c = f + 1u; c < (vwadwr_uint)sizeof(vwadwr_secret_key); c += 1) {
+      if (privkey[c] == v) {
+        if (++count > 3) return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_is_good_privkey
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_bool vwadwr_is_good_privkey (const vwadwr_secret_key privkey) {
+  return (privkey != NULL && check_privkey(privkey));
+}
+
+
+//==========================================================================
+//
+//  vwadwr_new_archive
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_archive *vwadwr_new_archive (
+                                    vwadwr_memman *mman, vwadwr_iostream *outstrm,
+                                    const char *author, /* can be NULL */
+                                    const char *title, /* can be NULL */
+                                    const char *comment, /* can be NULL */
+                                    vwadwr_uint flags,
+                                    const vwadwr_secret_key privkey,
+                                    vwadwr_public_key respubkey, /* OUT; can be NULL */
+                                    int *error) /* OUT; can be NULL */
+{
+  vwadwr_archive *res;
+  int xerr = 0;
+  if (error == NULL) error = &xerr; // to avoid endless checks
+  if (respubkey) memset(respubkey, 0, sizeof(ed25519_public_key));
+  if (outstrm == NULL) { *error = VWADWR_ERR_OTHER; return NULL; }
+  if (privkey == NULL) { *error = VWADWR_ERR_PRIVKEY; return NULL; }
+  if (!check_privkey(privkey)) { *error = VWADWR_ERR_PRIVKEY; return NULL; }
+  if (!is_valid_string(author, 127, 1)) { *error = VWADWR_ERR_AUTHOR; return NULL; }
+  if (!is_valid_string(title, 127, 1)) { *error = VWADWR_ERR_TITLE; return NULL; }
+  if (!is_valid_string(comment, 65535, 0)) { *error = VWADWR_ERR_COMMENT; return NULL; }
+  if ((flags & ~VWADWR_NEW_DONT_SIGN) != 0) { *error = VWADWR_ERR_FLAGS; return NULL; }
+  *error = VWADWR_ERR_OTHER;
+
+  res = zalloc(mman, (vwadwr_uint)sizeof(vwadwr_archive));
+  if (res == NULL) return NULL;
+
+  res->mman = mman;
+  res->outstrm = outstrm;
+  res->namesSize = 4; // first string is always empty
+  res->fileCount = 0;
+
+  // public key
+  logf(NOTE, "generating public key");
+  ed25519_public_key pubkey;
+  edsign_sec_to_pub(pubkey, privkey);
+  if (respubkey) memcpy(respubkey, pubkey, sizeof(ed25519_public_key));
+  memcpy(res->pubkey, pubkey, 32);
+  memcpy(res->privkey, privkey, 32);
+
+  if ((flags & VWADWR_NEW_DONT_SIGN) == 0) {
+    res->has_privkey = 1;
+  } else {
+    res->has_privkey = 0;
+  }
+
+  // write header
+  if (outstrm->seek(outstrm, 0) != 0) {
+    logf(ERROR, "cannot seek to start");
+    goto error;
+  }
+  if (outstrm->write(outstrm, "VWAD", 4) != VWADWR_OK) {
+    logf(ERROR, "cannot write sign");
+    goto error;
+  }
+
+  // signature is random bytes for now
+  ed25519_signature edsign;
+  memset(edsign, 0, sizeof(ed25519_signature));
+  // fill dsign with giberish
+  crypt_buffer(deriveSeed(0xa28, res->pubkey, (vwadwr_uint)sizeof(ed25519_secret_key)),
+               0x29b, edsign, (vwadwr_uint)sizeof(ed25519_signature));
+  if (outstrm->write(outstrm, edsign, (int)sizeof(ed25519_signature)) != VWADWR_OK) {
+    logf(ERROR, "cannot write edsign");
+    goto error;
+  }
+
+  // encrypt public key
+  ed25519_public_key epk;
+  memcpy(epk, res->pubkey, sizeof(ed25519_public_key));
+  crypt_buffer(deriveSeed(0xa29, edsign, (vwadwr_uint)sizeof(ed25519_signature)),
+               0x29a, epk, (vwadwr_uint)sizeof(ed25519_public_key));
+
+  // write public key
+  if (outstrm->write(outstrm, epk, (int)sizeof(ed25519_public_key)) != VWADWR_OK) {
+    logf(ERROR, "cannot write public key");
+    goto error;
+  }
+
+  // write author
+  vwadwr_ubyte asslen = (author != NULL ? (vwadwr_ubyte)strlen(author) : 0u);
+  if (asslen) memcpy(res->author, author, asslen); res->author[asslen] = 0;
+
+  vwadwr_ubyte tsslen = (title != NULL ? (vwadwr_ubyte)strlen(title) : 0u);
+  if (tsslen) memcpy(res->title, title, tsslen); res->title[tsslen] = 0;
+
+  // lengthes
+  if (outstrm->write(outstrm, &asslen, 1) != VWADWR_OK) {
+    logf(ERROR, "cannot write author length");
+    goto error;
+  }
+  if (outstrm->write(outstrm, &tsslen, 1) != VWADWR_OK) {
+    logf(ERROR, "cannot write title length");
+    goto error;
+  }
+
+  const char *newln = "\x0d\x0a\x1b";
+
+  // write author
+  if (outstrm->write(outstrm, newln, 2) != VWADWR_OK) {
+    logf(ERROR, "cannot write author padding");
+    goto error;
+  }
+  if (asslen != 0 && outstrm->write(outstrm, author, (int)asslen) != VWADWR_OK) {
+    logf(ERROR, "cannot write author text");
+    goto error;
+  }
+  // write title
+  if (outstrm->write(outstrm, newln, 2) != VWADWR_OK) {
+    logf(ERROR, "cannot write title padding");
+    goto error;
+  }
+  if (tsslen != 0 && outstrm->write(outstrm, title, (int)tsslen) != VWADWR_OK) {
+    logf(ERROR, "cannot write title text");
+    goto error;
+  }
+  // final
+  if (outstrm->write(outstrm, newln, 4) != VWADWR_OK) {
+    logf(ERROR, "cannot write final padding");
+    goto error;
+  }
+
+  // create initial seed from pubkey, author, and title
+  res->xorRndSeed = deriveSeed(0x29c, res->pubkey, (vwadwr_uint)sizeof(ed25519_public_key));
+  res->xorRndSeed = deriveSeed(res->xorRndSeed, (const vwadwr_ubyte *)author, (int)asslen);
+  res->xorRndSeed = deriveSeed(res->xorRndSeed, (const vwadwr_ubyte *)title, (int)tsslen);
+  // remember it
+  res->xorRndSeedPK = res->xorRndSeed;
+
+  // now create header fields
+  put_u32(&res->mhdr.crc32, 0);
+  put_u16(&res->mhdr.version, 0);
+  vwadwr_ushort archflags = (res->has_privkey ? 0x00 : 0x01);
+  #ifdef VWAD_USE_NAME_LENGTHES
+  archflags |= 0x02;
+  #endif
+  put_u16(&res->mhdr.flags, archflags);
+  // unpacked comment size
+  const vwadwr_uint u_csz = (comment ? (vwadwr_uint)strlen(comment) : 0);
+  vassert(u_csz < 65556);
+  put_u16(&res->mhdr.u_cmt_size, u_csz);
+  // dir offset (unknown for now)
+  put_u32(&res->mhdr.dirofs, 0);
+
+  // compress and write comment
+  if (u_csz) {
+    put_u32(&res->mhdr.cmt_crc32, crc32_buf(comment, u_csz));
+    vwadwr_ubyte *pkc = xalloc(mman, u_csz);
+    if (pkc == NULL) {
+      logf(ERROR, "cannot alloc comment buffer");
+      goto error;
+    }
+    const int pksz1 = CompressLZFF3LitOnly(comment, u_csz, pkc, u_csz);
+    int pksz0 = CompressLZFF3(mman, comment, u_csz, pkc, u_csz, 1/*allow_lazy*/);
+    if (pksz0 == VWADWR_ERR_MEM) { xfree(mman, pkc); goto error; } // out of memory
+    // recompress with "literals only" mode again, if it is better
+    #if 1
+    if (pksz1 > 0 && pksz1 < (int)u_csz && (pksz0 < 1 || pksz0 >= (int)u_csz || pksz1 < pksz0)) {
+      pksz0 = CompressLZFF3LitOnly(comment, u_csz, pkc, u_csz);
+    }
+    #endif
+    if (pksz0 < 1 || pksz0 >= (int)u_csz) {
+      // write uncompressed
+      logf(NOTE, "comment: cannot pack, write uncompressed");
+      put_u16(&res->mhdr.p_cmt_size, 0);
+      if (outstrm->write(outstrm, &res->mhdr, (int)sizeof(res->mhdr)) != VWADWR_OK) {
+        xfree(mman, pkc);
+        goto error;
+      }
+      memcpy(pkc, comment, u_csz);
+      // encrypt comment with pk-seed
+      crypt_buffer(res->xorRndSeedPK, 2, pkc, u_csz);
+      // mix unpacked comment data
+      res->xorRndSeed = deriveSeed(res->xorRndSeed, pkc, u_csz);
+      if (outstrm->write(outstrm, pkc, (int)u_csz) != VWADWR_OK) {
+        xfree(mman, pkc);
+        goto error;
+      }
+    } else {
+      // write compressed
+      logf(NOTE, "comment: packed from %u to %d", u_csz, pksz0);
+      put_u16(&res->mhdr.p_cmt_size, (vwadwr_ushort)pksz0);
+      if (outstrm->write(outstrm, &res->mhdr, (int)sizeof(res->mhdr)) != VWADWR_OK) {
+        xfree(mman, pkc);
+        goto error;
+      }
+      // encrypt comment with pk-seed
+      crypt_buffer(res->xorRndSeedPK, 2, pkc, (vwadwr_uint)pksz0);
+      // mix packed comment data
+      res->xorRndSeed = deriveSeed(res->xorRndSeed, pkc, (vwadwr_uint)pksz0);
+      if (outstrm->write(outstrm, pkc, pksz0) != VWADWR_OK) {
+        xfree(mman, pkc);
+        goto error;
+      }
+    }
+  } else {
+    // still update the seed
+    res->xorRndSeed = deriveSeed(res->xorRndSeed, NULL, 0);
+    // write uncompressed nothing
+    put_u32(&res->mhdr.cmt_crc32, 0);
+    put_u16(&res->mhdr.p_cmt_size, 0);
+    if (outstrm->write(outstrm, &res->mhdr, (int)sizeof(res->mhdr)) != VWADWR_OK) {
+      goto error;
+    }
+  }
+  #if 0
+  logf(DEBUG, "pkseed: 0x%08x", res->xorRndSeedPK);
+  logf(DEBUG, "xnseed: 0x%08x", res->xorRndSeed);
+  #endif
+
+  *error = 0;
+  return res;
+
+error:
+  vwadwr_free_archive(&res);
+  return NULL;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_force_fat
+//
+//  force using FAT table for files.
+//  usually, FAT is created only if we opened more than one file for writing,
+//  and actually wrote some data into both.
+//
+//==========================================================================
+VWADWR_PUBLIC void vwadwr_force_fat (vwadwr_archive *wad) {
+  if (!is_error(wad)) {
+    vwadwr_ushort archflags = get_u16(&wad->mhdr.flags);
+    archflags |= 0x04;
+    put_u16(&wad->mhdr.flags, archflags);
+  }
+}
+
+
+//==========================================================================
+//
+//  vwadwr_is_fat
+//
+//  check if archive will have a FAT table.
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_bool vwadwr_is_fat (vwadwr_archive *wad) {
+  vwadwr_bool res = 0;
+  if (!is_error(wad)) {
+    const vwadwr_ushort archflags = get_u16(&wad->mhdr.flags);
+    res = (archflags&0x04 ? 1 : 0);
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_get_memman
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_memman *vwadwr_get_memman (vwadwr_archive *wad) {
+  return (!is_error(wad) ? wad->mman : NULL);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_get_outstrm
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_iostream *vwadwr_get_outstrm (vwadwr_archive *wad) {
+  return (!is_error(wad) ? wad->outstrm : NULL);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_is_valid_file_name
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_bool vwadwr_is_valid_file_name (const char *str) {
+  return is_valid_file_name(str);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_is_valid_group_name
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_bool vwadwr_is_valid_group_name (const char *str) {
+  return (!str || is_valid_string(str, 255, 1));
+}
+
+
+//==========================================================================
+//
+//  vwadwr_is_valid_comment
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_bool vwadwr_is_valid_comment (const char *str) {
+  return (!str || is_valid_string(str, 65535, 0));
+}
+
+
+//==========================================================================
+//
+//  vwadwr_register_group
+//
+//==========================================================================
+static GroupName *vwadwr_register_group (vwadwr_archive *wad, const char *grpname, int *err) {
+  *err = 0;
+  vassert(grpname != NULL && grpname[0]);
+  GroupName *gi = wad->groupNames;
+  while (gi != NULL && !strEquCI(grpname, gi->name)) gi = gi->next;
+  if (gi == NULL) {
+    const vwadwr_uint slen = (vwadwr_uint)strlen(grpname);
+    gi = zalloc(wad->mman, (vwadwr_uint)sizeof(GroupName));
+    if (gi == NULL) { *err = VWADWR_ERR_MEM; return NULL; }
+    gi->name = zalloc(wad->mman, slen + 1);
+    if (gi->name == NULL) { xfree(wad->mman, gi); *err = VWADWR_ERR_MEM; return NULL; }
+    strcpy(gi->name, grpname);
+    gi->gnameofs = 0; // not registered yet
+    wad->namesSize += slen + 1;
+    // align
+    if (wad->namesSize&0x03) wad->namesSize = (wad->namesSize|0x03)+1;
+    gi->next = wad->groupNames;
+    wad->groupNames = gi;
+  }
+  return gi;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_is_valid_dir
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_bool vwadwr_is_valid_dir (const vwadwr_archive *wad) {
+  return
+    !is_error(wad) &&
+    wad->namesSize >= 8 &&
+    (wad->namesSize&0x03) == 0 &&
+    /*wad->chunkCount > 0 &&*/ wad->chunkCount <= 0x1fffffffU &&
+    /*wad->fileCount > 0 &&*/ wad->fileCount <= 0x00ffffffU;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_check_dir
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_check_dir (const vwadwr_archive *wad) {
+  if (wad == NULL) return VWADWR_ERR_ARGS;
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+  if (wad->namesSize < 8) return VWADWR_ERR_NAMES_SIZE;
+  if ((wad->namesSize&0x03) != 0) return VWADWR_ERR_NAMES_ALIGN;
+  if (/*wad->chunkCount == 0 ||*/ wad->chunkCount > 0x1fffffffU) return VWADWR_ERR_CHUNK_COUNT;
+  if (/*wad->fileCount == 0 ||*/ wad->fileCount > 0x00ffffffU) return VWADWR_ERR_FILE_COUNT;
+  return VWADWR_OK;
+}
+
+
+typedef struct {
+  ChunkFAT *fat;
+  vwadwr_uint cidx; // in current item
+} ChunkIter;
+
+
+//==========================================================================
+//
+//  init_fat_iter
+//
+//==========================================================================
+static CC25519_INLINE void fat_iter_init (ChunkIter *it, ChunkFAT *fatHead) {
+  vassert(it);
+  vassert(!fatHead || fatHead->ccount != 0);
+  it->fat = fatHead;
+  it->cidx = 0;
+}
+
+
+//==========================================================================
+//
+//  fat_iter_next
+//
+//  returns `VWADWR_NO_CHUNKS` if there are no more chunks
+//
+//==========================================================================
+static CC25519_INLINE vwadwr_uint fat_iter_next (ChunkIter *it) {
+  vwadwr_uint res = VWADWR_NO_CHUNKS;
+  vassert(it);
+  if (it->fat) {
+    res = it->fat->findex + it->cidx;
+    it->cidx += 1;
+    if (it->cidx == it->fat->ccount) it->fat = it->fat->next;
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_write_directory
+//
+//==========================================================================
+static vwadwr_result vwadwr_write_directory (vwadwr_archive *wad, vwadwr_iostream *strm,
+                                             const vwadwr_uint dirofs)
+{
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+  if (strm == NULL || strm->write == NULL) return VWADWR_ERR_ARGS;
+  const int dcheck = vwadwr_check_dir(wad);
+  if (dcheck != VWADWR_OK) return dcheck;
+
+  vwadwr_uint fatSize = 0;
+  // calculate FAT size
+  if (vwadwr_is_fat(wad)) {
+    fatSize = wad->chunkCount * 4u;
+    logf(DEBUG, "FAT size: %u", fatSize);
+  }
+
+  // calculate directory size
+  const vwadwr_uint64 dirsz64 = (vwadwr_uint64)wad->namesSize+
+                           4+(vwadwr_uint64)wad->fileCount*VWADWR_FILE_ENTRY_SIZE+
+                           4+(vwadwr_uint64)wad->chunkCount*VWADWR_CHUNK_ENTRY_SIZE+
+                           (vwadwr_uint64)fatSize;
+
+  if (dirsz64 > 0x04000000) {
+    logf(ERROR, "directory too big");
+    return VWADWR_ERR_DIR_TOO_BIG;
+  }
+
+  const vwadwr_uint dirsz = (vwadwr_uint)dirsz64;
+
+  vwadwr_ubyte *fdir = zalloc(wad->mman, dirsz);
+  if (fdir == NULL) {
+    return VWADWR_ERR_MEM;
+  }
+
+  vwadwr_uint nidx;
+
+  // create names table
+  vwadwr_uint namesStart = 4+wad->fileCount*VWADWR_FILE_ENTRY_SIZE +
+                           4+wad->chunkCount*VWADWR_CHUNK_ENTRY_SIZE;
+  vwadwr_uint fdirofs = 0;
+  const vwadwr_uint z32 = 0;
+  const vwadwr_ushort z16 = 0;
+
+  vwadwr_uint *fatPtr = NULL;
+  if (fatSize) {
+    // use allocated directory to put FAT entries
+    fatPtr = (vwadwr_uint *)(fdir + namesStart);
+    namesStart += fatSize;
+  }
+
+  // put counters
+  put_u32(fdir + fdirofs, wad->chunkCount); fdirofs += 4;
+  put_u32(fdir + fdirofs, wad->fileCount); fdirofs += 4;
+
+  // put chunks
+  vwadwr_uint cwleft = wad->chunkCount;
+  for (ChunkPage *ci = wad->chunkPagesHead; cwleft && ci; ci = ci->next) {
+    vwadwr_uint ccx = 0;
+    while (ccx < CHUNK_PG_MAX && cwleft) {
+      memcpy(fdir + fdirofs, &z32, 4); fdirofs += 4;
+      memcpy(fdir + fdirofs, &z16, 2); fdirofs += 2;
+      put_u16(fdir + fdirofs, ci->pksize[ccx]); fdirofs += 2;
+      ccx += 1;
+      cwleft -= 1;
+    }
+  }
+  vassert(cwleft == 0);
+  vassert(fdirofs = 4+4 + wad->chunkCount*VWADWR_CHUNK_ENTRY_SIZE);
+
+  // build fat table
+  if (fatSize) {
+    // init to impossible value
+    for (vwadwr_uint f = 0; f < wad->chunkCount; f += 1) {
+      fatPtr[f] = 0xfffffffeU;
+    }
+    // fill the table
+    for (FileInfo *fi = wad->filesHead; fi; fi = fi->next) {
+      vwadwr_uint fcc = fi->chunkCount;
+      if (fcc != 0) {
+        ChunkIter it;
+        fat_iter_init(&it, fi->fatHead);
+        vwadwr_uint cc = fat_iter_next(&it);
+        vassert(cc != VWADWR_NO_CHUNKS);
+        do {
+          vwadwr_uint nextcc = fat_iter_next(&it);
+          fatPtr[cc] = nextcc;
+          cc = nextcc;
+          fcc -= 1;
+        } while (cc != VWADWR_NO_CHUNKS);
+        vassert(fcc == 0);
+      }
+    }
+    // convert offsets to deltas, and check the table
+    vwadwr_uint fatPrev = 0;
+    for (vwadwr_uint f = 0; f < wad->chunkCount; f += 1) {
+      vwadwr_uint val = fatPtr[f];
+      if (val != 0xffffffffU) {
+        vassert(val < wad->chunkCount);
+        put_u32(&fatPtr[f], val - fatPrev);
+        fatPrev = val;
+      } else {
+        fatPrev = 0;
+        fatPtr[f] = 0;
+      }
+    }
+  }
+
+  // put files, and fill names table
+  vwadwr_uint nameOfs = 4; // first string is always empty
+
+  // put group names
+  for (FileInfo *fi = wad->filesHead; fi; fi = fi->next) {
+    if (fi->group != NULL && fi->group->gnameofs == 0) {
+      // store group name
+      fi->group->gnameofs = nameOfs;
+      strcpy((char *)(fdir + namesStart + nameOfs), fi->group->name);
+      nameOfs += (vwadwr_uint)strlen(fi->group->name) + 1;
+      // align
+      if (nameOfs&0x03) nameOfs = (nameOfs|0x03)+1;
+      vassert(nameOfs + namesStart <= dirsz);
+    }
+  }
+
+  // put file names, and assign offsets
+  nidx = 0;
+  for (FileInfo *fi = wad->filesHead; fi; fi = fi->next) {
+    vassert(nidx != wad->fileCount);
+    vassert(fi->fname != NULL);
+    vassert(fi->fname->name != NULL);
+    // remember offset
+    fi->fname->nameofs = nameOfs;
+    strcpy((char *)(fdir + namesStart + nameOfs), fi->fname->name);
+    nameOfs += (vwadwr_uint)strlen(fi->fname->name) + 1;
+    // align
+    if (nameOfs&0x03) nameOfs = (nameOfs|0x03)+1;
+    vassert(nameOfs + namesStart <= dirsz);
+    nidx += 1;
+  }
+  vassert(nidx == wad->fileCount);
+  vassert(nameOfs == wad->namesSize);
+
+  // put file info
+  #ifdef VWAD_USE_NAME_LENGTHES
+  vwadwr_uint pnofs = 0;
+  #endif
+  vwadwr_uint ccc = 0;
+  for (FileInfo *fi = wad->filesHead; fi; fi = fi->next) {
+    vassert(fi->fname->nameofs != 0);
+    if (fatSize && fi->fatHead) {
+      put_u32(fdir + fdirofs, fi->fatHead->findex);
+    } else {
+      memcpy(fdir + fdirofs, &z32, 4); // first chunk will be calculated
+    }
+    fdirofs += 4;
+    memcpy(fdir + fdirofs, &z32, 4); fdirofs += 4;
+    memcpy(fdir + fdirofs, &z32, 4); fdirofs += 4;
+    if (fi->group != NULL) {
+      vassert(fi->group->gnameofs != 0);
+      put_u32(fdir + fdirofs, fi->group->gnameofs); fdirofs += 4; // gnameofs
+    } else {
+      put_u32(fdir + fdirofs, 0); fdirofs += 4; // gnameofs
+    }
+    put_u64(fdir + fdirofs, fi->ftime); fdirofs += 8;
+    put_u32(fdir + fdirofs, fi->crc32); fdirofs += 4;
+    put_u32(fdir + fdirofs, fi->upksize); fdirofs += 4;
+    put_u32(fdir + fdirofs, fi->chunkCount); fdirofs += 4;
+    ccc += fi->chunkCount;
+    #ifdef VWAD_USE_NAME_LENGTHES
+    if (pnofs == 0) {
+      put_u32(fdir + fdirofs, fi->fname->nameofs);
+    } else {
+      vassert(pnofs < fi->fname->nameofs);
+      put_u32(fdir + fdirofs, fi->fname->nameofs - pnofs);
+    }
+    pnofs = fi->fname->nameofs;
+    #else
+    put_u32(fdir + fdirofs, fi->fname->nameofs);
+    #endif
+    fdirofs += 4;
+  }
+  vassert(fdirofs == 4+wad->chunkCount*VWADWR_CHUNK_ENTRY_SIZE +
+                    4+wad->fileCount*VWADWR_FILE_ENTRY_SIZE);
+  fdirofs += fatSize;
+  vassert(fdirofs == namesStart);
+  vassert(ccc == wad->chunkCount);
+  // names
+  fdirofs += nameOfs;
+  vassert(fdirofs == dirsz);
+
+  // write directory
+  vwadwr_uint upk_crc32 = crc32_buf(fdir, dirsz);
+  vwadwr_ubyte *pkdir = xalloc(wad->mman, 0xffffff + 1);
+  vwadwr_uint pk_crc32;
+  int pks = CompressLZFF3(wad->mman, fdir, dirsz, pkdir, 0xffffff, 1/*allow_lazy*/);
+  if (pks == VWADWR_ERR_MEM) {
+    xfree(wad->mman, pkdir);
+    xfree(wad->mman, fdir);
+    logf(ERROR, "write error");
+    return VWADWR_ERR_MEM;
+  }
+  vassert(pks > 0); // the thing that should not be
+  vwadwr_ubyte *pkdir1 = xalloc(wad->mman, 0xffffff + 1);
+  int pks1 = pks;
+  if (pks1 < 1 || pks1 >= 0xffffff) pks1 = 0xffffff;
+  pks1 = CompressLZFF3LitOnly(fdir, dirsz, pkdir1, pks1);
+  if (pks1 > 0 && (pks < 1 || pks1 < pks)) {
+    logf(DEBUG, "dir packer: pks1=%d; pks=%d", pks1, pks);
+    xfree(wad->mman, pkdir);
+    pkdir = pkdir1;
+    pks = pks1;
+  } else {
+    //printf("!wad packer: pks1=%d; pks=%d\n", pks1, pks);
+    xfree(wad->mman, pkdir1);
+  }
+  logf(NOTE, "dir: packed from %u to %d", dirsz, pks);
+  xfree(wad->mman, fdir);
+
+  if (0x7fffffffU - dirofs < (vwadwr_uint)pks) {
+    xfree(wad->mman, pkdir);
+    logf(ERROR, "directory (%u bytes) is too big", dirsz);
+    return VWADWR_ERR_VWAD_TOO_BIG;
+  }
+
+  vwadwr_ubyte dirheader[4 * 4];
+  // packed dir data crc32
+  pk_crc32 = crc32_buf(pkdir, (vwadwr_uint)pks);
+  put_u32(dirheader + 0, pk_crc32);
+  // unpacked dir data crc32
+  put_u32(dirheader + 4, upk_crc32);
+  // packed dir size
+  vwadwr_uint tmp = (vwadwr_uint)pks;
+  put_u32(dirheader + 8, tmp);
+  // unpacked dir size
+  put_u32(dirheader + 12, dirsz);
+
+  // dir header
+  crypt_buffer(wad->xorRndSeed, 0xfffffffeU, dirheader, 4 * 4);
+  if (strm->write(strm, dirheader, 4 * 4) != VWADWR_OK) {
+    xfree(wad->mman, pkdir);
+    logf(ERROR, "write error");
+    return VWADWR_ERR_IO_ERROR;
+  }
+
+  // dir data
+  crypt_buffer(wad->xorRndSeed, 0xffffffffU, pkdir, (vwadwr_uint)pks);
+  if (strm->write(strm, pkdir, pks) != VWADWR_OK) {
+    xfree(wad->mman, pkdir);
+    logf(ERROR, "write error");
+    return VWADWR_ERR_IO_ERROR;
+  }
+  xfree(wad->mman, pkdir);
+
+  return VWADWR_OK;
+}
+
+
+//==========================================================================
+//
+//  find_by_fd
+//
+//==========================================================================
+static FileInfo *find_by_fd (vwadwr_archive *wad, vwadwr_fhandle fd) {
+  FileInfo *res = NULL;
+  if (!is_error(wad) && fd >= 0) {
+    res = wad->openedFiles;
+    while (res != NULL && res->fd != fd) res = res->next;
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_get_file_packed_size
+//
+//==========================================================================
+VWADWR_PUBLIC int vwadwr_get_file_packed_size (vwadwr_archive *wad, vwadwr_fhandle fd) {
+  FileInfo *fi = find_by_fd(wad, fd);
+  return (fi != NULL ? fi->pksize : -1);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_last_file_unpacked_size
+//
+//==========================================================================
+VWADWR_PUBLIC int vwadwr_get_file_unpacked_size (vwadwr_archive *wad, vwadwr_fhandle fd) {
+  FileInfo *fi = find_by_fd(wad, fd);
+  return (fi != NULL ? fi->upksize : -1);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_get_file_chunk_count
+//
+//==========================================================================
+VWADWR_PUBLIC int vwadwr_get_file_chunk_count (vwadwr_archive *wad, vwadwr_fhandle fd) {
+  FileInfo *fi = find_by_fd(wad, fd);
+  return (fi != NULL ? fi->chunkCount : -1);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_append_chunk
+//
+//==========================================================================
+static vwadwr_result vwadwr_append_chunk (vwadwr_archive *wad, vwadwr_ushort pksize) {
+  vassert(wad);
+  if (wad->chunkCount >= 0x3fffffff) {
+    set_error(wad);
+    return VWADWR_ERR_CHUNK_COUNT;
+  }
+  ChunkPage *pg;
+  vwadwr_uint lppos = wad->chunkCount % CHUNK_PG_MAX;
+  if (lppos == 0) {
+    // need new page
+    pg = zalloc(wad->mman, (vwadwr_uint)sizeof(ChunkPage));
+    if (pg == NULL) {
+      set_error(wad);
+      return VWADWR_ERR_MEM;
+    }
+    if (wad->chunkPagesTail) wad->chunkPagesTail->next = pg;
+    else wad->chunkPagesHead = pg;
+    pg->next = NULL;
+    wad->chunkPagesTail = pg;
+  } else {
+    pg = wad->chunkPagesTail;
+  }
+  pg->pksize[lppos] = pksize;
+  wad->chunkCount += 1;
+  vassert(wad->chunkCount != 0);
+  return VWADWR_OK;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_create_file_info
+//
+//==========================================================================
+static vwadwr_result vwadwr_create_file_info (vwadwr_archive *wad,
+                                              const char *pkfname, const char *gname,
+                                              vwadwr_uint crc32, vwadwr_uint64 ftime,
+                                              FileInfo **fip)
+{
+  if (fip) *fip = NULL;
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+  if (pkfname == NULL || pkfname[0] == 0 || !fip) return VWADWR_ERR_ARGS;
+
+  char *fname = normalize_name(wad->mman, pkfname);
+  if (fname == NULL) {
+    set_error(wad);
+    return VWADWR_ERR_MEM;
+  }
+
+  if (!vwadwr_is_valid_file_name(fname)) {
+    logf(ERROR, "bad file name: \"%s\"", fname);
+    xfree(wad->mman, fname);
+    return VWADWR_ERR_NAME;
+  }
+
+  if (wad->fileCount >= 0x00ffffffU) {
+    xfree(wad->mman, fname);
+    logf(ERROR, "too many files");
+    return VWADWR_ERR_FILE_COUNT;
+  }
+
+  const vwadwr_uint fnlen = (vwadwr_uint)strlen(fname);
+  if (fnlen >= 512) {
+    logf(ERROR, "file name too long: \"%s\"", fname);
+    xfree(wad->mman, fname);
+    return VWADWR_ERR_NAME;
+  }
+
+  if (wad->namesSize >= 0x3fffffff || 0x3fffffff - wad->namesSize < fnlen + 6 ||
+      wad->namesSize < 4 || (wad->namesSize&0x03) != 0)
+  {
+    xfree(wad->mman, fname);
+    logf(ERROR, "name table too big");
+    return VWADWR_ERR_NAMES_SIZE;
+  }
+
+  const vwadwr_uint hash = hashStrCI(fname);
+  const vwadwr_uint bkt = hash % HASH_BUCKETS;
+
+  // check finished file names
+  FileInfo *fi = wad->buckets[bkt];
+  while (fi != NULL) {
+    if (fi->nhash == hash && strEquCI(fi->fname->name, fname)) {
+      logf(ERROR, "duplicate file name: \"%s\" and \"%s\"", fname, fi->fname->name);
+      xfree(wad->mman, fname);
+      return VWADWR_ERR_DUP_FILE;
+    }
+    fi = fi->bknext;
+  }
+
+  // check opened file names (there are not many of them, so just loop)
+  fi = wad->openedFiles;
+  while (fi != NULL) {
+    if (fi->nhash == hash && strEquCI(fi->fname->name, fname)) {
+      logf(ERROR, "duplicate file name: \"%s\" and \"%s\"", fname, fi->fname->name);
+      xfree(wad->mman, fname);
+      return VWADWR_ERR_DUP_FILE;
+    }
+    fi = fi->next;
+  }
+
+  // create new file info
+  fi = zalloc(wad->mman, (vwadwr_uint)sizeof(FileInfo));
+  if (fi == NULL) {
+    xfree(wad->mman, fname);
+    set_error(wad);
+    return VWADWR_ERR_MEM;
+  }
+
+  if (gname && gname[0]) {
+    vassert(vwadwr_is_valid_group_name(gname)); // guaranteed by the caller
+    int err;
+    fi->group = vwadwr_register_group(wad, gname, &err);
+    if (err != 0) {
+      xfree(wad->mman, fname);
+      xfree(wad->mman, fi);
+      set_error(wad);
+      return err;
+    }
+  } else {
+    fi->group = NULL;
+  }
+
+  FileName *nn = zalloc(wad->mman, (vwadwr_uint)sizeof(FileName));
+  if (nn == NULL) {
+    xfree(wad->mman, fname);
+    xfree(wad->mman, fi);
+    set_error(wad);
+    return VWADWR_ERR_MEM;
+  }
+  nn->nameofs = 0; // will be set later
+  nn->name = fname;
+
+  fi->upksize = 0;
+  fi->pksize = 0;
+  fi->chunkCount = 0;
+  fi->nhash = hash;
+  fi->bknext = NULL;
+  fi->ftime = ftime;
+  fi->crc32 = crc32;
+
+  //fi->nameofs = wad->namesSize;
+  wad->namesSize += fnlen + 1;
+  // align
+  if (wad->namesSize&0x03) wad->namesSize = (wad->namesSize|0x03)+1;
+  fi->fname = nn;
+  fi->next = NULL;
+
+  // yeah, increment it here
+  ++wad->fileCount;
+
+  *fip = fi;
+
+  return VWADWR_OK;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_register_file
+//
+//==========================================================================
+static void vwadwr_register_file (vwadwr_archive *wad, FileInfo *fi) {
+  vassert(wad != NULL);
+  vassert(fi != NULL);
+  vassert(fi->fd >= 0);
+
+  FileInfo *prev = NULL;
+  FileInfo *curr = wad->openedFiles;
+
+  // it SHOULD be there
+  while (curr != fi) { prev = curr; curr = curr->next; }
+  // exclude from opene files list
+  if (prev != NULL) prev->next = fi->next; else wad->openedFiles = fi->next;
+  fi->fd = -1;
+
+  // instert into name hash table
+  const vwadwr_uint bkt = fi->nhash % HASH_BUCKETS;
+  fi->bknext = wad->buckets[bkt];
+  wad->buckets[bkt] = fi;
+
+  // append to finished files list
+  if (wad->filesTail) wad->filesTail->next = fi; else wad->filesHead = fi;
+  wad->filesTail = fi;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_append_opened
+//
+//==========================================================================
+static void vwadwr_append_opened (vwadwr_archive *wad, FileInfo *fi) {
+  vassert(!is_error(wad));
+  vassert(fi != NULL);
+  vassert(wad->lastUsedFD >= 0);
+  fi->fd = (vwadwr_fhandle)(hashU32(wad->lastUsedFD + 0x29aU)&0x7fffffffU);
+  // just in case, it is actually impossible
+  if (wad->lastUsedFD == 0x7fffffff) wad->lastUsedFD = 0; else wad->lastUsedFD += 1;
+  // fix fd (duplicate fd case should not happen, but...)
+  FileInfo *c;
+  do {
+    c = wad->openedFiles;
+    while (c != NULL && c->fd != fi->fd) c = c->next;
+    if (c != NULL) {
+      if (fi->fd == 0x7fffffff) fi->fd = 0; else fi->fd += 1;
+    }
+  } while (c != NULL);
+  // insert into opened files list
+  fi->next = wad->openedFiles;
+  wad->openedFiles = fi;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_create_file
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_fhandle vwadwr_create_file (vwadwr_archive *wad, int level,
+                                                 const char *pkfname, const char *groupname,
+                                                 vwadwr_ftime ftime)
+{
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+  if (pkfname == NULL) return VWADWR_ERR_ARGS;
+  if (!vwadwr_is_valid_group_name(groupname)) return VWADWR_ERR_GROUP;
+  if (!pkfname[0]) return VWADWR_ERR_NAME;
+
+  vwadwr_uint flags = 0;
+  FileInfo *fi = NULL;
+
+  if (level >= 0) {
+    switch (level) {
+      case VWADWR_COMP_FASTEST:
+        flags |= FI_ALLOW_LITONLY;
+        break;
+      case VWADWR_COMP_FAST:
+        flags |= FI_ALLOW_LZ;
+        break;
+      case VWADWR_COMP_MEDIUM:
+        flags |= FI_ALLOW_LZ|FI_ALLOW_LAZY;
+        break;
+      case VWADWR_COMP_BEST:
+      default:
+        flags |= FI_ALLOW_LZ|FI_ALLOW_LAZY|FI_ALLOW_LITONLY;
+        break;
+    }
+  }
+
+  // we don't know CRC32 yet
+  vwadwr_result rescode = vwadwr_create_file_info(wad, pkfname, groupname, crc32_init, ftime, &fi);
+  if (rescode != VWADWR_OK) {
+    vassert(fi == NULL);
+    logf(ERROR, "cannot append file info");
+    return rescode;
+  } else {
+    vassert(fi != NULL);
+    fi->flags = flags;
+    fi->fd = -1; // just in case
+    vwadwr_append_opened(wad, fi);
+    vassert(fi->fd >= 0);
+    return fi->fd;
+  }
+}
+
+
+//==========================================================================
+//
+//  vwadwr_create_raw_file
+//
+//  you can use this API to write files with the usual fwrite-like API.
+//  please note that you cannot seek backwards in this case, and only
+//  one file can be created for writing.
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_create_raw_file (vwadwr_archive *wad,
+                                                    const char *pkfname, const char *groupname,
+                                                    vwadwr_uint filecrc32, vwadwr_ftime ftime)
+{
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+  if (pkfname == NULL) return VWADWR_ERR_ARGS;
+  if (!vwadwr_is_valid_group_name(groupname)) return VWADWR_ERR_GROUP;
+  if (!pkfname[0]) return VWADWR_ERR_NAME;
+
+  // we don't know sizes and such yet, so use zeroes
+  FileInfo *fi = NULL;
+  vwadwr_result rescode = vwadwr_create_file_info(wad, pkfname, groupname, filecrc32, ftime, &fi);
+  if (rescode != VWADWR_OK) {
+    vassert(fi == NULL);
+    logf(ERROR, "cannot append file info");
+    return rescode;
+  } else {
+    vassert(fi != NULL);
+    fi->flags = FI_RAW;
+    fi->fd = -1; // just in case
+    vwadwr_append_opened(wad, fi);
+    vassert(fi->fd >= 0);
+    return fi->fd;
+  }
+}
+
+
+//==========================================================================
+//
+//  append_fat_chunk
+//
+//  this appends next used chunk to the file FAT
+//
+//==========================================================================
+static vwadwr_result append_fat_chunk (vwadwr_archive *wad, FileInfo *fi) {
+  vassert(wad);
+  vassert(fi);
+
+  const vwadwr_uint nchunk = wad->chunkCount;
+
+  ChunkFAT *seg = fi->fatTail;
+  // check if our file becomes segmented
+  if (seg != NULL) {
+    const vwadwr_uint lchunk = seg->findex + seg->ccount;
+    if (lchunk != nchunk) {
+      // segmented; need new segment
+      if ((fi->flags&FI_SEGMENTED) == 0) {
+        fi->flags |= FI_SEGMENTED;
+        vwadwr_force_fat(wad); // set archive header flag
+      }
+      seg = zalloc(wad->mman, (vwadwr_uint)sizeof(ChunkFAT));
+      if (seg == NULL) {
+        set_error(wad);
+        return VWADWR_ERR_MEM;
+      }
+      seg->findex = nchunk;
+      seg->ccount = 1;
+      seg->next = NULL;
+      if (fi->fatTail != NULL) fi->fatTail->next = seg; else fi->fatHead = seg;
+      fi->fatTail = seg;
+    } else {
+      // grow segment
+      seg->ccount += 1;
+    }
+  } else {
+    // first segment
+    seg = zalloc(wad->mman, (vwadwr_uint)sizeof(ChunkFAT));
+    if (seg == NULL) {
+      set_error(wad);
+      return VWADWR_ERR_MEM;
+    }
+    seg->findex = nchunk;
+    seg->ccount = 1;
+    seg->next = NULL;
+    vassert(fi->fatHead == NULL);
+    fi->fatHead = seg;
+    fi->fatTail = seg;
+  }
+
+  return VWADWR_OK;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_flush_chunk
+//
+//==========================================================================
+static vwadwr_result vwadwr_flush_chunk (vwadwr_archive *wad, FileInfo *fi) {
+  vwadwr_result rescode;
+
+  vassert(!is_error(wad));
+  vassert(fi);
+
+  if (fi->flags&FI_FLUSHED) return VWADWR_ERR_INVALID_MODE;
+
+  if (fi->chunkCount >= 0x3fffffffU) {
+    set_error(wad);
+    return VWADWR_ERR_CHUNK_COUNT;
+  }
+
+  vassert(fi->wrpos > 0 && fi->wrpos <= 65536);
+  fi->crc32 = crc32_part(fi->crc32, fi->wrchunkPtr, fi->wrpos);
+
+  // compress
+  const vwadwr_uint rd = fi->wrpos;
+  const vwadwr_uint crc32 = crc32_buf(fi->wrchunkPtr, rd);
+  char *dest = wad->pkbuf0; // compressed buffer
+  int pks;
+
+  if (fi->flags&FI_ALLOW_LZ) {
+    // LZ compression allowed
+    const int allow_lazy = (fi->flags&FI_ALLOW_LAZY);
+    pks = CompressLZFF3(wad->mman, fi->wrchunkPtr, rd, dest + 4, 65535, allow_lazy);
+    if (pks == VWADWR_ERR_MEM) {
+      set_error(wad);
+      return VWADWR_ERR_MEM;
+    }
+    if (fi->flags&FI_ALLOW_LITONLY) {
+      int pks1 = pks - 1;
+      if (pks1 <= 0) pks1 = 65535;
+      pks1 = CompressLZFF3LitOnly(fi->wrchunkPtr, rd, wad->pkbuf1 + 4, pks1);
+      if (pks1 > 0 && (pks <= 0 || pks1 < pks)) {
+        // use this buffer
+        dest = wad->pkbuf1;
+        pks = pks1;
+      }
+    }
+  } else {
+    // no LZ compression
+    if (fi->flags&FI_ALLOW_LITONLY) {
+      pks = CompressLZFF3LitOnly(fi->wrchunkPtr, rd, dest + 4, 65535);
+      if (pks < 1) pks = -1;
+    } else {
+      pks = -1;
+    }
+  }
+
+  // append new file segment
+  rescode = append_fat_chunk(wad, fi);
+  if (rescode != VWADWR_OK) return rescode;
+
+  // append chunk and write it
+  const vwadwr_uint nonce = 4 + wad->chunkCount;
+  if (pks <= 0 || pks > 65535 || pks > (int)rd) {
+    // raw chunk
+    rescode = vwadwr_append_chunk(wad, 0);
+    if (rescode != VWADWR_OK) return rescode;
+    vassert(rd > 0 && rd <= 65536);
+    memcpy(dest + 4, fi->wrchunkPtr, rd);
+    pks = (int)rd;
+  } else {
+    // packed chunk
+    rescode = vwadwr_append_chunk(wad, (vwadwr_uint)pks);
+    if (rescode != VWADWR_OK) return rescode;
+  }
+  put_u32(dest, crc32);
+  crypt_buffer(wad->xorRndSeed, nonce, dest, (vwadwr_uint)pks + 4);
+  if (wad->outstrm->write(wad->outstrm, dest, pks + 4) != VWADWR_OK) {
+    set_error(wad);
+    return VWADWR_ERR_IO_ERROR;
+  }
+
+  fi->upksize += fi->wrpos;
+  fi->pksize += (vwadwr_uint)pks;
+  fi->chunkCount += 1;
+
+  if (fi->upksize > 0x7fffffffU || fi->pksize > 0x7fffffffU) {
+    set_error(wad);
+    return VWADWR_ERR_FILE_TOO_BIG;
+  }
+
+  fi->wrpos = 0;
+
+  return VWADWR_OK;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_write
+//
+//  writing 0 bytes is not an error
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_write (vwadwr_archive *wad, vwadwr_fhandle fd,
+                                          const void *buf, vwadwr_uint len)
+{
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+
+  FileInfo *fi = find_by_fd(wad, fd);
+  if (fi == NULL) return VWADWR_ERR_FILE_INVALID;
+
+  if ((fi->flags&(FI_FLUSHED|FI_RAW)) != 0) return VWADWR_ERR_INVALID_MODE;
+
+  if (len > 0x7ffffff0U) {
+    set_error(wad);
+    return VWADWR_ERR_IO_ERROR;
+  }
+  if (len == 0) return VWADWR_OK;
+  if (buf == NULL) {
+    set_error(wad);
+    return VWADWR_ERR_IO_ERROR;
+  }
+  if (0x7ffffff0U - fi->upksize < len) {
+    set_error(wad);
+    return VWADWR_ERR_FILE_TOO_BIG;
+  }
+
+  if (fi->wrchunkPtr == NULL) {
+    fi->wrchunkPtr = (char *)xalloc(wad->mman, 65536);
+    if (fi->wrchunkPtr == NULL) {
+      set_error(wad);
+      return VWADWR_ERR_MEM;
+    }
+  }
+
+  vwadwr_result rescode;
+  const char *src = (const char *)buf;
+  while (len != 0) {
+    int left = 65536 - (int)fi->wrpos;
+    if (left > (int)len) left = (int)len;
+    memcpy(fi->wrchunkPtr + fi->wrpos, src, left);
+    fi->wrpos += (vwadwr_uint)left;
+    src += (vwadwr_uint)left;
+    len -= (vwadwr_uint)left;
+    vassert(fi->wrpos <= 65536);
+    if (fi->wrpos == 65536) {
+      // we have complete chunk, pack and write it
+      rescode = vwadwr_flush_chunk(wad, fi);
+      if (rescode != VWADWR_OK) return rescode;
+    }
+  }
+
+  return VWADWR_OK;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_flush_fi
+//
+//==========================================================================
+static vwadwr_result vwadwr_flush_fi (vwadwr_archive *wad, FileInfo *fi) {
+  vassert(!is_error(wad));
+  vassert(fi != NULL);
+  vassert(fi->fd >= 0);
+
+  if ((fi->flags&FI_FLUSHED) == 0) {
+    if ((fi->flags&FI_RAW) == 0) {
+      if (fi->wrpos != 0) {
+        // flush final chunk
+        vwadwr_result rescode = vwadwr_flush_chunk(wad, fi);
+        if (rescode != VWADWR_OK) return rescode;
+      }
+      // final CRC32
+      fi->crc32 = crc32_final(fi->crc32);
+    }
+    fi->flags |= FI_FLUSHED;
+  }
+
+  return VWADWR_OK;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_flush_file
+//
+//  flush buffered file data (i.e. write the last chunk).
+//  you don't need to explicitly call this, but if you want correct
+//  final stats (see the API above), you should flush the file
+//  before closing, get stats, and then close the file.
+//  note that you cannot write anything to the file after flushing.
+//  flushing raw files is allowed.
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_flush_file (vwadwr_archive *wad, vwadwr_fhandle fd) {
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+
+  FileInfo *fi = find_by_fd(wad, fd);
+  if (fi == NULL) return VWADWR_ERR_FILE_INVALID;
+
+  return vwadwr_flush_fi(wad, fi);
+}
+
+
+//==========================================================================
+//
+//  vwadwr_close_file
+//
+//  if this returned error, there is no reason to continue; call `vwadwr_free_archive()`
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_close_file (vwadwr_archive *wad, vwadwr_fhandle fd) {
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+
+  FileInfo *fi = find_by_fd(wad, fd);
+  if (fi == NULL) return VWADWR_ERR_FILE_INVALID;
+
+  vwadwr_result fres = vwadwr_flush_fi(wad, fi);
+  if (fres == VWADWR_OK) vwadwr_register_file(wad, fi);
+
+  if (fi->wrchunkPtr != NULL) {
+    xfree(wad->mman, fi->wrchunkPtr);
+    fi->wrchunkPtr = NULL;
+  }
+
+  return fres;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_write_raw_chunk
+//
+//  used to copy raw decrypted chunks from other VWAD
+//  use raw reading API in reader to obtain them
+//  `pksz`, `upksz` and `packed` are exactly what `vwad_get_file_chunk_size()` returns
+//  `chunk` is what `vwad_read_raw_file_chunk()` read
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_write_raw_chunk (vwadwr_archive *wad, vwadwr_fhandle fd,
+                                                    const void *chunk, int pksz, int upksz,
+                                                    int packed)
+{
+  if (is_error(wad)) return VWADWR_ERR_OTHER;
+  if (chunk == NULL) return VWADWR_ERR_ARGS;
+  if (pksz < 5 || upksz < 1 || pksz > 65536 + 4 || upksz > 65536) return VWADWR_ERR_ARGS;
+
+  FileInfo *fi = find_by_fd(wad, fd);
+  if (fi == NULL) return VWADWR_ERR_FILE_INVALID;
+
+  if ((fi->flags&(FI_FLUSHED|FI_RAW)) != FI_RAW) return VWADWR_ERR_INVALID_MODE;
+  if (0x7ffffff0U - fi->upksize < (vwadwr_uint)pksz) {
+    set_error(wad);
+    return VWADWR_ERR_FILE_TOO_BIG;
+  }
+  if (fi->chunkCount >= 0x3fffffffU) {
+    set_error(wad);
+    return VWADWR_ERR_CHUNK_COUNT;
+  }
+
+  vwadwr_result rescode;
+
+  // append new file segment
+  rescode = append_fat_chunk(wad, fi);
+  if (rescode != VWADWR_OK) return rescode;
+
+  const vwadwr_uint nonce = 4 + wad->chunkCount;
+  vwadwr_uint csz = (vwadwr_uint)pksz - 4;
+  if (!packed) {
+    // raw chunk
+    rescode = vwadwr_append_chunk(wad, 0);
+    if (rescode != VWADWR_OK) return rescode;
+  } else {
+    // packed chunk
+    rescode = vwadwr_append_chunk(wad, (vwadwr_uint)csz);
+    if (rescode != VWADWR_OK) return rescode;
+  }
+  csz += 4; /* crc32 */
+  memcpy(wad->pkbuf0, chunk, csz);
+  crypt_buffer(wad->xorRndSeed, nonce, wad->pkbuf0, csz);
+  if (wad->outstrm->write(wad->outstrm, wad->pkbuf0, csz) != VWADWR_OK) {
+    set_error(wad);
+    return VWADWR_ERR_IO_ERROR;
+  }
+  csz -= 4; /* crc32 */
+
+  fi->upksize += (vwadwr_uint)upksz;
+  fi->pksize += csz;
+  fi->chunkCount += 1;
+
+  if (fi->upksize > 0x7fffffffU || fi->pksize > 0x7fffffffU) {
+    set_error(wad);
+    return VWADWR_ERR_FILE_TOO_BIG;
+  }
+
+  return VWADWR_OK;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+typedef struct {
+  vwadwr_iostream *strm;
+  int currpos, size;
+} EdInfo;
+
+
+static int ed_total_size (cc_ed25519_iostream *strm) {
+  EdInfo *nfo = (EdInfo *)strm->udata;
+  return nfo->size - (4+64+32); // without header
+}
+
+
+static int ed_read (cc_ed25519_iostream *strm, int startpos, void *buf, int bufsize) {
+  EdInfo *nfo = (EdInfo *)strm->udata;
+  if (startpos < 0) return -1; // oops
+  startpos += 4+64+32; // skip header
+  if (startpos >= nfo->size) return -1;
+  const int max = nfo->size - startpos;
+  if (bufsize > max) bufsize = max;
+  if (nfo->currpos != startpos) {
+    if (nfo->strm->seek(nfo->strm, startpos) != 0) return -1;
+    nfo->currpos = startpos + bufsize;
+  } else {
+    nfo->currpos += bufsize;
+  }
+  while (bufsize != 0) {
+    const int rd = nfo->strm->read(nfo->strm, buf, bufsize);
+    if (rd <= 0) return -1;
+    if ((bufsize -= rd) != 0) {
+      buf = ((vwadwr_ubyte *)buf) + (vwadwr_uint)rd;
+    }
+  }
+  return 0;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_finish_archive
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_finish_archive (vwadwr_archive **wadp) {
+  if (wadp == NULL) return VWADWR_ERR_ARGS;
+
+  vwadwr_archive *wad = *wadp;
+  if (wad == NULL) return VWADWR_ERR_ARGS;
+
+  if (is_error(wad)) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "trying to finish errored archive");
+    return VWADWR_ERR_OTHER;
+  }
+
+  vwadwr_result rescode;
+
+  if (wad->openedFiles != NULL) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "trying to finish archive with opened files");
+    return VWADWR_ERR_INVALID_MODE;
+  }
+
+  rescode = vwadwr_check_dir(wad);
+  if (rescode != VWADWR_OK) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "invalid directory");
+    return rescode;
+  }
+
+  int dirofspos = wad->outstrm->tell(wad->outstrm);
+  if (dirofspos <= 4*3+32+64 || dirofspos > 0x6fffffff) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "archive too big");
+    return VWADWR_ERR_VWAD_TOO_BIG;
+  }
+
+  const vwadwr_uint dirofs = (vwadwr_uint)dirofspos;
+
+  // pack and write main directory
+  rescode = vwadwr_write_directory(wad, wad->outstrm, dirofs);
+  if (rescode != VWADWR_OK) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "cannot write directory");
+    return rescode;
+  }
+
+  const int fout_size = wad->outstrm->tell(wad->outstrm);
+  if (fout_size <= 0 || fout_size > 0x7ffffff0) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "output file too big");
+    return VWADWR_ERR_VWAD_TOO_BIG;
+  }
+
+  // write header
+  int sofs = 4+32+64+1+(int)strlen(wad->author)+1+(int)strlen(wad->title)+8;
+  if (wad->outstrm->seek(wad->outstrm, sofs) != 0) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "cannot seek to header");
+    return VWADWR_ERR_IO_ERROR;
+  }
+
+  // setup wad offset
+  put_u32(&wad->mhdr.dirofs, dirofs);
+  // calculate buffer crc32
+  put_u32(&wad->mhdr.crc32, crc32_buf(&wad->mhdr.version, (vwadwr_uint)sizeof(wad->mhdr)-4));
+
+  // encrypt and write main header using pk-derived seed
+  crypt_buffer(wad->xorRndSeedPK, 1, &wad->mhdr, (vwadwr_uint)sizeof(wad->mhdr));
+  if (wad->outstrm->write(wad->outstrm, &wad->mhdr, (int)sizeof(wad->mhdr)) != VWADWR_OK) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "write error");
+    return VWADWR_ERR_IO_ERROR;
+  }
+
+  ed25519_signature edsign;
+  if (wad->has_privkey) {
+    cc_ed25519_iostream edstrm;
+    EdInfo nfo;
+    nfo.strm = wad->outstrm;
+    nfo.currpos = -1;
+    nfo.size = fout_size;
+    if (nfo.size <= 0) {
+      vwadwr_free_archive(wadp);
+      logf(ERROR, "tell error");
+      return VWADWR_ERR_IO_ERROR;
+    }
+    edstrm.udata = &nfo;
+    edstrm.total_size = ed_total_size;
+    edstrm.read = ed_read;
+
+    logf(NOTE, "creating signature");
+    int sres = edsign_sign_stream(edsign, wad->pubkey, wad->privkey, &edstrm);
+    if (sres != 0) {
+      vwadwr_free_archive(wadp);
+      logf(ERROR, "failed to sign data");
+      return VWADWR_ERR_OTHER;
+    }
+  } else {
+    // fill signature with file-dependent gibberish
+    vwadwr_uint xseed = wad->fileCount;
+    for (FileInfo *fi = wad->filesHead; fi != NULL; fi = fi->next) {
+      xseed = hashU32(xseed ^ fi->upksize);
+      xseed = hashU32(xseed ^ fi->chunkCount);
+      xseed = hashU32(xseed ^ fi->crc32);
+    }
+    if (xseed == 0) xseed = deriveSeed(0xa27, NULL, 0);
+    memset(edsign, 0, sizeof(ed25519_signature));
+    crypt_buffer(xseed, 0x29b, edsign, (vwadwr_uint)sizeof(ed25519_signature));
+  }
+
+  // write signature (or gibberish)
+  if (wad->outstrm->seek(wad->outstrm, 4) != 0) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "cannot seek in output file");
+    return VWADWR_ERR_IO_ERROR;
+  }
+  if (wad->outstrm->write(wad->outstrm, edsign, (int)sizeof(ed25519_signature)) != VWADWR_OK) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "write error");
+    return VWADWR_ERR_IO_ERROR;
+  }
+
+  // re-encrypt public key
+  // create initial seed from signature, author, and title
+  vwadwr_uint pkxseed;
+  pkxseed = deriveSeed(0xa29, edsign, (vwadwr_uint)sizeof(ed25519_signature));
+  pkxseed = deriveSeed(pkxseed, (const vwadwr_ubyte *)wad->author, (vwadwr_uint)strlen(wad->author));
+  pkxseed = deriveSeed(pkxseed, (const vwadwr_ubyte *)wad->title, (vwadwr_uint)strlen(wad->title));
+  #if 0
+  logf(DEBUG, "kkseed: 0x%08x", pkxseed);
+  #endif
+
+  ed25519_public_key epk;
+  memcpy(epk, wad->pubkey, sizeof(ed25519_public_key));
+  crypt_buffer(pkxseed, 0x29a, epk, (vwadwr_uint)sizeof(ed25519_public_key));
+
+  // write public key
+  if (wad->outstrm->write(wad->outstrm, epk, (int)sizeof(ed25519_public_key)) != VWADWR_OK) {
+    vwadwr_free_archive(wadp);
+    logf(ERROR, "write error");
+    return VWADWR_ERR_IO_ERROR;
+  }
+
+  vwadwr_free_archive(wadp);
+  return VWADWR_OK;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_wildmatch
+//
+//  returns:
+//    -1: malformed pattern
+//     0: equal
+//     1: not equal
+//
+//==========================================================================
+VWADWR_PUBLIC vwadwr_result vwadwr_wildmatch (const char *pat, vwadwr_uint plen,
+                                              const char *str, vwadwr_uint slen)
+{
+  #define GETSCH(dst_)  do { \
+    const char *stmp = &str[spos]; \
+    const vwadwr_uint uclen = utf_char_len(stmp); \
+    if (error || uclen == 0 || uclen > 3 || slen - spos < uclen) { error = 1; (dst_) = VWADWR_REPLACEMENT_CHAR; } \
+    else { \
+      (dst_) = unilower(utf_decode(&stmp)); \
+      if ((dst_) < 32 || (dst_) == VWADWR_REPLACEMENT_CHAR) error = 1; \
+      spos += uclen; \
+    } \
+  } while (0)
+
+  #define GETPCH(dst_)  do { \
+    const char *stmp = &pat[patpos]; \
+    const vwadwr_uint uclen = utf_char_len(stmp); \
+    if (error || uclen == 0 || uclen > 3 || plen - patpos < uclen) { error = 1; (dst_) = VWADWR_REPLACEMENT_CHAR; } \
+    else { \
+      (dst_) = unilower(utf_decode(&stmp)); \
+      if ((dst_) < 32 || (dst_) == VWADWR_REPLACEMENT_CHAR) error = 1; \
+      else patpos += uclen; \
+    } \
+  } while (0)
+
+  vwadwr_ushort sch, c0, c1;
+  vwadwr_bool hasMatch, inverted;
+  vwadwr_bool star = 0, dostar = 0;
+  vwadwr_uint patpos = 0, spos = 0;
+  int error = 0;
+
+  while (!error && !dostar && spos < slen) {
+    if (patpos == plen) {
+      dostar = 1;
+    } else {
+      GETSCH(sch); GETPCH(c0);
+      if (!error) {
+        switch (c0) {
+          case '\\':
+            GETPCH(c0);
+            dostar = (sch != c0);
+            break;
+          case '?': // match anything except '.'
+            dostar = (sch == '.');
+            break;
+          case '*':
+            star = 1;
+            --spos; // otherwise "*abc" will not match "abc"
+            slen -= spos; str += spos;
+            plen -= patpos; pat += patpos;
+            while (plen != 0 && *pat == '*') { --plen; ++pat; }
+            // restart the loop
+            spos = 0; patpos = 0;
+            break;
+          case '[':
+            hasMatch = 0;
+            inverted = 0;
+            if (patpos == plen) error = 1; // malformed pattern
+            else if (pat[patpos] == '^') {
+              inverted = 1;
+              ++patpos;
+              error = (patpos == plen); // malformed pattern?
+            }
+            if (!error) {
+              do {
+                GETPCH(c0);
+                if (!error && patpos != plen && pat[patpos] == '-') {
+                  // char range
+                  ++patpos; // skip '-'
+                  GETPCH(c1);
+                } else {
+                  c1 = c0;
+                }
+                // casts are UB, hence the stupid macro
+                hasMatch = hasMatch || (sch >= c0 && sch <= c1);
+              } while (!error && patpos != plen && pat[patpos] != ']');
+            }
+            error = error || (patpos == plen) || (pat[patpos] != ']'); // malformed pattern?
+            dostar = !error && (hasMatch != inverted);
+            break;
+          default:
+            dostar = (sch != c0);
+            break;
+        }
+      }
+    }
+    // star check
+    if (dostar && !error) {
+      // `error` is always zero here
+      if (!star) {
+        // not equal, do not reset "dostar"
+        spos = slen;
+      } else {
+        dostar = 0;
+        if (plen == 0) {
+          // equal
+          spos = slen;
+        } else {
+          --slen; ++str; // slen is never zero here
+          spos = 0; patpos = 0;
+        }
+      }
+    }
+  }
+
+  int res;
+  if (error) res = -1; // malformed pattern
+  else if (dostar) res = 1; // not equal
+  else {
+    plen -= patpos; pat += patpos;
+    while (plen != 0 && *pat == '*') { --plen; ++pat; }
+    if (plen == 0) res = 0; else res = 1;
+  }
+  return res;
+}
+
+
+//==========================================================================
+//
+//  vwadwr_wildmatch_path
+//
+//  this matches individual path parts
+//  exception: if `pat` contains no slashes, match only the name
+//
+//==========================================================================
+#ifdef VWAD_DEBUG_WILDPATH
+#include <stdio.h>
+#endif
+VWADWR_PUBLIC vwadwr_result vwadwr_wildmatch_path (const char *pat, vwadwr_uint plen,
+                                                   const char *str, vwadwr_uint slen)
+{
+  vwadwr_uint ppos, spos;
+  vwadwr_bool pat_has_slash = 0;
+  vwadwr_result res;
+
+  while (plen && pat[0] == '/') { pat_has_slash = 1; --plen; ++pat; }
+  // look for slashes
+  if (!pat_has_slash) {
+    ppos = 0; while (ppos < plen && pat[ppos] != '/') ++ppos;
+    pat_has_slash = (ppos < plen);
+  }
+
+  // if no slashes in pattern, match only filename
+  if (!pat_has_slash) {
+    spos = slen; while (spos != 0 && str[spos - 1] != '/') --spos;
+    slen -= spos; str += spos;
+    res = vwadwr_wildmatch(pat, plen, str, slen);
+  } else {
+    // match by path parts
+    #ifdef VWAD_DEBUG_WILDPATH
+    fprintf(stderr, "=== pat:<%.*s>; str:<%.*s> ===\n",
+            (vwadwr_uint)plen, pat, (vwadwr_uint)slen, str);
+    #endif
+    while (slen && str[0] == '/') { --slen; ++str; }
+    res = 0;
+    while (res == 0 && plen != 0 && slen != 0) {
+      // find slash in pat and in str
+      ppos = 0; while (ppos != plen && pat[ppos] != '/') ++ppos;
+      spos = 0; while (spos != slen && str[spos] != '/') ++spos;
+      #ifdef VWAD_DEBUG_WILDPATH
+      fprintf(stderr, "  MT: ppos=%u; spos=%u; pat=<%.*s>; str=<%.*s> (ex: %d)\n",
+              (vwadwr_uint)ppos, (vwadwr_uint)spos,
+              (vwadwr_uint)ppos, pat, (vwadwr_uint)spos, str,
+              ((ppos == plen) != (spos == slen)));
+      #endif
+      if ((ppos == plen) != (spos == slen)) {
+        res = 1;
+      } else {
+        res = vwadwr_wildmatch(pat, ppos, str, spos);
+        plen -= ppos; pat += ppos;
+        slen -= spos; str += spos;
+        while (plen && pat[0] == '/') { --plen; ++pat; }
+        while (slen && str[0] == '/') { --slen; ++str; }
+      }
+    }
+    #ifdef VWAD_DEBUG_WILDPATH
+    fprintf(stderr, " res: %d\n", res);
+    #endif
+  }
+
+  return res;
+}
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+#if defined(__cplusplus)
+}
+#endif

--- a/thirdparty/libvwad/vwadwrite.h
+++ b/thirdparty/libvwad/vwadwrite.h
@@ -1,0 +1,437 @@
+/* coded by Ketmar // Invisible Vector (psyc://ketmar.no-ip.org/~Ketmar)
+ * Understanding is not required. Only obedience.
+ *
+ * This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar.
+ * See http://www.wtfpl.net/ for more details.
+ */
+/*
+  VWADs are chunked archives with zlib-comparable compression ratio.
+  usually VWAD size on max copression level is little lesser than
+  the corresponding ZIP file. the most useful feature of VWAD is the
+  ability to read files non-sequentially without unpacking the whole
+  file first. i.e. seeking in archive files is quite cheap, and can
+  be used freely.
+
+  any archive can be signed with Ed25519 digital signature. please,
+  note that you have to provide good cryptographically strong PRNG
+  by yourself (actually, you should use it to generate a private key,
+  the library itself doesn't have any PRNG generator).
+
+  note that while archive chunks are "encrypted", this "encryption"
+  is not cryptographically strong, and used mostly to hide non-compressed
+  data from simple viewing tools.
+
+  archived files can be annotated with arbitrary "group name". this can
+  be used in various content creation tools. group tags are not used
+  by the library itself. group names are case-insensitive.
+
+  also, archived files can have a 64-bit last modification timestamp
+  (seconds since Unix Epoch). you can use zero as timestamp if you
+  don't care.
+
+  file names can containprintable unicode chars from the first plane
+  (see `vwadwr_is_uni_printable()`), and names are case-insensitive.
+  all names should be utf-8 encoded. also note that whice case folding
+  is unicode-aware, not all codepoints are implemented. latin-1 and
+  basic cyrillic should be safe, though.
+  path delimiter is "/" (and only "/").
+  file names may not contain chars [1..31], and char 127.
+  you can use `vwadwr_is_valid_file_name()` to check filename validity,
+  and `vwadwr_is_valid_group_name()` to check group name validity.
+
+
+  archive can be tagged with author name, short description, and a comment.
+  author name and description can contain unicode chars, but cannot have
+  control chars (with codes < 31).
+  comments can be multiline (only '\x0a' is allowed as a newline char).
+  tabs are allowed too.
+  you can use `vwadwr_is_valid_comment()` to check if comment text is valid.
+
+  currently, only limited subset of the first unicode plane is supported.
+  deal with it.
+
+  WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
+  the writer is not thread-safe!
+  WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING! WARNING!
+*/
+#ifndef VWADWRITER_HEADER
+#define VWADWRITER_HEADER
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/*#define VWADWR_DEBUG_ALLOCS*/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+
+// WARNING! if compiler complains with something like "size of unnamed array is negative",
+//          it means that type sizes are wrong!
+
+// this should be 8 bit (i hope so)
+typedef unsigned char vwadwr_ubyte;
+// this should be 16 bit (i hope so)
+typedef unsigned short vwadwr_ushort;
+// this should be 32 bit (i hope so)
+typedef unsigned int vwadwr_uint;
+// this should be 64 bit (i hope so)
+typedef unsigned long long vwadwr_uint64;
+
+// size checks
+typedef char vwadwr_temp_typedef_check_char[(sizeof(char) == 1) ? 1 : -1];
+typedef char vwadwr_temp_typedef_check_char[(sizeof(int) == 4) ? 1 : -1];
+typedef char vwadwr_temp_typedef_check_ubyte[(sizeof(vwadwr_ubyte) == 1) ? 1 : -1];
+typedef char vwadwr_temp_typedef_check_ushort[(sizeof(vwadwr_ushort) == 2) ? 1 : -1];
+typedef char vwadwr_temp_typedef_check_uint[(sizeof(vwadwr_uint) == 4) ? 1 : -1];
+typedef char vwadwr_temp_typedef_check_uint64[(sizeof(vwadwr_uint64) == 8) ? 1 : -1];
+
+// this should be 64 bit (i hope so)
+typedef vwadwr_uint64 vwadwr_ftime;
+
+// for digital signatures
+typedef vwadwr_ubyte vwadwr_public_key[32];
+typedef vwadwr_ubyte vwadwr_secret_key[32];
+
+// 40 bytes of key, 5 bytes of crc32, plus zero
+typedef char vwadwr_z85_key[46];
+
+
+// for self-documentation purposes
+typedef int vwadwr_bool;
+
+// for self-documentation purposes
+// 0 is success, negative value is error
+typedef int vwadwr_result;
+
+// file handle used for writing
+// negative value is error
+typedef int vwadwr_fhandle;
+
+
+// opacue directory handle
+typedef struct vwadwr_archive_t vwadwr_archive;
+
+
+// i/o stream
+typedef struct vwadwr_iostream_t vwadwr_iostream;
+struct vwadwr_iostream_t {
+  // return non-zero on failure; failure can be delayed
+  // will never be called with negative `pos`
+  vwadwr_result (*seek) (vwadwr_iostream *strm, int pos);
+  // return negative on failure
+  int (*tell) (vwadwr_iostream *strm);
+  // read at most bufsize bytes; return number of read bytes, or negative on failure
+  // will never be called with zero or negative `bufsize`
+  // this is used only for creating digital signatures;
+  // if you don't need digital signatures, you can leave this as `NULL`
+  int (*read) (vwadwr_iostream *strm, void *buf, int bufsize);
+  // write *exactly* bufsize bytes; return 0 on success, negative on failure
+  // will never be called with zero or negative `bufsize`
+  vwadwr_result (*write) (vwadwr_iostream *strm, const void *buf, int bufsize);
+  // user data
+  void *udata;
+};
+
+// memory allocation
+typedef struct vwadwr_memman_t vwadwr_memman;
+struct vwadwr_memman_t {
+  // will never be called with zero `size`
+  // return NULL on OOM
+  void *(*alloc) (vwadwr_memman *mman, vwadwr_uint size);
+  // will never be called with NULL `p`
+  void (*free) (vwadwr_memman *mman, void *p);
+  #ifdef VWADWR_DEBUG_ALLOCS
+  // optional notifier for debug. called:
+  //   before alloc; `p` is `NULL`, `size` is size
+  //   after alloc; `p` is not `NULL`, `size` is size
+  //   before free; `p` is not `NULL`, `size` is `0`
+  void (*notify) (vwadwr_memman *mman, void *p, vwadwr_uint size,
+                  const char *srcfunc, const char *srcfile, int srcline);
+  #endif
+  // user data
+  void *udata;
+};
+
+
+#define VWADWR_LOG_NOTE     (0)
+#define VWADWR_LOG_WARNING  (1)
+#define VWADWR_LOG_ERROR    (2)
+#define VWADWR_LOG_DEBUG    (3)
+
+// logging; can be NULL
+// `type` is the above enum
+extern void (*vwadwr_logf) (int type, const char *fmt, ...);
+
+// assertion; can be NULL, then the lib will simply traps
+extern void (*vwadwr_assertion_failed) (const char *fmt, ...);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// you can encode keys in printable ASCII chars, and decode them back.
+// encoded key contains a checksum, so mistyped keys could be detected.
+void vwadwr_z85_encode_key (const vwadwr_public_key inkey, vwadwr_z85_key enkey);
+vwadwr_result vwadwr_z85_decode_key (const vwadwr_z85_key enkey, vwadwr_public_key outkey);
+void vwadwr_z85_get_pubkey (vwadwr_ubyte *pubkey, const vwadwr_ubyte *privkey);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// error codes
+#define VWADWR_OK           (0)
+// invalid author string
+#define VWADWR_ERR_AUTHOR   (-1)
+// invalid title string
+#define VWADWR_ERR_TITLE    (-2)
+// invalid comment text
+#define VWADWR_ERR_COMMENT  (-3)
+// invalid flags
+#define VWADWR_ERR_FLAGS    (-4)
+// invalid private key
+#define VWADWR_ERR_PRIVKEY  (-5)
+// out of memory
+#define VWADWR_ERR_MEM      (-6)
+// invalid file name
+#define VWADWR_ERR_NAME     (-7)
+// invalid file group name
+#define VWADWR_ERR_GROUP    (-8)
+// directory check: bad name align (should not happen)
+#define VWADWR_ERR_NAMES_ALIGN  (-9)
+// directory check: bad name table size (too big)
+#define VWADWR_ERR_NAMES_SIZE   (-10)
+// directory check: bad chunk count (too many)
+#define VWADWR_ERR_CHUNK_COUNT  (-11)
+// directory check: bad file count (too many)
+#define VWADWR_ERR_FILE_COUNT   (-12)
+// resulting vwad archive is too big
+#define VWADWR_ERR_VWAD_TOO_BIG (-13)
+// trying to pack file bigger than 4 gb
+#define VWADWR_ERR_FILE_TOO_BIG (-14)
+// duplicate file name
+#define VWADWR_ERR_DUP_FILE     (-15)
+// directory too big
+#define VWADWR_ERR_DIR_TOO_BIG  (-16)
+// invalid ascii key encoding
+#define VWADWR_ERR_BAD_ASCII    (-17)
+// various i/o errors (i don't care what exactly gone wrong)
+#define VWADWR_ERR_IO_ERROR     (-18)
+// trying to write data using invalid fd
+#define VWADWR_ERR_FILE_INVALID  (-19)
+// trying to write raw chunk to normal file, or vice versa
+// also, trying to finish archive when there are still opened files
+#define VWADWR_ERR_INVALID_MODE (-20)
+// function argument error (some pointer is NULL, or such)
+#define VWADWR_ERR_ARGS         (-669)
+// some other error
+#define VWADWR_ERR_OTHER       (-666)
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// various validators
+
+// check if the provided encryption/signing key is "good enough".
+// note that trying to create an archive with "non-good" key will fail.
+// good crypto PRNG will almost always generate good keys.
+vwadwr_bool vwadwr_is_good_privkey (const vwadwr_secret_key privkey);
+
+// use this to check if archived file name is valid.
+// archive file name should not start with slash,
+// should not end with slash, should not be empty,
+// should not be longer than 255 chars, and
+// should not contain double slashes.
+vwadwr_bool vwadwr_is_valid_file_name (const char *str);
+
+// use this to check if archived group name is valid.
+// group name not be longer than 255 chars.
+// `NULL` is valid group name.
+vwadwr_bool vwadwr_is_valid_group_name (const char *str);
+
+// check if comment text is valid.
+// `NULL` is valid comment text.
+vwadwr_bool vwadwr_is_valid_comment (const char *str);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// flags for `vwadwr_new_archive()`
+#define VWADWR_NEW_DEFAULT    (0u)
+#define VWADWR_NEW_DONT_SIGN  (0x4000u)
+
+// if `mman` is `NULL`, use libc memory manager
+// will return `NULL` on any error (including invalid comment)
+// `privkey` cannot be NULL, and should be filled with GOOD random data
+vwadwr_archive *vwadwr_new_archive (vwadwr_memman *mman, vwadwr_iostream *outstrm,
+                                    const char *author, /* can be NULL */
+                                    const char *title, /* can be NULL */
+                                    const char *comment, /* can be NULL */
+                                    vwadwr_uint flags,
+                                    /* cannot be NULL; must ALWAYS be filled with GOOD random bytes */
+                                    const vwadwr_secret_key privkey,
+                                    vwadwr_public_key respubkey, /* OUT; can be NULL */
+                                    int *error); /* OUT; can be NULL */
+
+// this can be used to abort archive creation. it doesn't write FAT,
+// just frees all memory.
+// `*wadp` will be set to NULL.
+// it is safe to pass `NULL` as `wadp` and/or as `*wadp`.
+void vwadwr_free_archive (vwadwr_archive **wadp);
+
+// return non-zero if `wad` is `NULL`, or some fatal error previously happened.
+vwadwr_bool vwadwr_is_error (const vwadwr_archive *wad);
+
+// force using FAT table for files.
+// usually, FAT is created only if we opened more than one file for writing,
+// and actually wrote some data into both.
+void vwadwr_force_fat (vwadwr_archive *wad);
+
+// check if archive will have a FAT table.
+vwadwr_bool vwadwr_is_fat (vwadwr_archive *wad);
+
+// get memory manager for the given archive
+// on any fatal error archive handle will be wiped, and this will return `NULL`.
+vwadwr_memman *vwadwr_get_memman (vwadwr_archive *wad);
+
+// get i/o stream for the given archive.
+// on any fatal error archive handle will be wiped, and this will return `NULL`.
+vwadwr_iostream *vwadwr_get_outstrm (vwadwr_archive *wad);
+
+// you can call this before `vwadwr_finish()` to perform basic checks.
+vwadwr_bool vwadwr_is_valid_dir (const vwadwr_archive *wad);
+
+// this is the same as above, but returns more detailed failure
+// reason using error code.
+vwadwr_result vwadwr_check_dir (const vwadwr_archive *wad);
+
+// this will write the FAT directory, and call `vwadwr_free_archive()` automatically
+// (even in case of error). it frees handle because there is not much could be
+// done with it after calling "finish" anyway.
+// `*wadp` will be set to NULL.
+// it is safe to pass `NULL` as `wadp` and/or as `*wadp`.
+vwadwr_result vwadwr_finish_archive (vwadwr_archive **wadp);
+
+// compression levels.
+// PLEASE, do not use numbers directly, i may change them at any time.
+/* no compression */
+#define VWADWR_COMP_DISABLE  (-1)
+/* literal-only mode (silly!) */
+#define VWADWR_COMP_FASTEST  (0)
+/* no literal-only, with no lazy matching */
+#define VWADWR_COMP_FAST     (1)
+/* no literal-only, with lazy matching */
+#define VWADWR_COMP_MEDIUM   (2)
+/* with literal-only, with lazy matching */
+#define VWADWR_COMP_BEST     (3)
+
+
+// can be used during file writing to get some stats.
+// if you want to get final stats after compression,
+// flush the file first with `vwadwr_flush_file()`.
+// all functions return negative value on error.
+int vwadwr_get_file_packed_size (vwadwr_archive *wad, vwadwr_fhandle fd);
+int vwadwr_get_file_unpacked_size (vwadwr_archive *wad, vwadwr_fhandle fd);
+int vwadwr_get_file_chunk_count (vwadwr_archive *wad, vwadwr_fhandle fd);
+
+// you can use this API to write files with the usual file write-like API.
+// please note that you cannot seek while writing; but opening several files
+// simultaneously is ok. but if you will write one file at a time, archive
+// will be smaller (because no FAT is required in this case), and seeking in
+// such archives will be faster.
+// this is for `vwadwr_write()`.
+// if this returned error, there is no reason to continue; call `vwadwr_free_archive()`.
+// note that opening file for writing will not immediately commit file record
+// into archive directory: it is commited only when the file is closed.
+// on error, returns negative error code.
+vwadwr_fhandle vwadwr_create_file (vwadwr_archive *wad, int level, /* VWADWR_COMP_xxx */
+                                   const char *pkfname,
+                                   const char *groupname, /* can be NULL */
+                                   vwadwr_ftime ftime); /* can be 0; seconds since Epoch */
+
+// trying to write 0 bytes is not an error, just a no-op
+// (yet some error checking will still be done).
+// if this returned error, there is no reason to continue; call `vwadwr_free_archive()`
+vwadwr_result vwadwr_write (vwadwr_archive *wad, vwadwr_fhandle fd,
+                            const void *buf, vwadwr_uint len);
+
+// flush buffered file data (i.e. write the last chunk).
+// you don't need to explicitly call this, but if you want correct
+// final stats (see the API above), you should flush the file
+// before closing, get stats, and then close the file.
+// note that you cannot write anything to the file after flushing.
+// flushing raw files is allowed.
+// flushing already flushed file is not an error.
+vwadwr_result vwadwr_flush_file (vwadwr_archive *wad, vwadwr_fhandle fd);
+
+// if this returned error, there is no reason to continue; call `vwadwr_free_archive()`
+vwadwr_result vwadwr_close_file (vwadwr_archive *wad, vwadwr_fhandle fd);
+
+// the same as `vwadwr_create_file()`, but for raw files.
+// use `vwadwr_write_raw_chunk()` to write raw file data.
+// on error, returns negative error code.
+vwadwr_fhandle vwadwr_create_raw_file (vwadwr_archive *wad,
+                                       const char *pkfname,
+                                       const char *groupname, /* can be NULL */
+                                       vwadwr_uint filecrc32,
+                                       vwadwr_ftime ftime); /* can be 0; seconds since Epoch */
+
+// use to copy raw decrypted chunks from other VWAD(s).
+// use raw reading API in reader to obtain chunk data.
+// `pksz`, `upksz` and `packed` are exactly what `vwad_get_raw_file_chunk_info()` returns
+// `chunk` is what `vwad_read_raw_file_chunk()` read
+vwadwr_result vwadwr_write_raw_chunk (vwadwr_archive *wad, vwadwr_fhandle fd,
+                                      const void *chunk, int pksz, int upksz, int packed);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// the following API is using the libc memory manager
+
+vwadwr_iostream *vwadwr_new_file_stream (FILE *fl);
+// this will close the file
+vwadwr_result vwadwr_close_file_stream (vwadwr_iostream *strm);
+// this will NOT close the file
+void vwadwr_free_file_stream (vwadwr_iostream *strm);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// your bog stadard CRC32 calculator. uses the same poly as zlib.
+
+vwadwr_uint vwadwr_crc32_init (void);
+vwadwr_uint vwadwr_crc32_part (vwadwr_uint crc32, const void *src, vwadwr_uint len);
+vwadwr_uint vwadwr_crc32_final (vwadwr_uint crc32);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// case-insensitive utf-8 wildcard matching
+// returns:
+//   -1: malformed pattern
+//    0: equal
+//    1: not equal
+vwadwr_result vwadwr_wildmatch (const char *pat, vwadwr_uint plen, const char *str, vwadwr_uint slen);
+vwadwr_result vwadwr_wildmatch_path (const char *pat, vwadwr_uint plen, const char *str, vwadwr_uint slen);
+
+
+// ////////////////////////////////////////////////////////////////////////// //
+// WARNING! the following API works only with unicode plane 1 -- [0..65535]!
+
+// "invalid char" unicode code
+#define VWADWR_REPLACEMENT_CHAR  (0x0FFFDu)
+
+vwadwr_uint vwadwr_utf_char_len (const void *str);
+// advances `strp` at least by one byte.
+// returns `VWADWR_REPLACEMENT_CHAR` on invalid char.
+// invalid chars are thouse with invalid utf-8, 0x7f, and unprintable.
+// printable chars are determined with `vwad_is_uni_printable()`.
+vwadwr_ushort vwadwr_utf_decode (const char **strp);
+
+// control chars are not printable, except tab (0x09), and newline (0x0a)
+// del (0x7f) is not printable too.
+vwadwr_bool vwadwr_is_uni_printable (vwadwr_ushort ch);
+// supports only limited set of known chars (mostly latin and slavic).
+vwadwr_ushort vwadwr_uni_tolower (vwadwr_ushort ch);
+
+
+#if defined(__cplusplus)
+}
+#endif
+#endif


### PR DESCRIPTION
The [vWAD](https://repo.or.cz/k8vavoom.git/blob_plain/HEAD:/libs/core/libvwad/vwadvfs.h) format has been in use by k8vavoom for some time now, primarily for its base packs and savegames but it can also be used for external mapsets and mods. EDGE-Classic has also added support for the format to supplement regular zip/pk3/epk/loose folder support. At the moment, there is no real tooling for the format outside of a handful of CLI programs that must be compiled on one's personal box. This adds support for the following vWAD features in the hopes that users of k8vavoom, EDGE-Classic, and possibly ports like Zandronum that have a similar level of DECORATE support as k8vavoom can easily view/edit/create files in this format:

- New vWad creation
- Loading/Editing/Saving existing vWads
- Viewing vWad-specific metadata if present (Author, Title, Comment, Public Key if signed)
- Generating new Private/Public vWad signing key pairs
- Deriving the vWad Public key from a provided Private Key
- Automatically signing saved vWads with a specific key (the 'vwad_private_key' CVAR; if this is blank vWads saved by SLADE will not be signed)
- Automatically setting the 'Author' metadata field for vWads (the 'vwad_author_name' CVAR)