### PR TITLE
Use wxWidgets to center the mouse on the 3D map editor

### DIFF
--- a/src/MapEditor/UI/MapCanvas.cpp
+++ b/src/MapEditor/UI/MapCanvas.cpp
@@ -116,9 +116,9 @@ void MapCanvas::draw()
 // -----------------------------------------------------------------------------
 void MapCanvas::mouseToCenter()
 {
-	auto rect   = GetScreenRect();
 	mouse_warp_ = true;
-	sf::Mouse::setPosition(sf::Vector2i(rect.x + int(rect.width * 0.5), rect.y + int(rect.height * 0.5)));
+	const wxSize size = GetSize();
+	WarpPointer(int(size.x * 0.5), int(size.y * 0.5));
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Upcoming wxWidgets releases will use the `wp_pointer_warp_v1` Wayland protocol for `wxWindow::WarpPointer`, which allows the 3D map editor to work on Wayland compositors that support it (e.g. Plasma 6.5+).

In the mid-long term, this should fix issue #1595.