### PR TITLE
doc: specify build requirements more exactly

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -2,13 +2,14 @@
 
 ### Mandatory build-time requirements
 
-* C++17 compiler (e.g. g++ 8.x)
+* C++17 compiler (e.g. g++ >= 8.x)
 * bzip2 library
 * ftgl, an OpenGL font managing library
-* mpg123 library
+* mpg123 library >= 1.28.1
 * OpenGL
 * SFML
-* wxWidgets 3.x
+* wxWidgets >= 3.3.1 (it may build with lesser, but that is not recommended due
+  to known bugs)
 * zlib
 * libwebp
 


### PR DESCRIPTION
SLADE uses wxBitmapBundle, first introduced with wx 3.1.6. SLADE uses mpg123_ssize_t, first introduced with mpg123 1.28.1.