### PR TITLE
Automatic bidirectional alignment in x and y direction

### DIFF
--- a/src/General/KeyBind.cpp
+++ b/src/General/KeyBind.cpp
@@ -720,7 +720,8 @@ void KeyBind::initBinds()
 	// Map Editor 3D Walls (me3d_wall*)
 	group = "Map Editor 3D Mode Walls";
 	addBind("me3d_wall_toggle_link_ofs", Keypress("O", KPM_CTRL), "Toggle linked wall offsets", group);
-	addBind("me3d_wall_autoalign_x", Keypress("A", KPM_CTRL), "Auto-align textures on X", group);
+	addBind("me3d_wall_autoalign_x", Keypress("A", KPM_CTRL), "Auto-align textures on X", group, false, 1);
+	addBind("me3d_wall_autoalign_y", Keypress("A", KPM_SHIFT), "Auto-align textures on Y", group, false, 1);
 	addBind("me3d_wall_unpeg_lower", Keypress("L"), "Toggle lower unpegged", group);
 	addBind("me3d_wall_unpeg_upper", Keypress("U"), "Toggle upper unpegged", group);
 

--- a/src/MapEditor/Edit/Edit3D.cpp
+++ b/src/MapEditor/Edit/Edit3D.cpp
@@ -432,13 +432,6 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 		return;
 
 	// Get texture to match
-	// We cannot guarantee all textures of bottom, middle and top to
-	// be aligned consistently. However, we assume that by selecting the
-	// top, middle or bottom section of a wall as initial element the user
-	// expresses the intent to align these sections of the walls.
-	// We therefore store the/a height at which the top of the texture
-	// on the respective wall portion would reside.
-	// We use that later to determine the proper y-offset.
 	string tex;
 	if (start.type == ItemType::WallBottom)
 		tex = firstSide->texLower();
@@ -462,7 +455,7 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 		tex_width = gl::Texture::info(gl_tex).size.x;
 		tex_height = gl::Texture::info(gl_tex).size.y;
 	}
-	// TODO: If we don't have the height of the texture, we cannot convert anchors
+	// TODO: If we don't have the height of the texture, we cannot convert texture anchors
 
 	// Get vertical texture anchor
 	// We cannot guarantee all textures of bottom, middle and top to
@@ -535,26 +528,16 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 		AlignmentJob job = jobs.front();
 		jobs.pop();
 
-		log::debug("Side is next {}",job.side->index());
-
 		// Skip if side has already been processed
 		if (processedSides.find(job.side->index()) != processedSides.end())
-		{
-			log::debug("Side {} has already been processed => skipping",job.side->index());
 			continue;
-		}
 
 		// Skip if this wall does not have the desired texture
 		if (!(job.side->texUpper() == tex || job.side->texMiddle() == tex || job.side->texLower() == tex))
-		{
-			log::debug("Side {} does not have proper texture => skipping",job.side->index());
 			continue;
-		}
 
 		// Add side to set of processed sides
 		processedSides.insert(job.side->index());
-
-		log::debug("Processing side {}",job.side->index());
 
 		// Wrap x-offset
 		if (tex_width > 0)
@@ -578,7 +561,6 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 		{
 		case AlignType::AlignY:
 		case AlignType::AlignXY:
-			// Set Y offset
 			// First we need to determine the top height for the respective texture
 			int currentTexTopHeight = -1;
 			auto currentLine = job.side->parentLine();
@@ -626,6 +608,7 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 						currentOffsetY += tex_height;
 				}
 			}
+			// Set Y offset
 			job.side->setIntProperty("offsety", currentOffsetY);
 			break;
 		}
@@ -638,7 +621,6 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 			AlignmentJob nextSideJob;
 			nextSideJob.side = nextSide;
 			nextSideJob.offsetX = job.offsetX + sideLen;
-			log::debug("Adding next side {}", nextSide->index());
 			jobs.push(nextSideJob);
 
 			if (nextSide->parentLine()->boolProperty("twosided"))

