### PR TITLE
Add support for Outlaws LAB archives

### DIFF
--- a/dist/res/config/archive_formats.cfg
+++ b/dist/res/config/archive_formats.cfg
@@ -140,6 +140,15 @@ archive_formats
 		extensions { hog = "Descent HOG"; }
 	}
 
+	lab
+	{
+		name = "Outlaws LAB";
+		names_extensions = true;
+		supports_dirs = false;
+		entry_format = "archive_lab";
+		extensions { lab = "Outlaws LAB"; }
+	}
+
 	lfd
 	{
 		name = "Dark Forces LFD";

--- a/dist/res/config/entry_types/text.cfg
+++ b/dist/res/config/entry_types/text.cfg
@@ -553,7 +553,7 @@ jedi_level : text
 
 jedi_model : text
 {
-	name = "DF Model";
+	name = "DF/OL Model";
 	match_ext = "3do";
 }
 
@@ -565,7 +565,7 @@ jedi_vue : text
 
 jedi_inf : text
 {
-	name = "DF Script";
+	name = "DF/OL Script";
 	match_ext = "inf";
 }
 
@@ -579,6 +579,42 @@ jedi_goal : text
 {
 	name = "DF Goals";
 	match_ext = "gol";
+}
+
+ol_level : text
+{
+	name = "OL Level";
+	match_ext = "lvt";
+}
+
+ol_objects : text
+{
+	name = "OL Objects";
+	match_ext = "obt";
+}
+
+ol_items : text
+{
+	name = "OL Items";
+	match_ext = "itm";
+}
+
+ol_physics : text
+{
+	name = "OL Physics";
+	match_ext = "phy";
+}
+
+ol_campaign : text
+{
+	name = "OL Campaign";
+	match_ext = "rcm", "rca", "rcs";
+}
+
+ol_script : text
+{
+	name = "OL Script";
+	match_ext = "msc";
 }
 
 rottscript : text

--- a/src/Archive/ArchiveEntry.cpp
+++ b/src/Archive/ArchiveEntry.cpp
@@ -131,6 +131,30 @@ string_view ArchiveEntry::upperNameNoExt() const
 }
 
 // -----------------------------------------------------------------------------
+// Returns the entry file extension
+// -----------------------------------------------------------------------------
+string_view ArchiveEntry::ext() const
+{
+	auto ext_pos = name_.find('.');
+	if (ext_pos != string::npos)
+		return { name_.data() + ext_pos };
+
+	return {};
+}
+
+// -----------------------------------------------------------------------------
+// Returns the entry file extension in uppercase
+// -----------------------------------------------------------------------------
+string_view ArchiveEntry::upperExt() const
+{
+	auto ext_pos = upper_name_.find('.');
+	if (ext_pos != string::npos)
+		return { upper_name_.data() + ext_pos };
+
+	return {};
+}
+
+// -----------------------------------------------------------------------------
 // Returns the entry's parent archive
 // -----------------------------------------------------------------------------
 Archive* ArchiveEntry::parent() const

--- a/src/Archive/ArchiveEntry.h
+++ b/src/Archive/ArchiveEntry.h
@@ -39,8 +39,10 @@ public:
 	// Accessors
 	const string&            name() const { return name_; }
 	string_view              nameNoExt() const;
+	string_view              ext() const;
 	const string&            upperName() const { return upper_name_; }
 	string_view              upperNameNoExt() const;
+	string_view              upperExt() const;
 	uint32_t                 size() const { return data_loaded_ ? data_.size() : size_; }
 	MemChunk&                data(bool allow_load = true);
 	const uint8_t*           rawData(bool allow_load = true);

