### PR TITLE
Fix failed fluid synth driver causing segfault

### DIFF
--- a/src/Audio/MIDIPlayer.cpp
+++ b/src/Audio/MIDIPlayer.cpp
@@ -375,6 +375,7 @@ private:
 
 			// Driver creation unsuccessful
 			delete_fluid_synth(fs_synth_);
+			fs_synth_ = nullptr;
 			return false;
 		}
 


### PR DESCRIPTION
A failed fluid synth driver initializiation would cause SLADE to segfault when clicking on any audio file.

This could for example happen when fluidsynth wasn't compiled with pulseaudio support.

The cause was `fs_synth_` still pointing to the freed memory
(specifically `fluid_synth_all_notes_off(fs_synth_, -1)` would be called in `FluidSynthMIDIPlayer::stop()` while clicking on audio files).