--- a/src/MapEditor/Edit/Edit3D.cpp
+++ b/src/MapEditor/Edit/Edit3D.cpp
@@ -539,19 +539,19 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 		// Add side to set of processed sides
 		processedSides.insert(job.side->index());
 
-		// Wrap x-offset
-		if (tex_width > 0)
-		{
-			while (job.offsetX >= tex_width)
-				job.offsetX -= tex_width;
-			while (job.offsetX < 0)
-				job.offsetX += tex_width;
-		}
 
 		switch (alignType)
 		{
 		case AlignType::AlignX:
 		case AlignType::AlignXY:
+			// Wrap x-offset
+			if (tex_width > 0)
+			{
+				while (job.offsetX >= tex_width)
+					job.offsetX -= tex_width;
+				while (job.offsetX < 0)
+					job.offsetX += tex_width;
+			}
 			// Set X offset
 			job.side->setIntProperty("offsetx", job.offsetX);
 			break;

--- a/src/MapEditor/Edit/Edit3D.cpp
+++ b/src/MapEditor/Edit/Edit3D.cpp
@@ -623,7 +623,7 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 			nextSideJob.offsetX = job.offsetX + sideLen;
 			jobs.push(nextSideJob);
 
-			if (nextSide->parentLine()->boolProperty("twosided"))
+			if (game::configuration().lineBasicFlagSet("twosided", nextSide->parentLine(), context_.mapDesc().format))
 			{
 				// The line is two-sided, so we consider the sector on the other side
 				auto nextOpposite = nextSide->oppositeSide();
@@ -650,7 +650,7 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 			prevSideJob.offsetX = job.offsetX - prevLen;
 			jobs.push(prevSideJob);
 
-			if (prevSide->parentLine()->boolProperty("twosided"))
+			if (game::configuration().lineBasicFlagSet("twosided", prevLine, context_.mapDesc().format))
 			{
 				// The line is two-sided, so we consider the sector on the other side
 				auto prevOpposite = prevSide->oppositeSide();

--- a/src/MapEditor/Edit/Edit3D.cpp
+++ b/src/MapEditor/Edit/Edit3D.cpp
@@ -457,8 +457,8 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 	}
 	else if (alignType == AlignType::AlignY || alignType == AlignType::AlignXY)
 	{
-		log::warning("Cannot determine height of texture {}, but is required for y alignment", tex);
 		// We need the height of the texture for vertical alignment to determine anchor points
+		log::warning("Cannot determine height of texture {}, but is required for y alignment", tex);
 		return;
 	}
 

--- a/src/MapEditor/Edit/Edit3D.cpp
+++ b/src/MapEditor/Edit/Edit3D.cpp
@@ -455,7 +455,12 @@ void Edit3D::autoAlign(mapeditor::Item start, AlignType alignType) const
 		tex_width = gl::Texture::info(gl_tex).size.x;
 		tex_height = gl::Texture::info(gl_tex).size.y;
 	}
-	// TODO: If we don't have the height of the texture, we cannot convert texture anchors
+	else if (alignType == AlignType::AlignY || alignType == AlignType::AlignXY)
+	{
+		log::warning("Cannot determine height of texture {}, but is required for y alignment", tex);
+		// We need the height of the texture for vertical alignment to determine anchor points
+		return;
+	}
 
 	// Get vertical texture anchor
 	// We cannot guarantee all textures of bottom, middle and top to

--- a/src/MapEditor/Edit/Edit3D.h
+++ b/src/MapEditor/Edit/Edit3D.h
@@ -80,14 +80,12 @@ private:
 	void        getAdjacentWalls(mapeditor::Item item, vector<mapeditor::Item>& list) const;
 	void        getAdjacentFlats(mapeditor::Item item, vector<mapeditor::Item>& list) const;
 
-	// Helper for texture auto-alighment
-	static void doAlign(
-		MapSide*                 side,
-		AlignType                alignType,
-		int                      offsetX,
-		int                      offsetY,
-		string_view              tex,
-		vector<mapeditor::Item>& walls_done,
-		int                      tex_width);
+	// Helper type for texture auto-alignment
+	struct AlignmentJob
+	{
+		MapSide* side;
+		int offsetX;
+		int offsetY;
+	};
 };
 } // namespace slade

