### PR TITLE
Small CI fixes

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -83,4 +83,5 @@ jobs:
       with:
         name: ${{ github.ref_name }}
         allowUpdates: true
+        omitBodyDuringUpdate: true
         artifacts: ${{ matrix.config.artifact-path }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -68,7 +68,17 @@ jobs:
       run: |
         cd build
         dylibbundler -od -b -x slade.app/Contents/MacOS/slade -d slade.app/Contents/MacOS/libs -p @executable_path/libs
-        create-dmg --app-drop-link 10 10 ./slade_${{ matrix.config.package_name }}_${{ github.ref_name }}.dmg ./slade.app
+
+        for i in {1..10};
+        do
+          if create-dmg --app-drop-link 10 10 ./slade_${{ matrix.config.package_name }}_${{ github.ref_name }}.dmg ./slade.app;
+          then
+            echo "slade_${{ matrix.config.package_name }}_${{ github.ref_name }}.dmg created"
+            break
+          else
+            echo "create-dmg failed $i"
+          fi
+        done
 
     - name: Upload Artifacts
       if: ${{ matrix.config.package_name }}


### PR DESCRIPTION
- Dont delete release description when uploading artifacts
  https://github.com/kraflab/dsda-doom/commit/2a6741c70786ada4da588fdccd7d7c24d048ea69

- Add retry create dmg step on macOS CI
  There is a bug with the macos-13 runner where `hdutil` fails randomly https://github.com/actions/runner-images/issues/7522
  So this implements retries like many other projects have done