### PR TITLE
Add texturex/pnames tabs before setting up their layout

### DIFF
--- a/src/MainEditor/UI/TextureXEditor/PatchTablePanel.cpp
+++ b/src/MainEditor/UI/TextureXEditor/PatchTablePanel.cpp
@@ -203,11 +203,6 @@ PatchTablePanel::PatchTablePanel(wxWindow* parent, PatchTable* patch_table, Text
 	patch_table_{ patch_table },
 	parent_{ tx_editor }
 {
-	setupLayout();
-
-	// Bind events
-	list_patches_->Bind(wxEVT_LIST_ITEM_SELECTED, &PatchTablePanel::onDisplayChanged, this);
-
 	// Update when main palette changed
 	sc_palette_changed_ = theMainWindow->paletteChooser()->signals().palette_changed.connect([this]()
 																							 { updateDisplay(); });
@@ -250,6 +245,9 @@ void PatchTablePanel::setupLayout()
 	framesizer->Add(patch_canvas_, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, ui::pad());
 	framesizer->Add(label_dimensions_, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, ui::pad());
 	framesizer->Add(label_textures_, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, ui::pad());
+
+	// Bind events
+	list_patches_->Bind(wxEVT_LIST_ITEM_SELECTED, &PatchTablePanel::onDisplayChanged, this);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/MainEditor/UI/TextureXEditor/PatchTablePanel.h
+++ b/src/MainEditor/UI/TextureXEditor/PatchTablePanel.h
@@ -45,6 +45,8 @@ public:
 	PatchTablePanel(wxWindow* parent, PatchTable* patch_table, TextureXEditor* tx_editor = nullptr);
 	~PatchTablePanel() = default;
 
+	void setupLayout();
+
 private:
 	PatchTable*         patch_table_      = nullptr;
 	PatchTableListView* list_patches_     = nullptr;
@@ -55,7 +57,6 @@ private:
 	ui::ZoomControl*    zc_zoom_          = nullptr;
 	SToolBar*           toolbar_          = nullptr;
 
-	void setupLayout();
 	void updateDisplay();
 
 	void addPatch();

--- a/src/MainEditor/UI/TextureXEditor/TextureXEditor.cpp
+++ b/src/MainEditor/UI/TextureXEditor/TextureXEditor.cpp
@@ -314,8 +314,6 @@ bool TextureXEditor::openArchive(Archive* archive)
 		// Open TEXTUREX entry
 		if (tx_panel->openTEXTUREX(tx_entry))
 		{
-			// Set palette
-			tx_panel->setPalette(theMainWindow->paletteChooser()->selectedPalette());
 			// Lock entry
 			tx_entry->lock();
 
@@ -323,6 +321,9 @@ bool TextureXEditor::openArchive(Archive* archive)
 			tx_panel->SetName(wxS("textures"));
 			texture_editors_.push_back(tx_panel);
 			tabs_->AddPage(tx_panel, wxString::FromUTF8(tx_entry->name()));
+
+			tx_panel->setupUI();
+			tx_panel->setPalette(theMainWindow->paletteChooser()->selectedPalette());
 		}
 
 		tx_panel->Show(true);
@@ -335,6 +336,7 @@ bool TextureXEditor::openArchive(Archive* archive)
 		tabs_->AddPage(ptp, wxS("Patch Table (PNAMES)"));
 		ptp->SetName(wxS("pnames"));
 		pnames_tab_index_ = tabs_->GetPageCount() - 1;
+		ptp->setupLayout();
 	}
 
 	// Search archive for TEXTURES entries
@@ -363,8 +365,6 @@ bool TextureXEditor::openArchive(Archive* archive)
 		// Open TEXTURES entry
 		if (tx_panel->openTEXTUREX(ztx_entry))
 		{
-			// Set palette
-			tx_panel->setPalette(theMainWindow->paletteChooser()->selectedPalette());
 			// Lock entry
 			ztx_entry->lock();
 
@@ -372,6 +372,9 @@ bool TextureXEditor::openArchive(Archive* archive)
 			tx_panel->SetName(wxS("textures"));
 			texture_editors_.push_back(tx_panel);
 			tabs_->AddPage(tx_panel, wxString::FromUTF8(ztx_entry->name()));
+
+			tx_panel->setupUI();
+			tx_panel->setPalette(theMainWindow->paletteChooser()->selectedPalette());
 		}
 
 		tx_panel->Show(true);
@@ -463,8 +466,6 @@ bool TextureXEditor::openEntry(ArchiveEntry* tx_entry)
 		// Open TEXTUREX entry
 		if (tx_panel->openTEXTUREX(tx_entry))
 		{
-			// Set palette
-			tx_panel->setPalette(theMainWindow->paletteChooser()->selectedPalette());
 			// Lock entry
 			tx_entry->lock();
 
@@ -475,6 +476,9 @@ bool TextureXEditor::openEntry(ArchiveEntry* tx_entry)
 				tabs_->AddPage(tx_panel, wxString::FromUTF8(tx_entry->name()));
 			else
 				tabs_->InsertPage(pnames_tab_index_, tx_panel, wxString::FromUTF8(tx_entry->name()));
+
+			tx_panel->setupUI();
+			tx_panel->setPalette(theMainWindow->paletteChooser()->selectedPalette());
 		}
 
 		tx_panel->Show(true);
@@ -491,8 +495,6 @@ bool TextureXEditor::openEntry(ArchiveEntry* tx_entry)
 		// Open TEXTURES entry
 		if (tx_panel->openTEXTUREX(tx_entry))
 		{
-			// Set palette
-			tx_panel->setPalette(theMainWindow->paletteChooser()->selectedPalette());
 			// Lock entry
 			tx_entry->lock();
 
@@ -503,6 +505,9 @@ bool TextureXEditor::openEntry(ArchiveEntry* tx_entry)
 				tabs_->AddPage(tx_panel, wxString::FromUTF8(tx_entry->name()));
 			else
 				tabs_->InsertPage(pnames_tab_index_, tx_panel, wxString::FromUTF8(tx_entry->name()));
+
+			tx_panel->setupUI();
+			tx_panel->setPalette(theMainWindow->paletteChooser()->selectedPalette());
 		}
 
 		tx_panel->Show(true);
@@ -515,6 +520,7 @@ bool TextureXEditor::openEntry(ArchiveEntry* tx_entry)
 		tabs_->AddPage(ptp, wxS("Patch Table (PNAMES)"));
 		ptp->SetName(wxS("pnames"));
 		pnames_tab_index_ = tabs_->GetPageCount() - 1;
+		ptp->setupLayout();
 	}
 
 	// Update layout

