### PR TITLE
Fix recognition of JPEG images without JFIF or Exif header

### DIFF
--- a/src/Archive/EntryType/DataFormats/ImageFormats.h
+++ b/src/Archive/EntryType/DataFormats/ImageFormats.h
@@ -253,13 +253,9 @@ public:
 		if (mc.size() > 128)
 		{
 			// Check for JPEG header
-			if ((mc[6] == 'J' && mc[7] == 'F' && mc[8] == 'I' && mc[9] == 'F')
-				|| (mc[6] == 'E' && mc[7] == 'x' && mc[8] == 'i' && mc[9] == 'f'))
+			if (mc[0] == 255 && mc[1] == 216 && mc[2] == 255)
 			{
-				if (mc[0] == 255 && mc[1] == 216 && mc[2] == 255)
-				{
-					return MATCH_TRUE;
-				}
+				return MATCH_TRUE;
 			}
 		}
 

--- a/src/Archive/EntryType/DataFormats/ImageFormats.h
+++ b/src/Archive/EntryType/DataFormats/ImageFormats.h
@@ -253,7 +253,14 @@ public:
 		if (mc.size() > 128)
 		{
 			// Check for JPEG header
-			if (mc[0] == 255 && mc[1] == 216 && mc[2] == 255)
+
+			// Start Of Image: FFD8
+			bool start_of_image = mc[0] == 255 && mc[1] == 216;
+			// First segment tag: either an application tag - FFE0-FFEF
+			// or a 'Define quantization table(s)' marker if there is no metadata - FFDB
+			bool first_segment_tag = mc[2] == 255 && (mc[3] == 219 || mc[3] >= 224 && mc[3] <= 239);
+
+			if (start_of_image && first_segment_tag)
 			{
 				return MATCH_TRUE;
 			}


### PR DESCRIPTION
There was this JPEG file in HROT.pak which was not recognised by SLADE, because it had no JFIF or Exif header. It turns out these are optional, and this is a valid JPEG file:

<img width="32" height="32" alt="mesic" src="https://github.com/user-attachments/assets/186fd562-9216-4ced-92d5-54f8ff3530b3" />
