### PR TITLE
Don't strip symbols when building AppImage

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           export LDAI_OUTPUT="SLADE.AppImage"
           export LDAI_UPDATE_INFORMATION="gh-releases-zsync|sirjuddington|SLADE|latest|SLADE.AppImage.zsync"
+          export NO_STRIP=1
           ${{ steps.install-linuxdeploy.outputs.linuxdeploy }} --output=appimage --appdir AppDir
 
       - name: Upload Artifacts


### PR DESCRIPTION
This will likely increase its size, but without it we get useless crash reports