### PR TITLE
Upload Linux artifacts

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -30,11 +30,15 @@ jobs:
           - name: "Linux GCC"
             os: ubuntu-24.04
             shell: bash
+            package_name: "linux_gcc"
+            artifact-path: build/*
 
           - name: "Linux Clang"
             os: ubuntu-24.04
             shell: bash
             extra_options: "-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++"
+            package_name: "linux_clang"
+            artifact-path: build/*
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Linux artifacts should be uploaded, just like macOS ones.

FYI your release mechanism is also broken (I think) so maybe I could fix that too.