### PR TITLE
Fix offset issues and sprite duplication in TEXTUREX editor (#2017)

### DIFF
--- a/src/MainEditor/UI/TextureXEditor/TextureEditorPanel.cpp
+++ b/src/MainEditor/UI/TextureXEditor/TextureEditorPanel.cpp
@@ -870,8 +870,8 @@ void TextureEditorPanel::onTexCanvasMouseEvent(wxMouseEvent& e)
 						continue;
 					int16_t cx = sel_patch->xOffset();
 					int16_t cy = sel_patch->yOffset();
-					sel_patch->setOffsetX(cx + diff.x);
-					sel_patch->setOffsetY(cy + diff.y);
+					sel_patch->setOffsetX(cx + diff.x * tex_current_->scaleX());
+					sel_patch->setOffsetY(cy + diff.y * tex_current_->scaleY());
 					tex_modified_ = true;
 				}
 
@@ -889,8 +889,8 @@ void TextureEditorPanel::onTexCanvasMouseEvent(wxMouseEvent& e)
 				Vec2i diff = tex_cur - tex_prev;
 
 				// Modify offsets
-				tex_current_->setOffsetX(tex_current_->offsetX() - diff.x);
-				tex_current_->setOffsetY(tex_current_->offsetY() - diff.y);
+				tex_current_->setOffsetX(tex_current_->offsetX() - diff.x * tex_current_->scaleX());
+				tex_current_->setOffsetY(tex_current_->offsetY() - diff.y * tex_current_->scaleY());
 				tex_modified_ = true;
 
 				// Refresh texture canvas

--- a/src/UI/Canvas/CTextureCanvas.cpp
+++ b/src/UI/Canvas/CTextureCanvas.cpp
@@ -134,20 +134,6 @@ void CTextureCanvas::drawTexture(wxgfx::Context& ctx, Vec2d scale, Vec2i offset,
 		for (uint32_t a = 0; a < texture_->nPatches(); a++)
 			drawPatch(ctx, a);
 	}
-
-	// If we aren't currently dragging a patch, draw the fully generated texture
-	if (!dragging_)
-	{
-		// Generate wxBitmap if needed
-		if (!tex_preview_ || !tex_bitmap_.IsOk())
-		{
-			loadTexturePreview();
-			sImageToBitmap(*tex_preview_, palette_.get(), tex_bitmap_, view_.scale());
-		}
-
-		// Draw the texture
-		ctx.drawBitmap(tex_bitmap_, offset.x, offset.y, 1.0, texture_->width() * scale.x, texture_->height() * scale.y);
-	}
 }
 
 // -----------------------------------------------------------------------------
@@ -156,10 +142,10 @@ void CTextureCanvas::drawTexture(wxgfx::Context& ctx, Vec2d scale, Vec2i offset,
 void CTextureCanvas::drawTextureBorder(wxgfx::Context& ctx, Vec2d scale, Vec2i offset) const
 {
 	constexpr float ext = 0.0f;
-	const auto      x1  = offset.x;
-	const auto      x2  = offset.x + texture_->width() * scale.x;
-	const auto      y1  = offset.y;
-	const auto      y2  = offset.y + texture_->height() * scale.y;
+	const auto      x1  = -offset.x*scale.x;
+	const auto      x2  = (-offset.x + texture_->width())*scale.x-1;
+	const auto      y1  = -offset.y*scale.y;
+	const auto      y2  = (-offset.y + texture_->height())*scale.y-1;
 
 	// Border
 	ctx.setPen({ 0, 0, 0 }, 2.0);
@@ -218,7 +204,7 @@ void CTextureCanvas::drawPatch(const wxgfx::Context& ctx, int index)
 
 	// Draw patch
 	ctx.drawBitmap(
-		patch_bitmaps_[index], patch->xOffset(), patch->yOffset(), 1.0, patch_image->width(), patch_image->height());
+		patch_bitmaps_[index], (patch->xOffset() - texture_->offsetX())/texture_->scaleX(), (patch->yOffset() - texture_->offsetY())/texture_->scaleY(), 1.0, patch_image->width() / texture_->scaleX(), patch_image->height() / texture_->scaleY());
 }
 
 
@@ -301,7 +287,7 @@ void CTextureCanvas::onPaint(wxPaintEvent& e)
 		if (patches_[a].selected)
 		{
 			auto patch = texture_->patch(a);
-			ctx.drawRect(patch->xOffset(), patch->yOffset(), patches_[a].image->width(), patches_[a].image->height());
+			ctx.drawRect((patch->xOffset()-texture_->offsetX())/texture_->scaleX(), (patch->yOffset()-texture_->offsetY())/texture_->scaleY(), patches_[a].image->width()/texture_->scaleX(), patches_[a].image->height()/texture_->scaleY());
 		}
 
 	// Draw hilighted patch outline
