### PR TITLE
Add support for base udmf spec

### DIFF
--- a/dist/res/config/games/doom1.cfg
+++ b/dist/res/config/games/doom1.cfg
@@ -10,7 +10,7 @@ game doom
 	iwad = "doom.wad";
 
 	// Supported map formats
-	map_formats = doom;
+	map_formats = doom, udmf;
 
 	// DECORATE filters
 	filters = "doom", "any";
@@ -20,6 +20,9 @@ game doom
 
 	// Light levels
 	light_level_interval = 16;
+
+	// UDMF namespace
+	udmf_namespace = "doom";
 
 	// Maps
 	maps

--- a/dist/res/config/games/doom2.cfg
+++ b/dist/res/config/games/doom2.cfg
@@ -10,7 +10,7 @@ game doom2
 	iwad = "doom2.wad";
 
 	// Supported map formats
-	map_formats = doom;
+	map_formats = doom, udmf;
 
 	// DECORATE filters
 	filters = "doom", "any";
@@ -20,6 +20,9 @@ game doom2
 
 	// Light levels
 	light_level_interval = 16;
+
+	// UDMF namespace
+	udmf_namespace = "doom";
 
 	// Maps
 	maps

--- a/dist/res/config/games/heretic.cfg
+++ b/dist/res/config/games/heretic.cfg
@@ -9,7 +9,7 @@ game heretic
 	iwad = "heretic.wad";
 
 	// Supported map formats
-	map_formats = doom;
+	map_formats = doom, udmf;
 
 	// DECORATE filters
 	filters = "heretic", "raven", "any";
@@ -19,6 +19,9 @@ game heretic
 
 	// Light levels
 	light_level_interval = 16;
+
+	// UDMF namespace
+	udmf_namespace = "heretic";
 
 	// Maps
 	maps

--- a/dist/res/config/games/hexen.cfg
+++ b/dist/res/config/games/hexen.cfg
@@ -9,7 +9,7 @@ game hexen
 	iwad = "hexen.wad";
 
 	// Supported map formats
-	map_formats = hexen;
+	map_formats = hexen, udmf;
 
 	// DECORATE filters
 	filters = "hexen", "raven", "any";
@@ -22,6 +22,9 @@ game hexen
 
 	// Light levels
 	light_level_interval = 16;
+
+	// UDMF namespace
+	udmf_namespace = "hexen";
 
 	// Maps
 	maps

--- a/dist/res/config/games/include/props_base.cfg
+++ b/dist/res/config/games/include/props_base.cfg
@@ -20,11 +20,12 @@ udmf_properties
 			type = int;
 			show_always = true;
 
+			// Defaults to 0 in Doom/Heretic/Strife namespaces
 			property id
 			{
 				name = "Line ID";
 				type = id;
-				default = -1;
+				default = 0;
 				show_always = false;
 			}
 
@@ -77,7 +78,7 @@ udmf_properties
 				type = actionspecial;
 			}
 
-			property arg0		= "Arg 0";
+			property arg0		= "Target ID";
 			property arg1		= "Arg 1";
 			property arg2		= "Arg 2";
 			property arg3		= "Arg 3";

--- a/dist/res/config/games/include/props_hexen.cfg
+++ b/dist/res/config/games/include/props_hexen.cfg
@@ -3,6 +3,18 @@ udmf_properties
 {
 	block linedef
 	{
+		group "Basic"
+		{
+			// Defaults to -1 in Hexen namespaces
+			property id
+			{
+				name = "Line ID";
+				type = id;
+				default = -1;
+				show_always = false;
+			}
+		}
+
 		group "Flags"
 		{
 			property repeatspecial

--- a/dist/res/config/games/include/sectors_doom.cfg
+++ b/dist/res/config/games/include/sectors_doom.cfg
@@ -1,4 +1,4 @@
-#ifdef MAP_DOOM
+
 // Vanilla Doom sector types
 sector_types
 {
@@ -19,4 +19,3 @@ sector_types
 	type 16	= "20% Damage";
 	type 17	= "Light Flicker";
 }
-#endif

--- a/dist/res/config/games/include/sectors_heretic.cfg
+++ b/dist/res/config/games/include/sectors_heretic.cfg
@@ -1,4 +1,4 @@
-#ifdef MAP_DOOM
+
 // Heretic sector types
 sector_types
 {
@@ -50,4 +50,3 @@ sector_types
 	type 50	= "Wind West (10)";
 	type 51	= "Wind West (25)";
 }
-#endif

--- a/dist/res/config/games/include/sectors_strife.cfg
+++ b/dist/res/config/games/include/sectors_strife.cfg
@@ -1,4 +1,4 @@
-#ifdef MAP_DOOM
+
 // Vanilla Strife sector types
 sector_types
 {
@@ -21,4 +21,3 @@ sector_types
 	type 17	= "Light Flicker";
 	type 18	= "Carry player by tag";
 }
-#endif

--- a/dist/res/config/games/include/specials_doom1.cfg
+++ b/dist/res/config/games/include/specials_doom1.cfg
@@ -1,7 +1,6 @@
 
 // Doom 1 action specials
 
-#ifdef MAP_DOOM
 action_specials
 {
 	group "Doors"
@@ -184,4 +183,3 @@ action_specials
 		special 48	= "Scrolling Wall";
 	}
 }
-#endif

--- a/dist/res/config/games/include/specials_doom2.cfg
+++ b/dist/res/config/games/include/specials_doom2.cfg
@@ -1,7 +1,6 @@
 
 // Doom 2/Ultimate Doom action specials
 
-#ifdef MAP_DOOM
 action_specials
 {
 	group "Doors"
@@ -101,4 +100,3 @@ action_specials
 		special 138	= "SR Light To 255";
 	}
 }
-#endif

--- a/dist/res/config/games/include/specials_heretic.cfg
+++ b/dist/res/config/games/include/specials_heretic.cfg
@@ -1,7 +1,6 @@
 
 // Heretic action specials
 
-#ifdef MAP_DOOM
 action_specials
 {
 	group "Doors"
@@ -189,4 +188,3 @@ action_specials
 		special 99	= "Scrolling Wall Right";
 	}
 }
