### PR TITLE
Add properties for Eternity texture scaling and linedef wrapmidtex

### DIFF
--- a/dist/res/config/ports/eternity.cfg
+++ b/dist/res/config/ports/eternity.cfg
@@ -53,9 +53,9 @@ port eternity
 	udmf_sector_color = false;
 	udmf_sector_fog = false;
 	udmf_side_lighting = true;
-	udmf_side_midtex_wrapping = false;
+	udmf_side_midtex_wrapping = true;
 	udmf_side_scaling = false;
-	udmf_texture_scaling = false;
+	udmf_texture_scaling = true;
 	udmf_texture_offsets = true;
 }
 

--- a/dist/res/config/ports/include/props_eternity.cfg
+++ b/dist/res/config/ports/include/props_eternity.cfg
@@ -21,7 +21,7 @@ udmf_properties
 			//property blocksight		= "Blocks Monster Sight";
 			property zoneboundary		= "Reverb Zone Boundary";
 			property clipmidtex			= "Clip MidTex";
-			//property wrapmidtex		= "Wrap MidTex";
+			property wrapmidtex			= "Wrap MidTex";
 			property midtex3dimpassible	= "3D Midtex Allows Projectiles Through";
 		}
 
@@ -144,6 +144,20 @@ udmf_properties
 			property offsety_bottom	= "Lower Y Offset";
 		}
 
+		group "Scaling"
+		{
+			type = float;
+			default = 1;
+			show_always = false;
+
+			property scalex_top		= "Upper X Scale";
+			property scaley_top		= "Upper Y Scale";
+			property scalex_mid		= "Middle X Scale";
+			property scaley_mid		= "Middle Y Scale";
+			property scalex_bottom	= "Lower X Scale";
+			property scaley_bottom	= "Lower Y Scale";
+		}
+
 		group "Skew"
 		{
 			type = string;
@@ -154,16 +168,6 @@ udmf_properties
 			property skew_middle_type	= "Middle Skew Type";
 			property skew_bottom_type	= "Bottom Skew Type";
 		}
-
-		/*group "Scaling"
-		{
-			type = float;
-			default = 1;
-			show_always = false;
-
-			property scalex			= "X Scale";
-			property scaley			= "Y Scale";
-		}*/
 
 		group "Lighting"
 		{


### PR DESCRIPTION
Just pushed through sidedef props for scaling and the linedef wrapmidtex flag for EE over the past few days. This lets SLADE take advantage of that.