### PR TITLE
Make png optimization use Slade's cache directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In addition to full Doom [WAD](http://doomwiki.org/wiki/WAD) and [ZIP/PK3](http:
 * [Many more](https://github.com/sirjuddington/SLADE/wiki/Supported-Data-Formats)
 
 **Advanced text editor**  
-The SLADE3 text editor can recognise many text based languages, and provide syntax hilighting, function calltips and autocomplete for them. It also has a bunch of other useful text editing features such as autoindent and find / replace.
+The SLADE3 text editor can recognise many text based languages, and provide syntax highlighting, function calltips and autocomplete for them. It also has a bunch of other useful text editing features such as autoindent and find / replace.
 
 **Graphic conversion**  
 All supported graphic formats can be converted to PNG/DoomGfx/DoomFlat and more, with an advanced graphic conversion dialog that provides conversion options and previews.

--- a/src/MainEditor/EntryOperations.cpp
+++ b/src/MainEditor/EntryOperations.cpp
@@ -1386,7 +1386,8 @@ bool entryoperations::optimizePNG(ArchiveEntry* entry)
 	// Run PNGCrush
 	if (!pngpathc.empty() && fileutil::fileExists(pngpathc))
 	{
-		strutil::Path fn(pngpathc);
+		string tmppath = app::path("", app::Dir::Temp) += "opt";
+		strutil::Path fn(tmppath);
 		fn.setExtension("opt");
 		string pngfile = fn.fullPath();
 		fn.setExtension("png");
@@ -1438,7 +1439,8 @@ bool entryoperations::optimizePNG(ArchiveEntry* entry)
 	// Run PNGOut
 	if (!pngpatho.empty() && fileutil::fileExists(pngpatho))
 	{
-		strutil::Path fn(pngpatho);
+		string tmppath = app::path("", app::Dir::Temp) += "opt";
+		strutil::Path fn(tmppath);
 		fn.setExtension("opt");
 		string pngfile = fn.fullPath();
 		fn.setExtension("png");
@@ -1491,7 +1493,8 @@ bool entryoperations::optimizePNG(ArchiveEntry* entry)
 	// Run deflopt
 	if (!pngpathd.empty() && fileutil::fileExists(pngpathd))
 	{
-		strutil::Path fn(pngpathd);
+		string tmppath = app::path("", app::Dir::Temp) += "opt";
+		strutil::Path fn(tmppath);
 		fn.setExtension("png");
 		string pngfile = fn.fullPath();
 		entry->exportFile(pngfile);


### PR DESCRIPTION
On UNIX, SLADE tried to write PNG files to the location of the optimization tools which is usually located in a directory where regular users don't have write privileges. This pr makes these PNG files get written to SLADE's cache directory.
This pr also fixes 1 miss-spell in the README.
I did not manage to test this pr on windows because I couldn't figure out how to compile SLADE on windows, although it should work because it changes one file path to a path that the rest of SLADE uses.