### PR TITLE
Fix Eternity Line_QuickPortal special

### DIFF
--- a/dist/res/config/ports/include/specials_eternity.cfg
+++ b/dist/res/config/ports/include/specials_eternity.cfg
@@ -2672,11 +2672,10 @@ action_specials
 				name = "Non-interactive";
 				type = choice;
 				custom_values {
-					0 = "True";
-					1 = "Interactive";
+					0 = "Interactive";
+					1 = "Non-interactive";
 				}
 			}
-			tagged = line;
 		}
 	}
 


### PR DESCRIPTION
This fixes a couple issues with the definition of [Line_QuickPortal](https://eternity.youfailit.net/wiki/Line_QuickPortal) for Eternity.

- The values of Arg1 were labeled backwards. 0 makes the portal interactive and 1 makes it non-interactive.
- Arg1 was also being treated as a Line ID, which is not correct. So for an interactive portal (Arg1=0) it was drawing an arrow to every other line with ID=0

Portals are actually connected by having the same line ID, but I couldn't see a way to represent that in SLADE, so I just removed the tag type.