--- a/src/MapEditor/Edit/Edit3D.h
+++ b/src/MapEditor/Edit/Edit3D.h
@@ -52,7 +52,7 @@ public:
 	void changeSectorLight(int amount) const;
 	void changeOffset(int amount, bool x) const;
 	void changeSectorHeight(int amount) const;
-	void autoAlignX(mapeditor::Item start) const;
+	void autoAlign(mapeditor::Item start, AlignType alignType = AlignType::AlignX) const;
 	void resetOffsets() const;
 	void toggleUnpegged(bool lower) const;
 	void copy(CopyType type);

--- a/src/MapEditor/Edit/Edit3D.h
+++ b/src/MapEditor/Edit/Edit3D.h
@@ -86,5 +86,8 @@ private:
 		MapSide* side;
 		int offsetX;
 	};
+
+	// Helper function for texture auto-alignment
+	int getTextureTopHeight(MapLine* firstLine, mapeditor::ItemType wallType, int tex_height) const;
 };
 } // namespace slade

--- a/src/MapEditor/Edit/Edit3D.h
+++ b/src/MapEditor/Edit/Edit3D.h
@@ -2,10 +2,12 @@
 
 #include "MapEditor/MapEditor.h"
 #include "SLADEMap/MapObject/MapThing.h"
+#include <queue>
 
 namespace slade
 {
 class MapEditContext;
+class MapVertex;
 class MapSide;
 class UndoManager;
 
@@ -87,7 +89,9 @@ private:
 		int offsetX;
 	};
 
-	// Helper function for texture auto-alignment
+	// Helper functions for texture auto-alignment
 	int getTextureTopHeight(MapLine* firstLine, mapeditor::ItemType wallType, int tex_height) const;
+	static void enqueueConnectedLines(std::queue<AlignmentJob>& jobs, MapVertex* commonVertex, int textureOffset);
+	static void enqueueSide(std::queue<AlignmentJob>& jobs, MapSide* side, MapVertex* commonVertex, int textureOffset);
 };
 } // namespace slade

--- a/src/MapEditor/Edit/Edit3D.h
+++ b/src/MapEditor/Edit/Edit3D.h
@@ -85,7 +85,6 @@ private:
 	{
 		MapSide* side;
 		int offsetX;
-		int offsetY;
 	};
 };
 } // namespace slade

--- a/src/MapEditor/Edit/Edit3D.h
+++ b/src/MapEditor/Edit/Edit3D.h
@@ -86,12 +86,12 @@ private:
 	struct AlignmentJob
 	{
 		MapSide* side;
-		int offsetX;
+		int tex_offset_x;
 	};
 
 	// Helper functions for texture auto-alignment
-	int getTextureTopHeight(MapLine* firstLine, mapeditor::ItemType wallType, int tex_height) const;
-	static void enqueueConnectedLines(std::queue<AlignmentJob>& jobs, MapVertex* commonVertex, int textureOffset);
-	static void enqueueSide(std::queue<AlignmentJob>& jobs, MapSide* side, MapVertex* commonVertex, int textureOffset);
+	int getTextureTopHeight(MapLine* firstLine, mapeditor::ItemType wall_type, int tex_height) const;
+	static void enqueueConnectedLines(std::queue<AlignmentJob>& jobs, MapVertex* common_vertex, int tex_offset_x);
+	static void enqueueSide(std::queue<AlignmentJob>& jobs, MapSide* side, MapVertex* common_vertex, int tex_offset_x);
 };
 } // namespace slade

--- a/src/MapEditor/Edit/Edit3D.h
+++ b/src/MapEditor/Edit/Edit3D.h
@@ -19,6 +19,13 @@ public:
 		Scale
 	};
 
+	enum class AlignType
+	{
+		AlignX = 1,
+		AlignY = 2,
+		AlignXY = AlignX | AlignY
+	};
+
 	explicit Edit3D(MapEditContext& context);
 
 	UndoManager* undoManager() const { return undo_manager_.get(); }
