### PR TITLE
Simpler crash reporting + crash dialog updates

### DIFF
--- a/src/Application/SLADEWxApp.h
+++ b/src/Application/SLADEWxApp.h
@@ -26,15 +26,16 @@ public:
 	void checkForUpdates(bool message_box);
 
 	void onMenu(wxCommandEvent& e);
-	void onVersionCheckCompleted(wxWebRequestEvent& e);
+	void onWebRequestUpdate(wxWebRequestEvent& e);
 	void onActivate(wxActivateEvent& e);
 	void onEndSession(wxCloseEvent& e);
 
 private:
-	wxSingleInstanceChecker* single_instance_checker_ = nullptr;
-	MainAppFileListener*     file_listener_           = nullptr;
-	SLADECrashDialog*        crash_dialog_            = nullptr;
-	bool                     session_ending_          = false;
+	wxSingleInstanceChecker* single_instance_checker_  = nullptr;
+	MainAppFileListener*     file_listener_            = nullptr;
+	SLADECrashDialog*        crash_dialog_             = nullptr;
+	bool                     session_ending_           = false;
+	int                      version_check_request_id_ = 0;
 };
 
 DECLARE_APP(SLADEWxApp)


### PR DESCRIPTION
This should make crash reporting a lot easier for users, so they don't have to sign up for and post on GitHub, which I'm pretty sure puts a lot of people off reporting anything.

I've set up a Cloudflare worker that takes crash reports and stores them in a database, so this adds a new 'Send and Exit' button to the crash dialog which will automatically send the crash info to the worker before exiting. The 'Create GitHub Issue' button is still there as well, which can be used for those who want it (and is still likely more useful as I can ask for further details there etc.)

Also updates the crash dialog layout a bit and fixes DPI-related issues with it.