-#endif

--- a/dist/res/config/games/include/specials_strife.cfg
+++ b/dist/res/config/games/include/specials_strife.cfg
@@ -1,7 +1,6 @@
 
 // Strife action specials
 
-#ifdef MAP_DOOM
 action_specials
 {
 	group "Doors"
@@ -331,4 +330,3 @@ action_specials
 		special 148	= "SR Forcefield";
 	}
 }
-#endif

--- a/dist/res/config/games/strife.cfg
+++ b/dist/res/config/games/strife.cfg
@@ -9,7 +9,7 @@ game strife
 	iwad = "strife1.wad";
 
 	// Supported map formats
-	map_formats = doom;
+	map_formats = doom, udmf;
 
 	// DECORATE filters
 	filters = "strife", "any";
@@ -19,6 +19,9 @@ game strife
 
 	// Light levels
 	light_level_interval = 16;
+
+	// UDMF namespace
+	udmf_namespace = "strife";
 
 	// Maps
 	maps

--- a/dist/res/config/ports/boom.cfg
+++ b/dist/res/config/ports/boom.cfg
@@ -17,6 +17,10 @@ port boom
 
 	// Light levels
 	light_level_interval = 16;
+
+	// UDMF namespace
+	udmf_namespace = "doom";
+
 }
 
 // Action specials

--- a/dist/res/config/ports/boom_mbf.cfg
+++ b/dist/res/config/ports/boom_mbf.cfg
@@ -17,6 +17,10 @@ port boom_mbf
 
 	// Light levels
 	light_level_interval = 16;
+
+	// UDMF namespace
+	udmf_namespace = "doom";
+
 }
 
 // Action specials

--- a/dist/res/config/ports/include/flags_boom.cfg
+++ b/dist/res/config/ports/include/flags_boom.cfg
@@ -1,5 +1,4 @@
 
-#ifdef MAP_DOOM
 thing_flags
 {
 	flag "Easy Skill"
@@ -107,4 +106,3 @@ line_flags
 		udmf	= "passuse";
 	}
 }
-#endif

--- a/dist/res/config/ports/include/flags_mbf.cfg
+++ b/dist/res/config/ports/include/flags_mbf.cfg
@@ -1,5 +1,4 @@
 
-#ifdef MAP_DOOM
 thing_flags
 {
 	flag "Easy Skill"
@@ -113,4 +112,3 @@ line_flags
 		udmf	= "passuse";
 	}
 }
-#endif

--- a/dist/res/config/ports/include/flags_mbf21.cfg
+++ b/dist/res/config/ports/include/flags_mbf21.cfg
@@ -1,15 +1,15 @@
 
-#ifdef MAP_DOOM
 line_flags
 {
 	flag "Block Land Monsters"
 	{
 		value 	= 4096;
+		udmf	= "blocklandmonsters";
 	}
 
 	flag "Block Players"
 	{
 		value 	= 8192;
+		udmf	= "blockplayers";
 	}
 }
-#endif

--- a/dist/res/config/ports/include/specials_boom.cfg
+++ b/dist/res/config/ports/include/specials_boom.cfg
@@ -1,6 +1,5 @@
 // Boom action specials
 
-#ifdef MAP_DOOM
 action_specials
 {
 	group "Floor Changers"
@@ -271,4 +270,3 @@ action_specials
 		}
 	}
 }
-#endif

--- a/dist/res/config/ports/include/specials_mbf.cfg
+++ b/dist/res/config/ports/include/specials_mbf.cfg
@@ -1,6 +1,5 @@
-// Boom action specials
+// MBF action specials
 
-#ifdef MAP_DOOM
 action_specials
 {
 	group "Transfers"
@@ -11,4 +10,3 @@ action_specials
 		special 272 = "-- Transfer Sky Texture (Flipped)";
 	}
 }
-#endif

--- a/dist/res/config/ports/include/specials_mbf21.cfg
+++ b/dist/res/config/ports/include/specials_mbf21.cfg
@@ -1,6 +1,5 @@
 // MBF21 action specials
 
-#ifdef MAP_DOOM
 action_specials
 {
 	group "Scrollers"
@@ -15,4 +14,3 @@ action_specials
 		}
 	}
 }
-#endif


### PR DESCRIPTION
Drafting, as I've come across a minor issue -- in UDMF maps that use the classic style of line specials, the action's target ID is provided on arg0, for all specials (with the exception of the EDGE Classic namespace, that uses only the "Line ID" field). Is there some way to change the default name for arg0, in this case, without needing to update _all_ classic line specials?

Couple test maps in the "Doom" UDMF namespace: [udmf_test.zip](https://github.com/user-attachments/files/23324685/udmf_test.zip)

<img width="831" height="599" alt="image" src="https://github.com/user-attachments/assets/a175f756-3456-4982-8507-87c9889d4df0" />