@@ -73,10 +80,12 @@ private:
 	void        getAdjacentWalls(mapeditor::Item item, vector<mapeditor::Item>& list) const;
 	void        getAdjacentFlats(mapeditor::Item item, vector<mapeditor::Item>& list) const;
 
-	// Helper for autoAlignX3d
-	static void doAlignX(
+	// Helper for texture auto-alighment
+	static void doAlign(
 		MapSide*                 side,
-		int                      offset,
+		AlignType                alignType,
+		int                      offsetX,
+		int                      offsetY,
 		string_view              tex,
 		vector<mapeditor::Item>& walls_done,
 		int                      tex_width);

--- a/src/MapEditor/MapEditContext.cpp
+++ b/src/MapEditor/MapEditContext.cpp
@@ -1236,7 +1236,9 @@ bool MapEditContext::handleKeyBind(string_view key, Vec2d position)
 
 		// Auto-align
 		else if (key == "me3d_wall_autoalign_x")
-			edit_3d_.autoAlignX(selection_.hilight());
+			edit_3d_.autoAlign(selection_.hilight(), Edit3D::AlignType::AlignX);
+		else if (key == "me3d_wall_autoalign_y")
+			edit_3d_.autoAlign(selection_.hilight(), Edit3D::AlignType::AlignY);
 
 		// Reset wall offsets
 		else if (key == "me3d_wall_reset")

--- a/src/SLADEMap/MapObject/MapLine.cpp
+++ b/src/SLADEMap/MapObject/MapLine.cpp
@@ -800,6 +800,66 @@ bool MapLine::intersects(MapLine* other, Vec2d& intersect_point) const
 }
 
 // -----------------------------------------------------------------------------
+// Returns the height of the lowest ceiling of any of the adjacent sectors
+// -----------------------------------------------------------------------------
+int MapLine::lowestCeiling() const
+{
+	int lowestCeiling = side1_->sector()->ceiling().height;
+	if (side2_)
+	{
+		const int ceiling2 = side2_->sector()->ceiling().height;
+		if (ceiling2<lowestCeiling)
+			lowestCeiling = ceiling2;
+	}
+	return lowestCeiling;
+}
+
+// -----------------------------------------------------------------------------
+// Returns the height of the highest ceiling of any of the adjacent sectors
+// -----------------------------------------------------------------------------
+int MapLine::highestCeiling() const
+{
+	int highestCeiling = side1_->sector()->ceiling().height;
+	if (side2_)
+	{
+		const int ceiling2 = side2_->sector()->ceiling().height;
+		if (ceiling2>highestCeiling)
+			highestCeiling = ceiling2;
+	}
+	return highestCeiling;
+}
+
+// -----------------------------------------------------------------------------
+// Returns the height of the lowest floor of any of the adjacent sectors
+// -----------------------------------------------------------------------------
+int MapLine::lowestFloor() const
+{
+	int lowestFloor = side1_->sector()->floor().height;
+	if (side2_)
+	{
+		const int floor2 = side2_->sector()->floor().height;
+		if (floor2<lowestFloor)
+			lowestFloor = floor2;
+	}
+	return lowestFloor;
+}
+
+// -----------------------------------------------------------------------------
+// Returns the height of the highest floor of any of the adjacent sectors
+// -----------------------------------------------------------------------------
+int MapLine::highestFloor() const
+{
+	int highestFloor = side1_->sector()->floor().height;
+	if (side2_)
+	{
+		const int floor2 = side2_->sector()->floor().height;
+		if (floor2>highestFloor)
+			highestFloor = floor2;
+	}
+	return highestFloor;
+}
+
+// -----------------------------------------------------------------------------
 // Clears any textures not needed on the line
 // (eg. a front upper texture that would be invisible)
 // -----------------------------------------------------------------------------

--- a/src/SLADEMap/MapObject/MapLine.h
+++ b/src/SLADEMap/MapObject/MapLine.h
@@ -104,6 +104,11 @@ public:
 	bool   overlaps(MapLine* other) const;
 	bool   intersects(MapLine* other, Vec2d& intersect_point) const;
 