@@ -312,10 +298,10 @@ void CTextureCanvas::onPaint(wxPaintEvent& e)
 		ctx.setPen({ 255, 255, 255, 150 }, 2.0);
 		auto patch = texture_->patch(hilight_patch_);
 		ctx.drawRect(
-			patch->xOffset(),
-			patch->yOffset(),
-			patches_[hilight_patch_].image->width(),
-			patches_[hilight_patch_].image->height());
+			(patch->xOffset()-texture_->offsetX())/texture_->scaleX(),
+			(patch->yOffset()-texture_->offsetY())/texture_->scaleY(),
+			patches_[hilight_patch_].image->width()/texture_->scaleX(),
+			patches_[hilight_patch_].image->height()/texture_->scaleY());
 		ctx.gc->SetCompositionMode(cm);
 	}
 }

--- a/src/UI/Canvas/CTextureCanvasBase.cpp
+++ b/src/UI/Canvas/CTextureCanvasBase.cpp
@@ -248,8 +248,8 @@ int CTextureCanvasBase::patchAt(int x, int y) const
 
 		// Check if x,y is within patch bounds
 		const auto patch = texture_->patch(a);
-		if (x >= patch->xOffset() && x < patch->xOffset() + img->width() && y >= patch->yOffset()
-			&& y < patch->yOffset() + img->height())
+		if (x >= (patch->xOffset()-texture_->offsetX())/texture_->scaleX() && x < (patch->xOffset() + img->width() - texture_->offsetX())/texture_->scaleX() && y >= (patch->yOffset() - texture_->offsetY())/texture_->scaleY()
+			&& (y < patch->yOffset() + img->height())/texture_->scaleY())
 		{
 			return a;
 		}

--- a/src/UI/Canvas/CTextureCanvasBase.cpp
+++ b/src/UI/Canvas/CTextureCanvasBase.cpp
@@ -249,7 +249,7 @@ int CTextureCanvasBase::patchAt(int x, int y) const
 		// Check if x,y is within patch bounds
 		const auto patch = texture_->patch(a);
 		if (x >= (patch->xOffset()-texture_->offsetX())/texture_->scaleX() && x < (patch->xOffset() + img->width() - texture_->offsetX())/texture_->scaleX() && y >= (patch->yOffset() - texture_->offsetY())/texture_->scaleY()
-			&& (y < patch->yOffset() + img->height())/texture_->scaleY())
+			&& (y < patch->yOffset() - texture_->offsetY() + img->height())/texture_->scaleY())
 		{
 			return a;
 		}

--- a/src/UI/Canvas/CTextureCanvasBase.h
+++ b/src/UI/Canvas/CTextureCanvasBase.h
@@ -57,7 +57,7 @@ public:
 	virtual void clearTexture();
 	virtual void clearPatches();
 	virtual void refreshPatch(unsigned index);
-	void         refreshTexturePreview();
+	virtual void         refreshTexturePreview();
 	bool         openTexture(CTexture* tex, Archive* parent);
 	void         resetViewOffsets();
 	void         redraw(bool update_tex = false);

--- a/src/UI/Canvas/GL/CTextureGLCanvas.cpp
+++ b/src/UI/Canvas/GL/CTextureGLCanvas.cpp
@@ -186,8 +186,8 @@ void CTextureGLCanvas::draw()
 	// Setup shader
 	initShader();
 	shader_->bind();
-	shader_->setUniform("view_tl", glm::vec2(view_.screenX(0), view_.screenY(0)));
-	shader_->setUniform("view_br", glm::vec2(view_.screenX(texture_->width()), view_.screenY(texture_->height())));
+	shader_->setUniform("view_tl", glm::vec2(view_.screenX(-offset.x*scale.x), view_.screenY(-offset.y*scale.x)));
+	shader_->setUniform("view_br", glm::vec2(view_.screenX((texture_->width()-offset.x)*scale.x), view_.screenY((texture_->height()-offset.y)*scale.y)));
 	shader_->setUniform("outside_colour", draw_outside_ ? glm::vec4{ 0.8f, 0.2f, 0.2f, 0.3f } : glm::vec4{ 0.0f });
 	shader_->setUniform("colour", glm::vec4{ 1.0f });
 	view_.setupShader(*shader_);
@@ -270,10 +270,10 @@ void CTextureGLCanvas::drawPatch(int num)
 		patch_gl_textures_[num] = gl::Texture::createFromImage(*patches_[num].image, palette_.get());
 	}
 
-	auto xoff   = static_cast<float>(patch->xOffset());
-	auto yoff   = static_cast<float>(patch->yOffset());
-	auto width  = static_cast<float>(patches_[num].image->width());
-	auto height = static_cast<float>(patches_[num].image->height());
+	auto xoff   = static_cast<float>((patch->xOffset() - texture_->offsetX())/ texture_->scaleX());
+	auto yoff   = static_cast<float>(patch->yOffset() - texture_->offsetY())/ texture_->scaleY();
+	auto width  = static_cast<float>(patches_[num].image->width() / texture_->scaleX());
+	auto height = static_cast<float>(patches_[num].image->height() / texture_->scaleY());
 	auto colour = glm::vec4{ 1.0f };
 
 	gl::VertexBuffer2D vb_patch;
