### PR TITLE
Lower Java max allocation to 1GB

### DIFF
--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -1221,7 +1221,7 @@ bool entryoperations::compileDECOHack(ArchiveEntry* entry, ArchiveEntry* target,
 	entry->exportFile(srcfile);
 
 	// Execute DECOHack
-	wxString      command = "\"" + path_java + "\" -cp \"" + path_decohack + "\"" + " -Xms64M -Xmx2G net.mtrop.doom.tools.DecoHackMain \"" + srcfile + "\" -o \"" + dehfile + "\"";
+	wxString      command = "\"" + path_java + "\" -cp \"" + path_decohack + "\"" + " -Xms64M -Xmx1G net.mtrop.doom.tools.DecoHackMain \"" + srcfile + "\" -o \"" + dehfile + "\"";
 	wxArrayString output;
 	wxArrayString errout;
 	wxGetApp().SetTopWindow(parent);

--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -1221,7 +1221,7 @@ bool entryoperations::compileDECOHack(ArchiveEntry* entry, ArchiveEntry* target,
 	entry->exportFile(srcfile);
 
 	// Execute DECOHack
-	wxString      command = "\"" + path_java + "\" -cp \"" + path_decohack + "\"" + " -Xms64M -Xmx4G net.mtrop.doom.tools.DecoHackMain \"" + srcfile + "\" -o \"" + dehfile + "\"";
+	wxString      command = "\"" + path_java + "\" -cp \"" + path_decohack + "\"" + " -Xms64M -Xmx2G net.mtrop.doom.tools.DecoHackMain \"" + srcfile + "\" -o \"" + dehfile + "\"";
 	wxArrayString output;
 	wxArrayString errout;
 	wxGetApp().SetTopWindow(parent);


### PR DESCRIPTION
The Java maximum heap size for DECOHack is currently being set to 4GB, the same as in the DoomTools scripts. This is too high for 32-bit versions of Java, and as Slade still supports 32 bits, I have lowered this to 1GB.