--- a/src/Archive/ArchiveManager.cpp
+++ b/src/Archive/ArchiveManager.cpp
@@ -347,6 +347,8 @@ shared_ptr<Archive> ArchiveManager::openArchive(string_view filename, bool manag
 		new_archive = std::make_shared<ChasmBinArchive>();
 	else if (SiNArchive::isSiNArchive(std_fn))
 		new_archive = std::make_shared<SiNArchive>();
+	else if (LabArchive::isLabArchive(std_fn))
+		new_archive = std::make_shared<LabArchive>();
 	else
 	{
 		// Unsupported format
@@ -452,6 +454,8 @@ shared_ptr<Archive> ArchiveManager::openArchive(ArchiveEntry* entry, bool manage
 		new_archive = std::make_shared<ChasmBinArchive>();
 	else if (SiNArchive::isSiNArchive(entry->data()))
 		new_archive = std::make_shared<SiNArchive>();
+	else if (LabArchive::isLabArchive(entry->data()))
+		new_archive = std::make_shared<LabArchive>();
 	else
 	{
 		// Unsupported format

--- a/src/Archive/EntryType/DataFormats/ArchiveFormats.h
+++ b/src/Archive/EntryType/DataFormats/ArchiveFormats.h
@@ -207,3 +207,12 @@ public:
 
 	int isThisFormat(MemChunk& mc) override { return SiNArchive::isSiNArchive(mc) ? MATCH_TRUE : MATCH_FALSE; }
 };
+
+class LabDataFormat : public EntryDataFormat
+{
+public:
+	LabDataFormat() : EntryDataFormat("archive_lab") {}
+	~LabDataFormat() = default;
+
+	int isThisFormat(MemChunk& mc) override { return LabArchive::isLabArchive(mc) ? MATCH_TRUE : MATCH_FALSE; }
+};

--- a/src/Archive/Formats/All.h
+++ b/src/Archive/Formats/All.h
@@ -9,6 +9,7 @@
 #include "GobArchive.h"
 #include "GrpArchive.h"
 #include "HogArchive.h"
+#include "LabArchive.h"
 #include "LfdArchive.h"
 #include "LibArchive.h"
 #include "PakArchive.h"

--- a/src/Archive/Formats/LabArchive.cpp
+++ b/src/Archive/Formats/LabArchive.cpp
@@ -1,0 +1,467 @@
+
+// -----------------------------------------------------------------------------
+// SLADE - It's a Doom Editor
+// Copyright(C) 2008 - 2026 Simon Judd
+//
+// Email:       sirjuddington@gmail.com
+// Web:         http://slade.mancubus.net
+// Filename:    LabArchive.cpp
+// Description: LabArchive, archive class to handle LAB archives from
+//              Outlaws
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 2 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA.
+// -----------------------------------------------------------------------------
+
+
+// -----------------------------------------------------------------------------
+//
+// Includes
+//
+// -----------------------------------------------------------------------------
+#include "Main.h"
+#include "LabArchive.h"
+#include "General/UI.h"
+
+using namespace slade;
+
+
+// -----------------------------------------------------------------------------
+//
+// External Variables
+//
+// -----------------------------------------------------------------------------
+EXTERN_CVAR(Bool, archive_load_data)
+
+
+// -----------------------------------------------------------------------------
+//
+// LabArchive Class Functions
+//
+// -----------------------------------------------------------------------------
+
+
+// -----------------------------------------------------------------------------
+// Returns the file byte offset for [entry]
+// -----------------------------------------------------------------------------
+uint32_t LabArchive::getEntryOffset(ArchiveEntry* entry)
+{
+	// Check entry
+	if (!checkEntry(entry))
+		return 0;
+
+	return (uint32_t)entry->exProp<int>("Offset");
+}
+
+// -----------------------------------------------------------------------------
+// Sets the file byte offset for [entry]
+// -----------------------------------------------------------------------------
+void LabArchive::setEntryOffset(ArchiveEntry* entry, uint32_t offset)
+{
+	// Check entry
+	if (!checkEntry(entry))
+		return;
+
+	entry->exProp("Offset") = (int)offset;
+}
+
+// -----------------------------------------------------------------------------
+// Reads lab format data from a MemChunk
+// Returns true if successful, false otherwise
+// -----------------------------------------------------------------------------
+bool LabArchive::open(MemChunk& mc)
+{
+	// Check data was given
+	if (!mc.hasData())
+		return false;
+
+	// Check size
+	if (mc.size() < 16)
+		return false;
+
+	// Check magic header
+	if (mc[0] != 'L' || mc[1] != 'A' || mc[2] != 'B' || mc[3] != 'N')
+		return false;
+
+	// Check version
+	uint32_t version = 0;
+	mc.seek(4, SEEK_SET);
+	mc.read(&version, 4);
+	version = wxINT32_SWAP_ON_BE(version);
+	if (version != 0x00010000)
+		return false;
+
+	// Get number of lumps
+	uint32_t num_lumps = 0;
+	mc.read(&num_lumps, 4);
+	num_lumps = wxINT32_SWAP_ON_BE(num_lumps);
+
+	// Compute directory size
+	uint32_t dir_offset = 16; // header
+	uint32_t dir_size = (num_lumps * 16);
+	if ((unsigned)mc.size() < (dir_offset + dir_size))
+		return false;
+
+	// Compute name directory
+	uint32_t namedir_offset = dir_offset + dir_size;
+	uint32_t namedir_size = 0;
+	mc.read(&namedir_size, 4);
+	namedir_size = wxINT32_SWAP_ON_BE(namedir_size);
+	if ((unsigned)mc.size() < (namedir_offset + namedir_size))
+		return false;
+
+	// Stop announcements (don't want to be announcing modification due to entries being added etc)
+	ArchiveModSignalBlocker sig_blocker{ *this };
+
+	// Read the directory
+	ui::setSplashProgressMessage("Reading lab archive data");
+	for (uint32_t d = 0; d < num_lumps; d++)
+	{
+		// Update splash window progress
+		ui::setSplashProgress(((float)d / (float)num_lumps));
+
+		// Read lump info
+		uint32_t name_offset = 0;
+		uint32_t offset      = 0;
+		uint32_t size        = 0;
+		char     type[4]     = { 0, 0, 0, 0 };
+
+		mc.read(&name_offset, 4); // Name
+		mc.read(&offset, 4);      // Offset
+		mc.read(&size, 4);        // Size
+		mc.read(&type, 4);        // Type
+
+		// Byteswap values for big endian if needed
+		name_offset = wxINT32_SWAP_ON_BE(name_offset);
+		offset = wxINT32_SWAP_ON_BE(offset);
+		size = wxINT32_SWAP_ON_BE(size);
+
+		// If the lump data goes past the end of the file,
+		// the labfile is invalid
+		if (offset + size > mc.size())
+		{
+			log::error("LabArchive::open: lab archive is invalid or corrupt");
+			global::error = "Archive is invalid and/or corrupt";
+			return false;
+		}
+
+		// Read name (zero-terminated)
+		const char* name = (const char*)&mc[namedir_offset + name_offset];
+
+		// Create & setup lump
+		auto nlump = std::make_shared<ArchiveEntry>(name, size);
+		nlump->setLoaded(false);
+		nlump->exProp("NameOffset") = (int)name_offset;
+		nlump->exProp("Offset") = (int)offset;
+		nlump->exProp("LabType") = string(type, std::size(type));
+		nlump->setState(ArchiveEntry::State::Unmodified);
+
+		// Add to entry list
+		rootDir()->addEntry(nlump);
+	}
+
+	// Detect all entry types
+	MemChunk edata;
+	ui::setSplashProgressMessage("Detecting entry types");
+	for (size_t a = 0; a < numEntries(); a++)
+	{
+		// Update splash window progress
+		ui::setSplashProgress((((float)a / (float)num_lumps)));
+
+		// Get entry
+		auto entry = entryAt(a);
+
+		// Read entry data if it isn't zero-sized
+		if (entry->size() > 0)
+		{
+			// Read the entry data
+			mc.exportMemChunk(edata, getEntryOffset(entry), entry->size());
+			entry->importMemChunk(edata);
+		}
+
+		// Detect entry type
+		EntryType::detectEntryType(*entry);
+
+		// Unload entry data if needed
+		if (!archive_load_data)
+			entry->unloadData();
+
+		// Set entry to unchanged
+		entry->setState(ArchiveEntry::State::Unmodified);
+	}
+
+	// Setup variables
+	sig_blocker.unblock();
+	setModified(false);
+
+	ui::setSplashProgressMessage("");
+
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Determines the lab FourCC based on file extension
+// -----------------------------------------------------------------------------
+string LabArchive::detectResType(ArchiveEntry* entry)
+{
+	string type = entry->exProp<string>("LabType");
+	if (!type.empty())
+		return type;
+
+	string_view ext = entry->upperExt();
+	if (ext == ".3DO") return "FOD3";
+	if (ext == ".ATX") return "FXTA";
+	if (ext == ".INF") return "FFNI";
+	if (ext == ".ITM") return "METI";
+	if (ext == ".LAF") return "TNFN";
+	if (ext == ".LVB") return "FTVL";
+	if (ext == ".LVT") return "FTVL";
+	if (ext == ".MSC") return "BCSM";
+	if (ext == ".NWX") return "FXAW";
+	if (ext == ".OBB") return "FTBO";
+	if (ext == ".OBT") return "FTBO";
+	if (ext == ".PCX") return "MTXT";
+	if (ext == ".PHY") return "SYHP";
+	if (ext == ".RCA") return "BPCR";
+	if (ext == ".RCM") return "BPCR";
+	if (ext == ".RCS") return "BPCR";
+	if (ext == ".WAV") return "DVAW";
+
+	return "";
+}
+
+// -----------------------------------------------------------------------------
+// Writes the lab archive to a MemChunk
+// Returns true if successful, false otherwise
+// -----------------------------------------------------------------------------
+bool LabArchive::write(MemChunk& mc, bool update)
+{
+	// Determine directory offset & individual lump offsets
+	uint32_t      dir_offset = 16;
+	uint32_t      name_offset = 0;
+	ArchiveEntry* entry;
+
+	dir_offset += 16 * numEntries();
+	for (uint32_t l = 0; l < numEntries(); l++)
+	{
+		entry = entryAt(l);
+		entry->exProp("NameOffset") = (int)name_offset;
+		dir_offset += entry->name().length() + 1;
+		name_offset += entry->name().length() + 1;
+	}
+	for (uint32_t l = 0; l < numEntries(); l++)
+	{
+		entry = entryAt(l);
+		setEntryOffset(entry, dir_offset);
+		dir_offset += entry->size();
+	}
+
+	// Clear/init MemChunk
+	mc.clear();
+	mc.seek(0, SEEK_SET);
+	mc.reSize(dir_offset);
+
+	// Write the header	
+	char     header[4] = { 'L', 'A', 'B', 'N' };
+	uint32_t version   = wxINT32_SWAP_ON_BE(0x00010000);
+	uint32_t num_lumps = wxINT32_SWAP_ON_BE(numEntries());
+	name_offset        = wxINT32_SWAP_ON_BE(name_offset);
+	mc.write(header, 4);
+	mc.write(&version, 4);
+	mc.write(&num_lumps, 4);
+	mc.write(&name_offset, 4);
+
+	// Write the directory
+	for (uint32_t l = 0; l < numEntries(); l++)
+	{
+		entry           = entryAt(l);
+		uint32_t name   = wxINT32_SWAP_ON_BE(entry->exProp<int>("NameOffset"));
+		uint32_t offset = wxINT32_SWAP_ON_BE(getEntryOffset(entry));
+		uint32_t size   = wxINT32_SWAP_ON_BE(entry->size());
+		char type[4]    = { 0, 0, 0, 0 };
+
+		// Determine resource type
+		string labType = detectResType(entry);
+		for (size_t c = 0; c < labType.length() && c < std::size(type); c++)
+			type[c] = labType[c];
+
+		mc.write(&name, 4);
+		mc.write(&offset, 4);
+		mc.write(&size, 4);
+		mc.write(type, 4);
+
+		if (update)
+		{
+			entry->setState(ArchiveEntry::State::Unmodified);
+			entry->exProp("NameOffset") = (int)name;
+			entry->exProp("Offset") = (int)offset;
+			entry->exProp("LabType") = string(type, std::size(type));
+		}
+	}
+
+	// Write the lumps
+	for (uint32_t l = 0; l < numEntries(); l++)
+	{
+		entry = entryAt(l);
+		mc.write(entry->name().c_str(), entry->name().length());
+		mc.write("\0", 1);
+	}
+	for (uint32_t l = 0; l < numEntries(); l++)
+	{
+		entry = entryAt(l);
+		mc.write(entry->rawData(), entry->size());
+	}
+
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Loads an entry's data from the labfile
+// Returns true if successful, false otherwise
+// -----------------------------------------------------------------------------
+bool LabArchive::loadEntryData(ArchiveEntry* entry)
+{
+	// Check the entry is valid and part of this archive
+	if (!checkEntry(entry))
+		return false;
+
+	// Do nothing if the lump's size is zero,
+	// or if it has already been loaded
+	if (entry->size() == 0 || entry->isLoaded())
+	{
+		entry->setLoaded();
+		return true;
+	}
+
+	// Open labfile
+	wxFile file(wxString::FromUTF8(filename_));
+
+	// Check if opening the file failed
+	if (!file.IsOpened())
+	{
+		log::error("LabArchive::loadEntryData: Failed to open labfile {}", filename_);
+		return false;
+	}
+
+	// Seek to lump offset in file and read it in
+	file.Seek(getEntryOffset(entry), wxFromStart);
+	entry->importFileStream(file, entry->size());
+
+	// Set the lump to loaded
+	entry->setLoaded();
+
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Checks if the given data is a valid Outlaws lab archive
+// -----------------------------------------------------------------------------
+bool LabArchive::isLabArchive(MemChunk& mc)
+{
+	// Check data was given
+	if (!mc.hasData())
+		return false;
+
+	// Check size
+	if (mc.size() < 16)
+		return false;
+
+	// Check magic header
+	if (mc[0] != 'L' || mc[1] != 'A' || mc[2] != 'B' || mc[3] != 'N')
+		return false;
+
+	// Check version
+	uint32_t version = 0;
+	mc.seek(4, SEEK_SET);
+	mc.read(&version, 4);
+	version = wxINT32_SWAP_ON_BE(version);
+	if (version != 0x00010000)
+		return false;
+
+	// Get number of lumps
+	uint32_t num_lumps = 0;
+	mc.read(&num_lumps, 4);
+	num_lumps = wxINT32_SWAP_ON_BE(num_lumps);
+
+	// Compute directory size
+	uint32_t dir_offset = 16; // header
+	uint32_t dir_size   = (num_lumps * 16);
+	if ((unsigned)mc.size() < (dir_offset + dir_size))
+		return false;
+
+	// Compute name directory
+	uint32_t namedir_offset = dir_offset + dir_size;
+	uint32_t namedir_size   = 0;
+	mc.read(&namedir_size, 4);
+	namedir_size = wxINT32_SWAP_ON_BE(namedir_size);
+	if ((unsigned)mc.size() < (namedir_offset + namedir_size))
+		return false;
+
+	// If it's passed to here it's probably a lab file
+	return true;
+}
+
+// -----------------------------------------------------------------------------
+// Checks if the file at [filename] is a valid Outlaws lab archive
+// -----------------------------------------------------------------------------
+bool LabArchive::isLabArchive(const string& filename)
+{
+	// Open file for reading
+	wxFile file(wxString::FromUTF8(filename));
+
+	// Check it opened ok
+	if (!file.IsOpened())
+		return false;
+
+	// Check size
+	if (file.Length() < 16)
+		return false;
+
+	// Read header
+	char header[4];
+	file.Read(header, 4);
+
+	// Check magic header
+	if (header[0] != 'L' || header[1] != 'A' || header[2] != 'B' || header[3] != 'N')
+		return false;
+
+	// Check version
+	uint32_t version = 0;
+	file.Read(&version, 4);
+	version = wxINT32_SWAP_ON_BE(version);
+	if (version != 0x00010000)
+		return false;
+
+	// Get number of lumps
+	uint32_t num_lumps = 0;
+	file.Read(&num_lumps, 4);
+	num_lumps = wxINT32_SWAP_ON_BE(num_lumps);
+
+	// Compute directory size
+	uint32_t dir_offset = 16; // header
+	uint32_t dir_size   = (num_lumps * 16);
+	if ((unsigned)file.Length() < (dir_offset + dir_size))
+		return false;
+
+	// Compute name directory
+	uint32_t namedir_offset = dir_offset + dir_size;
+	uint32_t namedir_size   = 0;
+	file.Read(&namedir_size, 4);
+	namedir_size = wxINT32_SWAP_ON_BE(namedir_size);
+	if ((unsigned)file.Length() < (namedir_offset + namedir_size))
+		return false;
+
+	// If it's passed to here it's probably a lab file
+	return true;
+}

--- a/src/Archive/Formats/LabArchive.h
+++ b/src/Archive/Formats/LabArchive.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Archive/Archive.h"
+
+namespace slade
+{
+class LabArchive : public TreelessArchive
+{
+public:
+	LabArchive() : TreelessArchive("lab") {}
+	~LabArchive() = default;
+
+	// LAB specific
+	uint32_t getEntryOffset(ArchiveEntry* entry);
+	void     setEntryOffset(ArchiveEntry* entry, uint32_t offset);
+	string   detectResType(ArchiveEntry* entry);
+
+	// Opening/writing
+	bool open(MemChunk& mc) override;                      // Open from MemChunk
+	bool write(MemChunk& mc, bool update = true) override; // Write to MemChunk
+
+	// Misc
+	bool loadEntryData(ArchiveEntry* entry) override;
+
+	// Static functions
+	static bool isLabArchive(MemChunk& mc);
+	static bool isLabArchive(const string& filename);
+};
+} // namespace slade

--- a/src/Scripting/Export/Archive.cpp
+++ b/src/Scripting/Export/Archive.cpp
@@ -237,6 +237,7 @@ void registerArchive(sol::state& lua)
 	REGISTER_ARCHIVE(DiskArchive);
 	REGISTER_ARCHIVE(PodArchive);
 	REGISTER_ARCHIVE(ChasmBinArchive);
+	REGISTER_ARCHIVE(LabArchive);
 #undef REGISTER_ARCHIVE
 }
 


### PR DESCRIPTION
Adds support for editing [Outlaws](https://en.wikipedia.org/wiki/Outlaws_(1997_video_game)) .lab files, as requested by #1674 

Archive format similar to Dark Forces, based on community specs:
https://github.com/df21-net/editor/blob/main/lawmaker/LAB.pas
https://github.com/njankowski/dftools/blob/master/formats/lab.py

<img width="1470" height="839" alt="image" src="https://github.com/user-attachments/assets/7672d261-15dc-4a26-8d5d-f7916c9dea33" />