+	int lowestCeiling() const;
+	int highestCeiling() const;
+	int lowestFloor() const;
+	int highestFloor() const;
+
 	void clearUnneededTextures() const;
 	void resetInternals();
 	void flip(bool sides = true);

--- a/src/SLADEMap/MapObject/MapSide.cpp
+++ b/src/SLADEMap/MapObject/MapSide.cpp
@@ -133,6 +133,93 @@ void MapSide::copy(MapObject* c)
 	MapObject::copy(c);
 }
 
+
+// -----------------------------------------------------------------------------
+// Determine whether this is the front side of the line
+// -----------------------------------------------------------------------------
+bool MapSide::isFrontSide() const
+{
+	return parentLine()->s1() == this;
+}
+
+// -----------------------------------------------------------------------------
+// Get the start vertex of this side
+// -----------------------------------------------------------------------------
+MapVertex* MapSide::startVertex() const
+{
+	if (isFrontSide())
+		return parentLine()->v1();
+	else
+		return parentLine()->v2();
+}
+
+// -----------------------------------------------------------------------------
+// Get the end vertex of this side
+// -----------------------------------------------------------------------------
+MapVertex* MapSide::endVertex() const
+{
+	if (isFrontSide())
+		return parentLine()->v2();
+	else
+		return parentLine()->v1();
+}
+
+// -----------------------------------------------------------------------------
+// Get the opposite side of this side
+// -----------------------------------------------------------------------------
+MapSide* MapSide::oppositeSide() const
+{
+	if (isFrontSide())
+		return parentLine()->s2();
+	else
+		return parentLine()->s1();
+}
+
+// -----------------------------------------------------------------------------
+// Returns the side sharing both our end vertex and the same sector
+// -----------------------------------------------------------------------------
+MapSide* MapSide::nextInSector() const
+{
+	for (MapLine* line: endVertex()->connectedLines())
+	{
+		// Check front side
+		auto s = line->s1();
+		if (s && s != this && s->sector()->index() == sector()->index())
+			return s;
+
+		// Check back side
+		s = line->s2();
+		if (s && s != this && s->sector()->index() == sector()->index())
+			return s;
+	}
+
+	// Any sector should have at least two sides associated with it, so we should not be here...
+	return nullptr;
+}
+
+// -----------------------------------------------------------------------------
+// Returns the side sharing both our start vertex and the same sector
+// -----------------------------------------------------------------------------
+MapSide* MapSide::prevInSector() const
+{
+	for (MapLine* line: startVertex()->connectedLines())
+	{
+		// Check front side
+		auto s = line->s1();
+		if (s && s != this && s->sector()->index() == sector()->index())
+			return s;
+
+		// Check back side
+		s = line->s2();
+		if (s && s != this && s->sector()->index() == sector()->index())
+			return s;
+	}
+
+	// Any sector should have at least two sides associated with it, so we should not be here...
+	return nullptr;
+}
+
+
 // -----------------------------------------------------------------------------
 // Returns the light level of the given side
 // -----------------------------------------------------------------------------

--- a/src/SLADEMap/MapObject/MapSide.cpp
+++ b/src/SLADEMap/MapObject/MapSide.cpp
@@ -164,61 +164,6 @@ MapVertex* MapSide::endVertex() const
 		return parentLine()->v1();
 }
 
-// -----------------------------------------------------------------------------
-// Get the opposite side of this side
-// -----------------------------------------------------------------------------
-MapSide* MapSide::oppositeSide() const
-{
-	if (isFrontSide())
-		return parentLine()->s2();
-	else
-		return parentLine()->s1();
-}
-
-// -----------------------------------------------------------------------------
-// Returns the side sharing both our end vertex and the same sector
-// -----------------------------------------------------------------------------
-MapSide* MapSide::nextInSector() const
-{
-	for (MapLine* line: endVertex()->connectedLines())
-	{
-		// Check front side
-		auto s = line->s1();
-		if (s && s != this && s->sector()->index() == sector()->index())
-			return s;
-
-		// Check back side
-		s = line->s2();
-		if (s && s != this && s->sector()->index() == sector()->index())
-			return s;
-	}
-
-	// Any sector should have at least two sides associated with it, so we should not be here...
-	return nullptr;
-}
-
-// -----------------------------------------------------------------------------
-// Returns the side sharing both our start vertex and the same sector
-// -----------------------------------------------------------------------------
-MapSide* MapSide::prevInSector() const
-{
-	for (MapLine* line: startVertex()->connectedLines())
-	{
-		// Check front side
-		auto s = line->s1();
-		if (s && s != this && s->sector()->index() == sector()->index())
-			return s;
-
-		// Check back side
-		s = line->s2();
-		if (s && s != this && s->sector()->index() == sector()->index())
-			return s;
-	}
-
-	// Any sector should have at least two sides associated with it, so we should not be here...
-	return nullptr;
-}
-
 
 // -----------------------------------------------------------------------------
 // Returns the light level of the given side

