### PR TITLE
Disable SysEx for FluidSynth

### DIFF
--- a/src/Audio/MIDIPlayer.cpp
+++ b/src/Audio/MIDIPlayer.cpp
@@ -341,6 +341,9 @@ private:
 		if (!fs_driver_str.empty())
 			fluid_settings_setstr(fs_settings_, "audio.driver", fs_driver_str.c_str());
 
+		// Disable SysEx
+		fluid_settings_setint(fs_settings_, "synth.device-id", 0);
+
 		// Create fluidsynth objects
 		fs_synth_   = new_fluid_synth(fs_settings_);
 		fs_player_  = new_fluid_player(fs_synth_);


### PR DESCRIPTION
This upstream commit causes some problems by enabling features that were never accounted for by wads or source ports: https://github.com/FluidSynth/fluidsynth/commit/e27738b377b6b83d932779a32c16019d9ccfb6d2

This PR just sets the old default (disabled). Example test wad: D_DDTBL3.mid in DBP37_AUGZEN.wad.