### PR TITLE
Basic support for 3ds Max model format

### DIFF
--- a/dist/res/config/entry_types/model.json
+++ b/dist/res/config/entry_types/model.json
@@ -20,6 +20,11 @@
     "format": "mesh_md3",
     "category": "3d Models"
   },
+  "model_3ds": {
+    "name": "Model (3ds Max)",
+    "format": "mesh_3ds",
+    "category": "3d Models"
+  },
   // Also, voxels!
   "voxel_vox": {
     "name": "Voxel (VOX)",

--- a/src/Archive/EntryType/DataFormats/ModelFormats.h
+++ b/src/Archive/EntryType/DataFormats/ModelFormats.h
@@ -76,6 +76,25 @@ public:
 	}
 };
 
+class ThreeDSModelDataFormat : public EntryDataFormat
+{
+public:
+	ThreeDSModelDataFormat() : EntryDataFormat("mesh_3ds") {};
+	~ThreeDSModelDataFormat() = default;
+
+	int isThisFormat(const MemChunk& mc) override
+	{
+		// Check size
+		if (mc.size() > 4)
+		{
+			// Check for MM header
+			if (mc[0] == 'M' && mc[1] == 'M')
+				return MATCH_TRUE;
+		}
+		return MATCH_FALSE;
+	}
+};
+
 class VOXVoxelDataFormat : public EntryDataFormat
 {
 public:

--- a/src/Archive/EntryType/EntryDataFormat.cpp
+++ b/src/Archive/EntryType/EntryDataFormat.cpp
@@ -342,6 +342,7 @@ void EntryDataFormat::initBuiltinFormats()
 	registerDataFormat<MDLModelDataFormat>();
 	registerDataFormat<MD2ModelDataFormat>();
 	registerDataFormat<MD3ModelDataFormat>();
+	registerDataFormat<ThreeDSModelDataFormat>();
 	registerDataFormat<VOXVoxelDataFormat>();
 	registerDataFormat<KVXVoxelDataFormat>();
 	registerDataFormat<RLE0DataFormat>();


### PR DESCRIPTION
The HROT.pak file uses Quake II and 3ds Max model files, so I added some basic support for the latter.