--- a/src/SLADEMap/MapObject/MapSide.h
+++ b/src/SLADEMap/MapObject/MapSide.h
@@ -37,6 +37,12 @@ public:
 
 	MapSector*    sector() const { return sector_; }
 	MapLine*      parentLine() const { return parent_; }
+	bool          isFrontSide() const;
+	MapVertex*    startVertex() const;
+	MapVertex*    endVertex() const;
+	MapSide*      oppositeSide() const;
+	MapSide*      nextInSector() const;
+	MapSide*      prevInSector() const;
 	const string& texUpper() const { return tex_upper_; }
 	const string& texMiddle() const { return tex_middle_; }
 	const string& texLower() const { return tex_lower_; }

--- a/src/SLADEMap/MapObject/MapSide.h
+++ b/src/SLADEMap/MapObject/MapSide.h
@@ -40,9 +40,6 @@ public:
 	bool          isFrontSide() const;
 	MapVertex*    startVertex() const;
 	MapVertex*    endVertex() const;
-	MapSide*      oppositeSide() const;
-	MapSide*      nextInSector() const;
-	MapSide*      prevInSector() const;
 	const string& texUpper() const { return tex_upper_; }
 	const string& texMiddle() const { return tex_middle_; }
 	const string& texLower() const { return tex_lower_; }


### PR DESCRIPTION
This addresses bidirectional alignment as mentioned in #400 and y-alignment as mentioned in #486. These are the aspects implemented:

- Automatic horizontal (x-) texture alignment in both directions (#486)
- Automatic vertical (y-) texture alignment using vanilla DOOM single y-offset per side and taking pegging into account (#400)

Aspects not implemented:
- auto-justification as mentioned in #486.
- application of individual y-offsets for upper, middle and lower wall part as supported by UDMF, for example.

This supersedes my previous pull request #1780 as I restructured the alignment implementation to minimize code duplication and extensive parameter passing, and extended the scope to generalized auto-alignment.

As this is limited to the single y-offset from vanilla DOOM, vertical alignment cannot be applied so that the whole wall is properly aligned, but instead only to part of a wall. The wall part selected when activating the alignment hotkey is taken as an indicator of user intent, i.e.

- If the upper part of a wall is selected, the intent is taken to be aligning upper parts of two-sided walls to each other.
- If the lower part of a wall is selected, the intent is taken to be aligning lower parts of two-sided walls to each other.
- If the midde part of a wall is selected, the intent is taken to be aligning middle parts of walls to each other.

When a one-sided wall is encountered while aligning with "upper wall" or "lower wall" intent, the middle section of the one-sided wall is aligned appropriately. Thus, taking the intent into consideration, this should mostly "just work as expected" (tm).

However, a wall is taken into consideration for alignment if any of its upper, middle or lower texture match the texture of the initial wall segment selected. If, for example, a one-sided wall is selected as initial wall by the user, alignment applies to the middle texture of two-sided walls, even if only the upper or lower wall texture matches that of the initial wall. In that case the non-matching middle texture of the two-sided wall would be aligned to the single middle texture of the one-sided wall.

This could be "fixed" by being more strict about the inclusion of walls into the alignment, but I have shied away from that as it would be a significant change away from the old behavior. However, if that is desired, I can amend this pull request appropriately.