@@ -317,10 +317,10 @@ void CTextureGLCanvas::drawPatchOutline(const gl::draw2d::Context& dc, int num) 
 void CTextureGLCanvas::drawTextureBorder(glm::vec2 scale, glm::vec2 offset)
 {
 	constexpr float ext = 0.0f;
-	const auto      x1  = offset.x;
-	const auto      x2  = offset.x + texture_->width() * scale.x;
-	const auto      y1  = offset.y;
-	const auto      y2  = offset.y + texture_->height() * scale.y;
+	const auto      x1  = -offset.x*scale.x;
+	const auto      x2  = (-offset.x + texture_->width())*scale.x;// * scale.x;
+	const auto      y1  = -offset.y*scale.y;
+	const auto      y2  = (-offset.y + texture_->height())*scale.y;// * scale.y;
 
 	// Setup border buffer if needed
 	if (!lb_border_)

--- a/src/UI/Canvas/GL/CTextureGLCanvas.cpp
+++ b/src/UI/Canvas/GL/CTextureGLCanvas.cpp
@@ -297,10 +297,10 @@ void CTextureGLCanvas::drawPatchOutline(const gl::draw2d::Context& dc, int num) 
 	if (!patch)
 		return;
 
-	auto x1 = static_cast<float>(patch->xOffset());
-	auto y1 = static_cast<float>(patch->yOffset());
-	auto x2 = x1 + static_cast<float>(patches_[num].image->width());
-	auto y2 = y1 + static_cast<float>(patches_[num].image->height());
+	auto x1 = static_cast<float>((patch->xOffset()-texture_->offsetX())/texture_->scaleX());
+	auto y1 = static_cast<float>((patch->yOffset()-texture_->offsetY())/texture_->scaleY());
+	auto x2 = x1 + static_cast<float>(patches_[num].image->width()/texture_->scaleX());
+	auto y2 = y1 + static_cast<float>(patches_[num].image->height()/texture_->scaleY());
 
 	vector<Rectf> lines;
 	lines.emplace_back(x1, y1, x1, y2);

--- a/src/UI/Canvas/GL/CTextureGLCanvas.cpp
+++ b/src/UI/Canvas/GL/CTextureGLCanvas.cpp
@@ -218,6 +218,20 @@ void CTextureGLCanvas::draw()
 	}
 }
 
+
+// -----------------------------------------------------------------------------
+// Unloads the preview image, so it is recreated on next draw
+// -----------------------------------------------------------------------------
+void CTextureGLCanvas::refreshTexturePreview() {
+	CTextureCanvasBase::refreshTexturePreview();
+
+	// Whenever this happens (e.g. on drag-and-drop finish) we should update the border position.
+	// Note: Maybe we should do this more often while dragging, it would be nice to have a live
+	// update
+	if (lb_border_)
+		lb_border_->buffer().clear();
+}
+
 // -----------------------------------------------------------------------------
 // Draws the currently opened composite texture
 // -----------------------------------------------------------------------------
@@ -231,21 +245,6 @@ void CTextureGLCanvas::drawTexture(gl::draw2d::Context& dc, glm::vec2 scale, glm
 	{
 		for (uint32_t a = 0; a < texture_->nPatches(); a++)
 			drawPatch(a);
-	}
-
-	// If we aren't currently dragging a patch, draw the fully generated texture
-	if (!dragging_)
-	{
-		// Generate if needed
-		if (!tex_preview_ || gl_tex_preview_ == 0)
-		{
-			loadTexturePreview();
-			gl_tex_preview_ = gl::Texture::createFromImage(*tex_preview_, palette_.get());
-		}
-
-		// Draw the texture
-		dc.texture = gl_tex_preview_;
-		dc.drawRect({ offset.x, offset.y, offset.x + width * scale.x, offset.y + height * scale.y, false });
 	}
 }
 

--- a/src/UI/Canvas/GL/CTextureGLCanvas.h
+++ b/src/UI/Canvas/GL/CTextureGLCanvas.h
@@ -38,6 +38,7 @@ public:
 	void clearTexture() override;
 	void clearPatches() override;
 	void refreshPatch(unsigned index) override;
+	void refreshTexturePreview() override;
 	void draw() override;
 
 private:


### PR DESCRIPTION
Updated TEXTUREX editor to remove bugs introduced in the renderer rewrite. (Resolves #2017)

Slade 3.2.12:
<img width="1905" height="1134" alt="2026-06-13-202947_hyprshot" src="https://github.com/user-attachments/assets/30bb0852-d280-4ee9-8185-f97c5db2d1e4" />

Current master commit (46fc51ac57f4fe54caf036b3d1e9b028a120be27 at time of writing):
<img width="1905" height="1134" alt="2026-06-13-203046_hyprshot" src="https://github.com/user-attachments/assets/ec102ad1-bc69-435e-a6dc-2a887bb1b830" />

This PR:
<img width="1905" height="1134" alt="2026-06-14-032710_hyprshot" src="https://github.com/user-attachments/assets/7ffadd83-f7bb-4b6b-9198-46b3e5d6acdc" />

Please lmk if any changes are needed