### PR TITLE
Added 'Quick Run Archive' button

### DIFF
--- a/dist/res/actions/arch.cfg
+++ b/dist/res/actions/arch.cfg
@@ -435,6 +435,14 @@ action arch_run
 	shortcut	= "Ctrl+Shift+R";
 }
 
+action arch_quick_run
+{
+       text            = "Quick Run Archive";
+       icon            = "run_quick";
+       help_text       = "Run the current archive without opening the configuration dialog";
+       shortcut        = "Ctrl+R";
+}
+
 action arch_script
 {
 	reserve_ids	= 100;

--- a/src/MainEditor/UI/ArchivePanel.cpp
+++ b/src/MainEditor/UI/ArchivePanel.cpp
@@ -706,6 +706,8 @@ void ArchivePanel::addMenus() const
 
 		menu_archive->AppendSeparator();
 		SAction::fromId("arch_run")->addToMenu(menu_archive, true, "Run");
+		SAction::fromId("arch_quick_run")->addToMenu(menu_archive, true,
+ "Quick Run");
 	}
 	if (!menu_entry)
 	{
@@ -3441,10 +3443,10 @@ bool ArchivePanel::handleAction(string_view id)
 	}
 
 	// Run archive
-	else if (id == "arch_run")
+	else if (id == "arch_run" || id == "arch_quick_run")
 	{
 		RunDialog dlg(this, archive.get());
-		if (dlg.ShowModal() == wxID_OK)
+		if (id == "arch_quick_run" || dlg.ShowModal() == wxID_OK)
 		{
 			auto command = dlg.selectedCommandLine(archive.get(), "");
 			if (!command.empty())

--- a/src/MainEditor/UI/MainWindow.cpp
+++ b/src/MainEditor/UI/MainWindow.cpp
@@ -351,6 +351,7 @@ void MainWindow::setupLayout()
 	tbg_archive->addActionButton("arch_texeditor");
 	tbg_archive->addActionButton("arch_mapeditor");
 	tbg_archive->addActionButton("arch_run");
+	tbg_archive->addActionButton("arch_quick_run");
 	auto* b_maint = tbg_archive->addActionButton(
 		"arch_maintenance", "Maintenance", "wrench", "Archive maintenance/cleanup tools");
 	b_maint->setMenu(ArchivePanel::createMaintenanceMenu());


### PR DESCRIPTION
Adds a 'Quick Run Archive' button to the archive view similar to the 'Quick Run Map' button found in the map editor (#1531). Executes the current run configuration without showing the configuration dialog.

<img width="802" alt="Screenshot 2025-05-15 at 12 35 58" src="https://github.com/user-attachments/assets/ab9cfc19-52c3-4558-97d9-8ea08c1aa27c" />