### PR TITLE
Fix a crash due to lack of write access permission

### DIFF
--- a/src/MapEditor/UI/MapEditorWindow.cpp
+++ b/src/MapEditor/UI/MapEditorWindow.cpp
@@ -962,6 +962,7 @@ bool MapEditorWindow::saveMap()
 bool MapEditorWindow::saveMapAs()
 {
 	auto& mdesc_current = mapeditor::editContext().mapDesc();
+	auto  previous_desc = mdesc_current;
 
 	// Show dialog
 	filedialog::FDInfo info;
@@ -990,21 +991,50 @@ bool MapEditorWindow::saveMapAs()
 	mdesc_current.head    = head;
 	mdesc_current.archive = false;
 	mdesc_current.end     = end;
-	saveMap();
+	if (!saveMap())
+	{
+		mdesc_current = previous_desc;
+		return false;
+	}
 
 	// Write wad to file
-	wad.save(info.filenames[0]);
+	if (!wad.save(info.filenames[0]))
+	{
+		wxMessageBox(
+			WX_FMT("Unable to save map to {}: {}", info.filenames[0], global::error),
+			wxS("Save Map As"),
+			wxOK | wxICON_ERROR);
+		mdesc_current = previous_desc;
+		return false;
+	}
+
 	auto archive = app::archiveManager().openArchive(info.filenames[0], true, true);
+	if (!archive)
+	{
+		wxMessageBox(
+			WX_FMT("Unable to open saved map {}: {}", info.filenames[0], global::error),
+			wxS("Save Map As"),
+			wxOK | wxICON_ERROR);
+		mdesc_current = previous_desc;
+		return false;
+	}
 	app::archiveManager().addRecentFile(info.filenames[0]);
 
 	// Update current map description
 	auto maps = archive->detectMaps();
-	if (!maps.empty())
+	if (maps.empty())
 	{
-		mdesc_current.head    = maps[0].head;
-		mdesc_current.archive = false;
-		mdesc_current.end     = maps[0].end;
+		wxMessageBox(
+			WX_FMT("Saved archive {} contains no maps", info.filenames[0]),
+			wxS("Save Map As"),
+			wxOK | wxICON_ERROR);
+		mdesc_current = previous_desc;
+		return false;
 	}
+
+	mdesc_current.head    = maps[0].head;
+	mdesc_current.archive = false;
+	mdesc_current.end     = maps[0].end;
 
 	// Set window title
 	SetTitle(wxString::FromUTF8(fmt::format("SLADE - {} of {}", mdesc_current.name, wad.filename(false))));


### PR DESCRIPTION
Map editor is crashing when trying to save the map in a location without write access. This PR addresses that.

Sample crash stack trace:

```
Version: 3.2.9
Current action: mapw_saveas
Operating System: Linux 6.8.0-87-generic x86_64
Graphics Vendor: AMD
Graphics Hardware: AMD Radeon 780M (radeonsi, phoenix, LLVM 20.1.2, DRM 3.57, 6.8.0-87-generic)
OpenGL Version: 4.6 (Compatibility Profile) Mesa 25.0.7-0ubuntu0.24.04.2

Stack Trace:
0: [unknown location] [unknown:123356344541108]
1: [unknown location] [unknown:123356334805808]
2: [unknown location] [unknown:99642997376582]
3: [unknown location] [unknown:99642997385176]
4: [unknown location] [unknown:99642995335027]
5: [unknown location] [unknown:99642994054045]
6: [unknown location] wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&)
7: [unknown location] wxEvtHandler::SearchDynamicEventTable(wxEvent&)
8: [unknown location] wxEvtHandler::TryHereOnly(wxEvent&)
9: [unknown location] wxEvtHandler::ProcessEventLocally(wxEvent&)
10: [unknown location] wxEvtHandler::ProcessEvent(wxEvent&)
11: [unknown location] wxWindowBase::TryAfter(wxEvent&)
12: [unknown location] wxEvtHandler::SafelyProcessEvent(wxEvent&)
13: [unknown location] wxMenuBase::DoProcessEvent(wxMenuBase*, wxEvent&, wxWindow*)
14: [unknown location] wxMenuBase::SendEvent(int, int)
15: [unknown location] [unknown:123356351144926]
16: [unknown location] g_closure_invoke
17: [unknown location] [unknown:123356326009100]
18: [unknown location] [unknown:123356325946769]
19: [unknown location] g_signal_emit_valist
20: [unknown location] g_signal_emit
21: [unknown location] gtk_widget_activate
22: [unknown location] gtk_menu_shell_activate_item
23: [unknown location] [unknown:123356328341409]
24: [unknown location] [unknown:123356326757111]
25: [unknown location] [unknown:123356325947069]
26: [unknown location] g_signal_emit_valist
27: [unknown location] g_signal_emit
28: [unknown location] [unknown:123356329700340]
29: [unknown location] [unknown:123356328244112]
30: [unknown location] gtk_main_do_event
31: [unknown location] [unknown:123356336972807]
32: [unknown location] [unknown:123356337339950]
33: [unknown location] [unknown:123356321011141]
34: [unknown location] [unknown:123356321400631]
35: [unknown location] g_main_loop_run
36: [unknown location] gtk_main
37: [unknown location] wxGUIEventLoop::DoRun()
38: [unknown location] wxEventLoopBase::Run()
39: [unknown location] wxAppConsoleBase::MainLoop()
40: [unknown location] wxEntry(int&, wchar_t**)
41: [unknown location] main
42: [unknown location] [unknown:123356334694858]
43: [unknown location] __libc_start_main
44: [unknown location] [unknown:99642994000581]

Last Log Messages:
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
[wxWidgets] Error: can't open file '/opt/dsa' (error 2: No such file or directory)
```