### PR TITLE
Fix center check for fractionally scaled 3D map editor

### DIFF
--- a/src/MapEditor/UI/MapCanvas.cpp
+++ b/src/MapEditor/UI/MapCanvas.cpp
@@ -157,24 +157,20 @@ void MapCanvas::mouseLook3d()
 		auto overlay_current = context_->currentOverlay();
 		if (!overlay_current || !overlay_current->isActive() || (overlay_current && overlay_current->allow3dMlook()))
 		{
-			// Get relative mouse movement (scale with dpi on macOS and Linux)
-			const bool   useScaleFactor = (app::platform() == app::MacOS || app::platform() == app::Linux);
-			const double scale          = useScaleFactor ? GetContentScaleFactor() : 1.;
-			const double threshold      = scale - 1.0;
+			// Get relative mouse movement
+			const wxPoint mouse_screen_pos = wxGetMousePosition();
+			const wxPoint mouse_client_pos = ScreenToClient(mouse_screen_pos);
 
-			wxRealPoint mouse_pos = wxGetMousePosition();
-			mouse_pos.x *= scale;
-			mouse_pos.y *= scale;
+			const wxSize size              = GetSize();
+			double xrel                    = mouse_client_pos.x - floor(size.x * 0.5);
+			double yrel                    = mouse_client_pos.y - floor(size.y * 0.5);
 
-			const wxRealPoint screen_pos = GetScreenPosition();
-			const double      xpos       = mouse_pos.x - screen_pos.x;
-			const double      ypos       = mouse_pos.y - screen_pos.y;
+			// Scale from logical to physical pixels for consistent movement on HiDPI displays
+			const double scale             = GetContentScaleFactor();
+			xrel *= scale;
+			yrel *= scale;
 
-			const wxSize size = GetSize();
-			const double xrel = xpos - floor(size.x * 0.5);
-			const double yrel = ypos - floor(size.y * 0.5);
-
-			if (fabs(xrel) > threshold || fabs(yrel) > threshold)
+			if (fabs(xrel) > 0 || fabs(yrel) > 0)
 			{
 				context_->renderer().renderer3D().cameraLook(xrel, yrel);
 				mouseToCenter();


### PR DESCRIPTION
In previous SLADE releases (e.g. 3.2.8), `MapCanvas::mouseToCenter` didn't target the actual center point for scaled ("HiDPI") displays. This is [because wxWidgets returns logical pixels, but `sf::Mouse::setPosition` expects physical pixels](https://github.com/sirjuddington/SLADE/blob/fb7cc161a6886c12c5120e30190a7813c6c16b62/src/MapEditor/UI/MapCanvas.cpp#L119-L121).

This still worked because `MapCanvas::mouseLook3d()` later compensated by scaling `wxGetMousePosition()` from logical to physical pixels.

After commit 2a5e2b25e31e ("Use wxWidgets to center the mouse on the 3D map editor"), `MapCanvas::mouseToCenter` actually centers the mouse on scaled displays.

Now the compensatory logic causes the camera to spin uncontrollably, so remove it. All intermediate calculations now work in logical pixels, we scale to physical deltas at the end for consistent camera movement.