--- a/src/MainEditor/UI/TextureXEditor/TextureXPanel.cpp
+++ b/src/MainEditor/UI/TextureXEditor/TextureXPanel.cpp
@@ -679,7 +679,10 @@ TextureXPanel::~TextureXPanel()
 }
 
 // -----------------------------------------------------------------------------
-// Loads a TEXTUREx or TEXTURES format texture list into the editor
+// Loads a TEXTUREx or TEXTURES format texture list into the editor.
+// If [entry] is a valid format returns truc.
+//
+// Call setupUI() after this if it succeeds
 // -----------------------------------------------------------------------------
 bool TextureXPanel::openTEXTUREX(ArchiveEntry* entry)
 {
@@ -689,7 +692,37 @@ bool TextureXPanel::openTEXTUREX(ArchiveEntry* entry)
 		// TEXTURE1/2 format
 		if (!texturex_.readTEXTUREXData(entry, tx_editor_->patchTable()))
 			return false;
+	}
+	else
+	{
+		// TEXTURES format
+		if (!texturex_.readTEXTURESData(entry))
+			return false;
+	}
 
+	tx_entry_ = entry;
+
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Sets up the UI after loading a TEXTUREx list
+// -----------------------------------------------------------------------------
+void TextureXPanel::setupUI()
+{
+	// TEXTURES format
+	if (texturex_.format() == TextureXList::Format::Textures)
+	{
+		// Create extended texture editor
+		texture_editor_ = new ZTextureEditorPanel(this, tx_editor_);
+
+		// Add 'type' column
+		list_textures_->InsertColumn(2, wxS("Type"));
+	}
+
+	// Any other TEXTUREx format
+	else
+	{
 		// Create default texture editor
 		texture_editor_ = new TextureEditorPanel(this, tx_editor_);
 
@@ -703,20 +736,6 @@ bool TextureXPanel::openTEXTUREX(ArchiveEntry* entry)
 				tx_editor_->patchTable().patch(tex->patch(p)->name()).used_in.push_back(tex->name());
 		}
 	}
-	else
-	{
-		// TEXTURES format
-		if (!texturex_.readTEXTURESData(entry))
-			return false;
-
-		// Create extended texture editor
-		texture_editor_ = new ZTextureEditorPanel(this, tx_editor_);
-
-		// Add 'type' column
-		list_textures_->InsertColumn(2, wxS("Type"));
-	}
-
-	tx_entry_ = entry;
 
 	// Add texture editor area
 	GetSizer()->Add(texture_editor_, 1, wxEXPAND | wxALL, ui::pad());
@@ -730,8 +749,6 @@ bool TextureXPanel::openTEXTUREX(ArchiveEntry* entry)
 	list_textures_->updateList();
 	Layout();
 	Update();
-
-	return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/MainEditor/UI/TextureXEditor/TextureXPanel.h
+++ b/src/MainEditor/UI/TextureXEditor/TextureXPanel.h
@@ -50,6 +50,7 @@ public:
 	TextureEditorPanel* textureEditor() const { return texture_editor_; }
 
 	bool openTEXTUREX(ArchiveEntry* entry);
+	void setupUI(); // Call after successful openTEXTUREX
 	bool saveTEXTUREX();
 	void setPalette(Palette* pal) const;
 	void applyChanges();


### PR DESCRIPTION
Apparently this causes a crash on Linux with x11+EGL, thanks to @Blzut3 for finding the issue